### PR TITLE
docs: use `@alpha` for installing packages

### DIFF
--- a/apps/docs/src/getting-started.md
+++ b/apps/docs/src/getting-started.md
@@ -22,15 +22,15 @@ Install the npm package with your corresponding package manager:
 ::: code-group
 
 ```sh [pnpm]
-pnpm add sit-onyx
+pnpm add sit-onyx@alpha
 ```
 
 ```sh [npm]
-npm install sit-onyx
+npm install sit-onyx@alpha
 ```
 
 ```sh [yarn]
-yarn install sit-onyx
+yarn install sit-onyx@alpha
 ```
 
 :::

--- a/apps/docs/src/packages/figma-utils.md
+++ b/apps/docs/src/packages/figma-utils.md
@@ -21,7 +21,7 @@ import packageJson from "../../../../packages/figma-utils/package.json";
 For a list of supported commands and options, run:
 
 ```sh
-npx @sit-onyx/figma-utils@latest --help
+npx @sit-onyx/figma-utils@alpha --help
 ```
 
 ::: tip Usage in CI
@@ -44,15 +44,15 @@ Install the npm package with your corresponding package manager:
 ::: code-group
 
 ```sh [pnpm]
-pnpm add @sit-onyx/figma-utils
+pnpm add @sit-onyx/figma-utils@alpha
 ```
 
 ```sh [npm]
-npm install @sit-onyx/figma-utils
+npm install @sit-onyx/figma-utils@alpha
 ```
 
 ```sh [yarn]
-yarn install @sit-onyx/figma-utils
+yarn install @sit-onyx/figma-utils@alpha
 ```
 
 :::

--- a/apps/docs/src/packages/headless.md
+++ b/apps/docs/src/packages/headless.md
@@ -34,15 +34,15 @@ Install the npm package with your corresponding package manager:
 ::: code-group
 
 ```sh [pnpm]
-pnpm add @sit-onyx/headless
+pnpm add @sit-onyx/headless@alpha
 ```
 
 ```sh [npm]
-npm install @sit-onyx/headless
+npm install @sit-onyx/headless@alpha
 ```
 
 ```sh [yarn]
-yarn install @sit-onyx/headless
+yarn install @sit-onyx/headless@alpha
 ```
 
 :::

--- a/apps/docs/src/packages/storybook-utils.md
+++ b/apps/docs/src/packages/storybook-utils.md
@@ -28,15 +28,15 @@ Install the npm package with your corresponding package manager:
 ::: code-group
 
 ```sh [pnpm]
-pnpm add -D @sit-onyx/storybook-utils
+pnpm add -D @sit-onyx/storybook-utils@alpha
 ```
 
 ```sh [npm]
-npm install -D @sit-onyx/storybook-utils
+npm install -D @sit-onyx/storybook-utils@alpha
 ```
 
 ```sh [yarn]
-yarn install -D @sit-onyx/storybook-utils
+yarn install -D @sit-onyx/storybook-utils@alpha
 ```
 
 :::

--- a/apps/docs/src/packages/vitepress-theme.md
+++ b/apps/docs/src/packages/vitepress-theme.md
@@ -33,15 +33,15 @@ The theme includes the following features:
 ::: code-group
 
 ```sh [pnpm]
-pnpm add -D @sit-onyx/vitepress-theme
+pnpm add -D @sit-onyx/vitepress-theme@alpha
 ```
 
 ```sh [npm]
-npm install -D @sit-onyx/vitepress-theme
+npm install -D @sit-onyx/vitepress-theme@alpha
 ```
 
 ```sh [yarn]
-yarn install -D @sit-onyx/vitepress-theme
+yarn install -D @sit-onyx/vitepress-theme@alpha
 ```
 
 :::


### PR DESCRIPTION
## Description

Update the docs to install our packages with the `@alpha` channel because we are currently in pre-release / alpha mode so trying to just install `sit-onyx` would always install version `0.0.0` although we already have e.g. version `1.0.0-alpha.1`

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
