### PR TITLE
feat(vitepress-theme): add `breakpoint` scss mixin

### DIFF
--- a/.changeset/nasty-mails-play.md
+++ b/.changeset/nasty-mails-play.md
@@ -3,3 +3,15 @@
 ---
 
 feat: add `breakpoint` scss mixin
+
+Example usage:
+
+```scss
+@use "@sit-onyx/vitepress-theme/mixins.scss";
+
+.some-class {
+  @include mixins.breakpoint(m, max) {
+    // your styles for m breakpoint
+  }
+}
+```

--- a/.changeset/nasty-mails-play.md
+++ b/.changeset/nasty-mails-play.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/vitepress-theme": minor
+---
+
+feat: add `breakpoint` scss mixin

--- a/.changeset/nasty-mails-play.md
+++ b/.changeset/nasty-mails-play.md
@@ -10,7 +10,7 @@ Example usage:
 @use "@sit-onyx/vitepress-theme/mixins.scss";
 
 .some-class {
-  @include mixins.breakpoint(m, max) {
+  @include mixins.breakpoint(max, m) {
     // your styles for m breakpoint
   }
 }

--- a/apps/docs/src/packages/vitepress-theme.md
+++ b/apps/docs/src/packages/vitepress-theme.md
@@ -104,7 +104,7 @@ Applies CSS only to the given VitePress breakpoint.
   }
 
   @include mixins.breakpoint(min, xl, 1) {
-    // your styles for grater than xl breakpoint (exclusive)
+    // your styles for greater than xl breakpoint (exclusive)
   }
 }
 ```

--- a/apps/docs/src/packages/vitepress-theme.md
+++ b/apps/docs/src/packages/vitepress-theme.md
@@ -88,12 +88,23 @@ Applies CSS only to the given VitePress breakpoint.
 @use "@sit-onyx/vitepress-theme/mixins.scss";
 
 .some-class {
-  @include mixins.breakpoint(m, max) {
+  @include mixins.breakpoint(max, m) {
     // your styles for m breakpoint and smaller
   }
 
-  @include mixins.breakpoint(m, min) {
+  @include mixins.breakpoint(min, m) {
     // your styles for m breakpoint and larger
+  }
+
+  // the breakpoint is inclusive so if you e.g. want to use
+  // min and max for the same breakpoint you should
+  // define an offset for either min or max
+  @include mixins.breakpoint(max, xl) {
+    // your styles for smaller and equal xl breakpoint
+  }
+
+  @include mixins.breakpoint(min, xl, 1) {
+    // your styles for grater than xl breakpoint (exclusive)
   }
 }
 ```

--- a/apps/docs/src/packages/vitepress-theme.md
+++ b/apps/docs/src/packages/vitepress-theme.md
@@ -62,3 +62,38 @@ export default OnyxTheme;
 ```
 
 :::
+
+## Utilities
+
+This package also includes some VitePress utilities that you can use on-demand.
+
+### Breakpoint SCSS mixin
+
+Applies CSS only to the given VitePress breakpoint.
+
+::: details Available VitePress breakpoints
+
+| Breakpoint name | Value    |
+| --------------- | -------- |
+| xs              | `375px`  |
+| s               | `640px`  |
+| m               | `768px`  |
+| l               | `960px`  |
+| xl              | `1280px` |
+| xxl             | `1440px` |
+
+:::
+
+```scss
+@use "@sit-onyx/vitepress-theme/mixins.scss";
+
+.some-class {
+  @include mixins.breakpoint(m, max) {
+    // your styles for m breakpoint and smaller
+  }
+
+  @include mixins.breakpoint(m, min) {
+    // your styles for m breakpoint and larger
+  }
+}
+```

--- a/packages/vitepress-theme/package.json
+++ b/packages/vitepress-theme/package.json
@@ -9,7 +9,8 @@
     "src"
   ],
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./mixins.scss": "./src/mixins.scss"
   },
   "homepage": "https://onyx.schwarz/packages/vitepress-theme.html",
   "repository": {

--- a/packages/vitepress-theme/src/mixins.scss
+++ b/packages/vitepress-theme/src/mixins.scss
@@ -43,24 +43,24 @@
   );
   --vp-home-hero-image-filter: blur(44px);
 
-  @include breakpoint(l, min) {
+  @include breakpoint(min, l) {
     --vp-home-hero-image-filter: blur(68px);
   }
 
-  @include breakpoint(s, min) {
+  @include breakpoint(min, s) {
     --vp-home-hero-image-filter: blur(56px);
   }
 }
 
 /**
  * Applies CSS only to the given VitePress breakpoint.
- * @param {string} $name - name of the VitePress breakpoint. One of: xs, s, m, l, xl or xxl
  * @param {string} $min-max - Whether the breakpoint should be considered as min or max width.
+ * @param {string} $name - name of the VitePress breakpoint. One of: xs, s, m, l, xl or xxl
  *
- * @example breakpoint(m, min)
- * @example breakpoint(m, max)
+ * @example breakpoint(min, m)
+ * @example breakpoint(max, m)
  */
-@mixin breakpoint($name, $min-max) {
+@mixin breakpoint($min-max, $name, $offset: 0) {
   $breakpoints: (
     xs: 375px,
     s: 640px,
@@ -70,7 +70,7 @@
     xxl: 1440px,
   );
 
-  @media (#{$min-max}-width: #{map-get($breakpoints, $name)}) {
+  @media (#{$min-max}-width: #{map-get($breakpoints, $name) + $offset}) {
     @content;
   }
 }

--- a/packages/vitepress-theme/src/mixins.scss
+++ b/packages/vitepress-theme/src/mixins.scss
@@ -56,6 +56,7 @@
  * Applies CSS only to the given VitePress breakpoint.
  * @param {string} $min-max - Whether the breakpoint should be considered as min or max width.
  * @param {string} $name - name of the VitePress breakpoint. One of: xs, s, m, l, xl or xxl
+ * @param {number} $offset - optional offset to add to the min/max width. Useful if both min and max are used for the same breakpoint
  *
  * @example breakpoint(min, m)
  * @example breakpoint(max, m)

--- a/packages/vitepress-theme/src/mixins.scss
+++ b/packages/vitepress-theme/src/mixins.scss
@@ -43,11 +43,34 @@
   );
   --vp-home-hero-image-filter: blur(44px);
 
-  @media (min-width: 960px) {
+  @include breakpoint(l, min) {
     --vp-home-hero-image-filter: blur(68px);
   }
 
-  @media (min-width: 640px) {
+  @include breakpoint(s, min) {
     --vp-home-hero-image-filter: blur(56px);
+  }
+}
+
+/**
+ * Applies CSS only to the given VitePress breakpoint.
+ * @param {string} $name - name of the VitePress breakpoint. One of: xs, s, m, l, xl or xxl
+ * @param {string} $min-max - Whether the breakpoint should be considered as min or max width.
+ *
+ * @example breakpoint(m, min)
+ * @example breakpoint(m, max)
+ */
+@mixin breakpoint($name, $min-max) {
+  $breakpoints: (
+    xs: 375px,
+    s: 640px,
+    m: 768px,
+    l: 960px,
+    xl: 1280px,
+    xxl: 1440px,
+  );
+
+  @media (#{$min-max}-width: #{map-get($breakpoints, $name)}) {
+    @content;
   }
 }


### PR DESCRIPTION
## Description

Add a scss mixin for applying CSS only to specific VitePress breakpoints

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
