### PR TITLE
fix(i18n): do not reset i18n when provided

### DIFF
--- a/.changeset/brave-lobsters-wonder.md
+++ b/.changeset/brave-lobsters-wonder.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+Ensure that the i18n instance is not reset even if it has been provided

--- a/.changeset/brave-lobsters-wonder.md
+++ b/.changeset/brave-lobsters-wonder.md
@@ -2,4 +2,4 @@
 "sit-onyx": patch
 ---
 
-Ensure that the i18n instance is not reset even if it has been provided
+Ensure that the i18n instance is not reset when it has been provided

--- a/packages/sit-onyx/src/i18n/index.ts
+++ b/packages/sit-onyx/src/i18n/index.ts
@@ -87,10 +87,10 @@ export const provideI18n = (options: ProvideI18nOptions) => {
 
 /**
  * Injects the Onyx i18n instance.
+ * Creates a fallback if provide was never called.
  */
 export const injectI18n = () => {
-  const fallbackInstance = createI18n();
-  return inject(I18N_INJECTION_KEY, fallbackInstance);
+  return inject(I18N_INJECTION_KEY, () => createI18n(), true);
 };
 
 /**


### PR DESCRIPTION
## Description

Ensure that the i18n instance is not reset when it has been provided.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
