### PR TITLE
fix(release): fix failing release pipeline caused by main branch being protected

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  prerelease:
+  release:
     name: Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{secrets.GH_PUSH_PROTECTED_KEY}}
 
       - uses: pnpm/action-setup@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ssh-key: ${{secrets.GH_PUSH_PROTECTED_KEY}}
+          ssh-key: ${{ secrets.GH_PUSH_PROTECTED_KEY }}
 
       - uses: pnpm/action-setup@v2
 


### PR DESCRIPTION
We now make use of Githubs [Deploy Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys) Feature.
This allows us to configure pipelines to push with admin permissions and ignore branch protections.