### PR TITLE
chore: do not auto open dev server in browser

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "vitepress dev src --open",
+    "dev": "vitepress dev src",
     "build": "vitepress build src",
     "preview": "vitepress preview src"
   },

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -26,10 +26,10 @@
     "url": "https://github.com/schwarzit/onyx/issues"
   },
   "scripts": {
-    "dev": "storybook dev -p 6006",
+    "dev": "storybook dev -p 6006 --no-open",
     "build": "pnpm run '/type-check|build-only/'",
     "build:storybook": "storybook build",
-    "preview": "vite serve storybook-static --open",
+    "preview": "vite serve storybook-static",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:components": "playwright install && playwright test",


### PR DESCRIPTION
## Description

Do not automatically open dev servers in the browser because for some browser (like Arc) that will open a redundant tab when new changes are saved (instead of re-loading the existing tab) which can get really annoying while e.g. writing documentation.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
