### PR TITLE
docs: update facts and figures

### DIFF
--- a/apps/docs/src/.vitepress/components/OnyxRoadmap.vue
+++ b/apps/docs/src/.vitepress/components/OnyxRoadmap.vue
@@ -55,7 +55,7 @@ const kpiTimestamp = Intl.DateTimeFormat("en-US", {
           <RoadmapCard :title="roadmapData.downloads" description="Downloads (last month)" />
           <RoadmapCard
             :title="packageJson.version"
-            description="onyx Version"
+            description="onyx version"
             href="https://www.npmjs.com/package/sit-onyx"
           />
           <RoadmapCard
@@ -72,11 +72,6 @@ const kpiTimestamp = Intl.DateTimeFormat("en-US", {
             :title="roadmapData.closedIssueCount"
             description="Closed issues"
             :href="`${packageJson.bugs.url}?q=${encodeURIComponent('is:issue is:closed')}`"
-          />
-          <RoadmapCard
-            :title="roadmapData.contributorCount"
-            description="Contributors"
-            :href="`${packageJson.repository.url}/graphs/contributors`"
           />
         </div>
       </section>

--- a/apps/docs/src/index.data.ts
+++ b/apps/docs/src/index.data.ts
@@ -239,13 +239,9 @@ const getOnyxNpmPackages = () => {
   const packagePath = fileURLToPath(new URL("../../../packages", import.meta.url));
 
   const packageFolders = fs.readdirSync(packagePath).filter((packageName) => {
-    const stat = fs.statSync(path.join(packagePath, packageName));
-    if (!stat.isDirectory()) return false;
-
     try {
-      const packageJson = JSON.parse(
-        fs.readFileSync(path.join(packagePath, packageName, "package.json"), "utf-8"),
-      );
+      const packageJsonPath = path.join(packagePath, packageName, "package.json");
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
       return !packageJson.private;
     } catch {
       // folder is invalid npm package because it does not contain a valid package.json file

--- a/apps/docs/src/index.data.ts
+++ b/apps/docs/src/index.data.ts
@@ -17,8 +17,6 @@ export type HomePageData = {
   mergedPRCount: number;
   /** Total number of closed issues on GitHub. */
   closedIssueCount: number;
-  /** Total number of GitHub contributors. */
-  contributorCount: number;
   /** Timestamp when this data has been fetched. */
   timestamp: string;
   /** Total number of npm downloads for all onyx npm packages in the last month. */
@@ -46,13 +44,7 @@ export default defineLoader({
       return total + countWord(fileContent, "satisfies Story;");
     }, 0);
 
-    // get available onyx npm packages
-    const packagePath = fileURLToPath(new URL("../../../packages", import.meta.url));
-    const packageFolders = fs.readdirSync(packagePath).filter((packageName) => {
-      const stat = fs.statSync(path.join(packagePath, packageName));
-      return stat.isDirectory();
-    });
-
+    const packageFolders = getOnyxNpmPackages();
     const npmPackageNames = packageFolders.map((packageName) =>
       packageName === "sit-onyx" ? packageName : `@sit-onyx/${packageName}`,
     );
@@ -66,7 +58,6 @@ export default defineLoader({
     const downloads = isDev ? 0 : await getNpmDownloadCount(npmPackageNames);
     const mergedPRCount = isDev ? 0 : await searchGitHub("issues", "type:pr is:merged");
     const closedIssueCount = isDev ? 0 : await searchGitHub("issues", "type:issue is:closed");
-    const contributorCount = isDev ? 0 : await getGitHubContributorCount();
 
     /** Checks whether the given component is implemented (meaning a Storybook file exists) */
     const isImplemented = (componentName: string) => {
@@ -145,7 +136,6 @@ export default defineLoader({
       variantCount,
       mergedPRCount,
       closedIssueCount,
-      contributorCount,
       timestamp: timestamp.toUTCString(),
       downloads,
       packageCount: packageFolders.length,
@@ -183,23 +173,6 @@ const searchGitHub = async (
   }
 
   return body.total_count;
-};
-
-/**
- * Gets the number of contributors.
- *
- * @see: https://docs.github.com/en/rest/metrics/statistics?apiVersion=2022-11-28#get-all-contributor-commit-activity
- */
-const getGitHubContributorCount = async (): Promise<number> => {
-  const body = await executeGitHubRequest("repos/SchwarzIT/onyx/stats/contributors");
-
-  if (!Array.isArray(body)) {
-    throw new Error(
-      `GitHub contributors data is not an array. Response body: ${JSON.stringify(body)}`,
-    );
-  }
-
-  return body.length;
 };
 
 /**
@@ -257,4 +230,28 @@ const executeGitHubRequest = async (apiRoute: string) => {
   }
 
   return body;
+};
+
+/**
+ * Gets a list of public onyx npm packages names.
+ */
+const getOnyxNpmPackages = () => {
+  const packagePath = fileURLToPath(new URL("../../../packages", import.meta.url));
+
+  const packageFolders = fs.readdirSync(packagePath).filter((packageName) => {
+    const stat = fs.statSync(path.join(packagePath, packageName));
+    if (!stat.isDirectory()) return false;
+
+    try {
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.join(packagePath, packageName, "package.json"), "utf-8"),
+      );
+      return !packageJson.private;
+    } catch {
+      // folder is invalid npm package because it does not contain a valid package.json file
+      return false;
+    }
+  });
+
+  return packageFolders;
 };


### PR DESCRIPTION
## Description

Remove the contributors count from the docs because the GitHub API route seems to be flaky because it randomly fails in CI. Also the npm package count not ignores private packages like our eslint-plugin which is not published and should therefore not be included in the count.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
