### PR TITLE
chore: snapshot release for PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
 
 jobs:
   prerelease:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,5 +49,7 @@ jobs:
       - name: 📸 Snapshot and Publish
         if: ${{ github.ref != 'refs/heads/main' }}
         run: |
+          # [Snapshot release fails if repository is in pre-release mode](https://github.com/changesets/changesets/issues/1195)
+          rm -f .changeset/pre.json
           npx changeset version --snapshot
           npx changeset publish --tag snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,5 +51,7 @@ jobs:
         run: |
           # [Snapshot release fails if repository is in pre-release mode](https://github.com/changesets/changesets/issues/1195)
           rm -f .changeset/pre.json
+          # Add empty changeset so we always have a new snapshot release for each new run
+          npx changeset add --empty
           npx changeset version --snapshot
           npx changeset publish --tag snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,13 @@
-name: Prerelease
+name: Release
 on:
   push:
     branches:
       - "main"
+  pull_request:
 
 jobs:
   prerelease:
-    name: Prerelease
+    name: Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -31,12 +32,22 @@ jobs:
       - name: 👷 Build packages
         run: pnpm build-all
 
-      - name: ⛴️ Version and Publish
+      - name: 🤖 Configure Git Bot
         run: |
           git config user.name "Release Bot[bot]"
           git config user.email "bot@example.com"
+
+      - name: ⛴️ Version and Publish
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
           npx changeset version
           npx changeset publish
-          git add .
+          git add --all
           git commit --amend --no-edit
           git push --follow-tags
+
+      - name: 📸 Snapshot and Publish
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          npx changeset version --snapshot
+          npx changeset publish --tag snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   prerelease:

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -2,6 +2,7 @@
   "name": "docs",
   "version": "0.0.0",
   "type": "module",
+  "private": true,
   "scripts": {
     "dev": "vitepress dev src",
     "build": "vitepress build src",


### PR DESCRIPTION

- Added conditiontional snapshot release to pipline
   - we only want to publish a real version on the main branch
   - all other branches/prs should only produce a snapshot
- Set `apps/docs` as private package as we don't want to publish it