### PR TITLE
docs: add missing images

### DIFF
--- a/apps/docs/src/.vitepress/components/OnyxPartners.vue
+++ b/apps/docs/src/.vitepress/components/OnyxPartners.vue
@@ -1,49 +1,29 @@
 <script lang="ts" setup>
 import { VPHomeSponsors } from "vitepress/theme";
+import coreUILogo from "../../assets/coreui-logo.svg";
+import stackitLogo from "../../assets/runs-on-stackit.svg";
+import storybookLogo from "../../assets/storybook-logo.svg";
+import vitepressLogo from "../../assets/vitepress-logo.svg";
+import vueLogo from "../../assets/vue-logo.svg";
+import waWiLogo from "../../assets/wawi-logo.svg";
 
 const partners = [
   {
     tier: "Special Partners",
     size: "big",
     items: [
-      {
-        name: "STACKIT",
-        img: new URL("../../assets/runs-on-stackit.svg", import.meta.url).href,
-        url: "https://www.stackit.de",
-      },
-      {
-        name: "WaWi Nexus",
-        img: new URL("../../assets/wawi-logo.svg", import.meta.url).href,
-      },
-      {
-        name: "CoreUI",
-        img: new URL("../../assets/coreui-logo.svg", import.meta.url).href,
-      },
+      { name: "STACKIT", img: stackitLogo, url: "https://www.stackit.de" },
+      { name: "WaWi Nexus", img: waWiLogo },
+      { name: "CoreUI", img: coreUILogo },
     ],
   },
   {
     tier: "Tools & Technologies",
     items: [
-      {
-        name: "Vue.js",
-        img: new URL("../../assets/vue-logo.svg", import.meta.url).href,
-        url: "https://vuejs.org",
-      },
-      {
-        name: "Figma",
-        img: "/icons/figma.svg",
-        url: "https://www.figma.com",
-      },
-      {
-        name: "Storybook",
-        img: new URL("../../assets/storybook-logo.svg", import.meta.url).href,
-        url: "https://storybook.js.org",
-      },
-      {
-        name: "VitePress",
-        img: new URL("../../assets/vitepress-logo.svg", import.meta.url).href,
-        url: "https://vitepress.dev",
-      },
+      { name: "Vue.js", img: vueLogo, url: "https://vuejs.org" },
+      { name: "Figma", img: "/icons/figma.svg", url: "https://www.figma.com" },
+      { name: "Storybook", img: storybookLogo, url: "https://storybook.js.org" },
+      { name: "VitePress", img: vitepressLogo, url: "https://vitepress.dev" },
     ],
   },
 ];


### PR DESCRIPTION
## Description

Seems like VitePress does not support the `new URL()` syntax for image imports which is typically supported by Vite so we need to import every image explicitly.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
