### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
   deploy_storybook:
     name: Deploy Storybook
     runs-on: ubuntu-latest
-    needs: build
+    needs: release
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
     steps:
       - uses: actions/checkout@v4
@@ -108,7 +108,7 @@ jobs:
   deploy_documentation:
     name: Deploy documentation
     runs-on: ubuntu-latest
-    needs: build
+    needs: release
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

The job "build" does not exist, it was a copy and paste bug. It should be "release".

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
