### PR TITLE
chore: ignore Playwright snapshots locally

### DIFF
--- a/packages/sit-onyx/playwright.config.ts
+++ b/packages/sit-onyx/playwright.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   // we don't want to update snapshots on the local machine of each developer.
   // if you want to update snapshots for your branch, use the corresponding GitHub action:
   // https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml
+  ignoreSnapshots: !process.env.CI,
   updateSnapshots: "none",
   timeout: 10 * 1000,
   fullyParallel: true,


### PR DESCRIPTION
Since the screenshots are generated in CI using linux, we must ignore comparing the screenshots when running the playwright tests locally. Otherwise they will always fail due to missing/different screenshots

closes #65 