### PR TITLE
chore: use env variables for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,9 +68,9 @@ jobs:
       - name: Deploy to Cloud Foundry
         uses: ./.github/templates/cf-push
         with:
-          endpoint: ${{ env.CF_ENDPOINT }}
-          org: ${{ env.CF_ORG }}
-          username: ${{ env.CF_USERNAME }}
+          endpoint: ${{ vars.CF_ENDPOINT }}
+          org: ${{ vars.CF_ORG }}
+          username: ${{ vars.CF_USERNAME }}
           password: ${{ secrets.CF_PASSWORD }}
           # we need to define a fallback value here because the default for the input
           # is only assigned when the workflow is triggered manually. When triggered e.g. on push
@@ -95,9 +95,9 @@ jobs:
       - name: Deploy to Cloud Foundry
         uses: ./.github/templates/cf-push
         with:
-          endpoint: ${{ env.CF_ENDPOINT }}
-          org: ${{ env.CF_ORG }}
-          username: ${{ env.CF_USERNAME }}
+          endpoint: ${{ vars.CF_ENDPOINT }}
+          org: ${{ vars.CF_ORG }}
+          username: ${{ vars.CF_USERNAME }}
           password: ${{ secrets.CF_PASSWORD }}
           # we need to define a fallback value here because the default for the input
           # is only assigned when the workflow is triggered manually. When triggered e.g. on push


### PR DESCRIPTION
Env variables must be accessed via `vars.` instead of `env.`, see:
https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-variables