### PR TITLE
fix: prevent build error `cannot be named without a reference`

### DIFF
--- a/packages/storybook-utils/src/actions.ts
+++ b/packages/storybook-utils/src/actions.ts
@@ -1,12 +1,8 @@
 import { useArgs } from "@storybook/preview-api";
-import type { ArgTypes, Meta } from "@storybook/vue3";
+import type { ArgTypes, Decorator, Meta } from "@storybook/vue3";
 import { deepmerge } from "deepmerge-ts";
 import { isReactive, reactive, watch } from "vue";
-import type {
-  ArrayElement,
-  DefineStorybookActionsAndVModelsOptions,
-  ExtractVueEventNames,
-} from ".";
+import type { DefineStorybookActionsAndVModelsOptions, ExtractVueEventNames } from ".";
 
 /**
  * Utility to define Storybook meta for a given Vue component which will take care of defining argTypes for
@@ -31,14 +27,14 @@ import type {
  */
 export const defineStorybookActionsAndVModels = <T>(
   options: DefineStorybookActionsAndVModelsOptions<T>,
-): Meta<T> => {
+): Meta => {
   const defaultMeta = {
     argTypes: {
       ...defineActions(options.events),
       ...{}, // this is needed to fix a type issue
     },
     decorators: [withVModelDecorator(options.events)],
-  } satisfies Meta<T>;
+  } satisfies Meta;
 
   return deepmerge(options, defaultMeta);
 };
@@ -81,9 +77,7 @@ export const defineActions = <T>(events: ExtractVueEventNames<T>[]): ArgTypes =>
  * }
  * ```
  */
-export const withVModelDecorator = <T>(
-  events: ExtractVueEventNames<T>[],
-): ArrayElement<Meta<T>["decorators"]> => {
+export const withVModelDecorator = <T>(events: ExtractVueEventNames<T>[]): Decorator => {
   return (story, ctx) => {
     const vModelEvents = events.filter((event) => event.startsWith("update:"));
     if (!vModelEvents.length) return story();

--- a/packages/storybook-utils/src/types.ts
+++ b/packages/storybook-utils/src/types.ts
@@ -46,8 +46,3 @@ export type DefineStorybookActionsAndVModelsOptions<T> = Meta<T> & {
   component: NonNullable<T>;
   events: ExtractVueEventNames<T>[];
 };
-
-/**
- * A utility type that gets the type of an array element.
- */
-export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;


### PR DESCRIPTION
closes #166

## Description

Prevents build errors for `sit-onyx` with "cannot be named without a reference"

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
