### PR TITLE
chore: define release files for headless and storybook-utils

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "author": "Schwarz IT KG",
   "license": "Apache-2.0",
+  "files": [
+    "src"
+  ],
   "exports": {
     ".": {
       "default": "./src/index.ts"

--- a/packages/storybook-utils/package.json
+++ b/packages/storybook-utils/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "author": "Schwarz IT KG",
   "license": "Apache-2.0",
+  "files": [
+    "src"
+  ],
   "exports": {
     ".": {
       "default": "./src/index.ts"


### PR DESCRIPTION
Define missing `files` property of `package.json` that defines which files should be included when the package is released to npm