### PR TITLE
docs: fix missing external link icons

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,6 +9,6 @@
     "preview": "vitepress preview src"
   },
   "devDependencies": {
-    "vitepress": "^1.0.0-rc.34"
+    "vitepress": "^1.0.0-rc.36"
   }
 }

--- a/apps/docs/src/.vitepress/theme/theme.scss
+++ b/apps/docs/src/.vitepress/theme/theme.scss
@@ -39,3 +39,14 @@
     border-radius: 12px; // same as feature section in home page
   }
 }
+
+// allow hiding external link indicator (e.g. for npm badges)
+.external-link {
+  &--hide {
+    a {
+      &::after {
+        display: none !important;
+      }
+    }
+  }
+}

--- a/apps/docs/src/.vitepress/theme/theme.scss
+++ b/apps/docs/src/.vitepress/theme/theme.scss
@@ -41,12 +41,10 @@
 }
 
 // allow hiding external link indicator (e.g. for npm badges)
-.external-link {
-  &--hide {
-    a {
-      &::after {
-        display: none !important;
-      }
+.hide-external-link {
+  a {
+    &::after {
+      display: none !important;
     }
   }
 }

--- a/apps/docs/src/getting-started.md
+++ b/apps/docs/src/getting-started.md
@@ -4,7 +4,7 @@
 This library is currently in early / active development.
 :::
 
-<div class="external-link--hide">
+<div class="hide-external-link">
 
 [![npm version](https://badge.fury.io/js/sit-onyx.svg)](https://www.npmjs.com/package/sit-onyx)
 

--- a/apps/docs/src/getting-started.md
+++ b/apps/docs/src/getting-started.md
@@ -4,7 +4,11 @@
 This library is currently in early / active development.
 :::
 
+<div class="external-link--hide">
+
 [![npm version](https://badge.fury.io/js/sit-onyx.svg)](https://www.npmjs.com/package/sit-onyx)
+
+</div>
 
 ## Installation
 

--- a/apps/docs/src/packages/figma-utils.md
+++ b/apps/docs/src/packages/figma-utils.md
@@ -8,7 +8,7 @@ import packageJson from "../../../../packages/figma-utils/package.json";
 
 # @sit-onyx/figma-utils
 
-<div class="external-link--hide">
+<div class="hide-external-link">
 
 [![npm version](https://badge.fury.io/js/@sit-onyx%2Ffigma-utils.svg)](https://www.npmjs.com/package/@sit-onyx/figma-utils)
 

--- a/apps/docs/src/packages/figma-utils.md
+++ b/apps/docs/src/packages/figma-utils.md
@@ -8,7 +8,11 @@ import packageJson from "../../../../packages/figma-utils/package.json";
 
 # @sit-onyx/figma-utils
 
+<div class="external-link--hide">
+
 [![npm version](https://badge.fury.io/js/@sit-onyx%2Ffigma-utils.svg)](https://www.npmjs.com/package/@sit-onyx/figma-utils)
+
+</div>
 
 {{ packageJson.description }}.
 

--- a/apps/docs/src/packages/headless.md
+++ b/apps/docs/src/packages/headless.md
@@ -8,7 +8,11 @@ import packageJson from "../../../../packages/headless/package.json";
 
 # @sit-onyx/headless
 
+<div class="external-link--hide">
+
 [![npm version](https://badge.fury.io/js/@sit-onyx%2Fheadless.svg)](https://www.npmjs.com/package/@sit-onyx/headless)
+
+</div>
 
 ::: warning Work in progress / Active development
 This library is currently in early / active development.

--- a/apps/docs/src/packages/headless.md
+++ b/apps/docs/src/packages/headless.md
@@ -8,7 +8,7 @@ import packageJson from "../../../../packages/headless/package.json";
 
 # @sit-onyx/headless
 
-<div class="external-link--hide">
+<div class="hide-external-link">
 
 [![npm version](https://badge.fury.io/js/@sit-onyx%2Fheadless.svg)](https://www.npmjs.com/package/@sit-onyx/headless)
 

--- a/apps/docs/src/packages/storybook-utils.md
+++ b/apps/docs/src/packages/storybook-utils.md
@@ -8,7 +8,7 @@ import packageJson from "../../../../packages/storybook-utils/package.json";
 
 # @sit-onyx/storybook-utils
 
-<div class="external-link--hide">
+<div class="hide-external-link">
 
 [![npm version](https://badge.fury.io/js/@sit-onyx%2Fstorybook-utils.svg)](https://www.npmjs.com/package/@sit-onyx/storybook-utils)
 

--- a/apps/docs/src/packages/storybook-utils.md
+++ b/apps/docs/src/packages/storybook-utils.md
@@ -8,7 +8,11 @@ import packageJson from "../../../../packages/storybook-utils/package.json";
 
 # @sit-onyx/storybook-utils
 
+<div class="external-link--hide">
+
 [![npm version](https://badge.fury.io/js/@sit-onyx%2Fstorybook-utils.svg)](https://www.npmjs.com/package/@sit-onyx/storybook-utils)
+
+</div>
 
 {{ packageJson.description }}.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
   apps/docs:
     devDependencies:
       vitepress:
-        specifier: ^1.0.0-rc.34
-        version: 1.0.0-rc.34(@algolia/client-search@4.22.0)(@types/node@20.10.6)(sass@1.69.6)(search-insights@2.13.0)(typescript@5.3.3)
+        specifier: ^1.0.0-rc.36
+        version: 1.0.0-rc.36(@algolia/client-search@4.22.0)(@types/node@20.10.6)(sass@1.69.6)(search-insights@2.13.0)(typescript@5.3.3)
 
   packages/figma-utils:
     dependencies:
@@ -4277,14 +4277,14 @@ packages:
       vue: 3.4.3(typescript@5.3.3)
     dev: true
 
-  /@vitejs/plugin-vue@5.0.2(vite@5.0.10)(vue@3.4.5):
+  /@vitejs/plugin-vue@5.0.2(vite@5.0.11)(vue@3.4.5):
     resolution: {integrity: sha512-kEjJHrLb5ePBvjD0SPZwJlw1QTRcjjCA9sB5VyfonoXVBxTS7TMnqL6EkLt1Eu61RDeiuZ/WN9Hf6PxXhPI2uA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.0.10(@types/node@20.10.6)(sass@1.69.6)
+      vite: 5.0.11(@types/node@20.10.6)(sass@1.69.6)
       vue: 3.4.5(typescript@5.3.3)
     dev: true
 
@@ -7898,11 +7898,6 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mrmime@2.0.0:
-    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
-    engines: {node: '>=10'}
-    dev: true
-
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: true
@@ -10198,12 +10193,49 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitepress@1.0.0-rc.34(@algolia/client-search@4.22.0)(@types/node@20.10.6)(sass@1.69.6)(search-insights@2.13.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-TUbTiSdAZFni2XlHlpx61KikgkQ5uG4Wtmw2R0SXhIOG6qGqzDJczAFjkMc4i45I9c3KyatwOYe8oEfCnzVYwQ==}
+  /vite@5.0.11(@types/node@20.10.6)(sass@1.69.6):
+    resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.10.6
+      esbuild: 0.19.11
+      postcss: 8.4.32
+      rollup: 4.9.2
+      sass: 1.69.6
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitepress@1.0.0-rc.36(@algolia/client-search@4.22.0)(@types/node@20.10.6)(sass@1.69.6)(search-insights@2.13.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-2z4dpM9PplN/yvTifhavOIAazlCR6OJ5PvLoRbc+7LdcFeIlCsuDGENLX4HjMW18jQZF5/j7++PNqdBfeazxUA==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4.3.2
-      postcss: ^8.4.32
+      postcss: ^8.4.33
     peerDependenciesMeta:
       markdown-it-mathjax3:
         optional: true
@@ -10213,18 +10245,17 @@ packages:
       '@docsearch/css': 3.5.2
       '@docsearch/js': 3.5.2(@algolia/client-search@4.22.0)(search-insights@2.13.0)
       '@types/markdown-it': 13.0.7
-      '@vitejs/plugin-vue': 5.0.2(vite@5.0.10)(vue@3.4.5)
+      '@vitejs/plugin-vue': 5.0.2(vite@5.0.11)(vue@3.4.5)
       '@vue/devtools-api': 6.5.1
       '@vueuse/core': 10.7.1(vue@3.4.5)
       '@vueuse/integrations': 10.7.1(focus-trap@7.5.4)(vue@3.4.5)
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 6.3.0
-      mrmime: 2.0.0
       shikiji: 0.9.17
       shikiji-core: 0.9.17
       shikiji-transformers: 0.9.17
-      vite: 5.0.10(@types/node@20.10.6)(sass@1.69.6)
+      vite: 5.0.11(@types/node@20.10.6)(sass@1.69.6)
       vue: 3.4.5(typescript@5.3.3)
     transitivePeerDependencies:
       - '@algolia/client-search'


### PR DESCRIPTION
## Description

Update VitePress to add missing icon for external link, see [VitePress changelog](https://github.com/vuejs/vitepress/blob/main/CHANGELOG.md#100-rc36-2024-1-8).

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
