### PR TITLE
chore: also build storybook with `build:all` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Schwarz IT KG",
   "license": "Apache-2.0",
   "scripts": {
-    "build:all": "pnpm -r --if-present build",
+    "build:all": "pnpm -r --if-present '/^build/'",
     "test:all": "pnpm -r --if-present test:coverage",
     "format:all": "prettier --write .",
     "format:check:all": "prettier --check .",


### PR DESCRIPTION
## Description

Previously `build:all` only run the `build` script of every package which does not include storybook because it has a `build:storybook` script. This causes the deployment to fail.
Now `build:all` will run all scripts in every package that start with "build"

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
