### PR TITLE
refactor: update CSS selectors for themes

### DIFF
--- a/.github/workflows/import-figma.yml
+++ b/.github/workflows/import-figma.yml
@@ -27,17 +27,17 @@ jobs:
       # we need to separately import the themes because they are all needed in different formats and selectors
       - name: Import onyx variables
         run: |
-          pnpm run @sit-onyx/figma-utils import-variables -k "${{ vars.FIGMA_FILE_KEY }}" -t "${{ secrets.FIGMA_TOKEN }}" -d "../sit-onyx/src/styles" -m onyx -f CSS JSON
+          pnpm run @sit-onyx/figma-utils import-variables -k "${{ vars.FIGMA_FILE_KEY }}" -t "${{ secrets.FIGMA_TOKEN }}" -d "../sit-onyx/src/styles" -m onyx -f CSS JSON -s ":where(:root), .onyx-default"
         working-directory: packages/figma-utils
 
       - name: Import light variables
         run: |
-          pnpm run @sit-onyx/figma-utils import-variables -k "${{ vars.FIGMA_FILE_KEY }}" -t "${{ secrets.FIGMA_TOKEN }}" -d "../sit-onyx/src/styles" -m light
+          pnpm run @sit-onyx/figma-utils import-variables -k "${{ vars.FIGMA_FILE_KEY }}" -t "${{ secrets.FIGMA_TOKEN }}" -d "../sit-onyx/src/styles" -m light -s ":where(:root), .onyx-light"
         working-directory: packages/figma-utils
 
       - name: Import dark variables
         run: |
-          pnpm run @sit-onyx/figma-utils import-variables -k "${{ vars.FIGMA_FILE_KEY }}" -t "${{ secrets.FIGMA_TOKEN }}" -d "../sit-onyx/src/styles" -m dark -s .{mode}
+          pnpm run @sit-onyx/figma-utils import-variables -k "${{ vars.FIGMA_FILE_KEY }}" -t "${{ secrets.FIGMA_TOKEN }}" -d "../sit-onyx/src/styles" -m dark -s ":where(.dark), .onyx-dark"
         working-directory: packages/figma-utils
 
       - name: Create pull request

--- a/packages/sit-onyx/src/styles/variables-dark.css
+++ b/packages/sit-onyx/src/styles/variables-dark.css
@@ -1,9 +1,10 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "dark" theme.
- * Imported from Figma API on Tue, 23 Jan 2024 12:10:40 GMT
+ * Imported from Figma API on Wed, 24 Jan 2024 15:58:07 GMT
  */
-.dark {
+:where(.dark),
+.onyx-dark {
   --onyx-color-base-action-100: var(--onyx-color-themed-action-1100);
   --onyx-color-base-action-200: var(--onyx-color-themed-action-1000);
   --onyx-color-base-action-300: var(--onyx-color-themed-action-900);
@@ -15,8 +16,9 @@
   --onyx-color-base-action-900: var(--onyx-color-themed-action-300);
   --onyx-color-base-background-blank: var(--onyx-color-themed-neutral-1100);
   --onyx-color-base-background-tinted: var(--onyx-color-themed-neutral-1200);
-  --onyx-color-base-border-active: var(--onyx-color-base-action-300);
+  --onyx-color-base-border-active: var(--onyx-color-base-action-500);
   --onyx-color-base-border-default: var(--onyx-color-base-neutral-300);
+  --onyx-color-base-border-hover: var(--onyx-color-base-action-300);
   --onyx-color-base-brand-100: var(--onyx-color-themed-brand-1100);
   --onyx-color-base-brand-200: var(--onyx-color-themed-brand-1000);
   --onyx-color-base-brand-300: var(--onyx-color-themed-brand-900);

--- a/packages/sit-onyx/src/styles/variables-light.css
+++ b/packages/sit-onyx/src/styles/variables-light.css
@@ -1,9 +1,10 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "light" theme.
- * Imported from Figma API on Tue, 23 Jan 2024 12:10:44 GMT
+ * Imported from Figma API on Wed, 24 Jan 2024 15:57:46 GMT
  */
-:root {
+:where(:root),
+.onyx-light {
   --onyx-color-base-action-100: var(--onyx-color-themed-action-100);
   --onyx-color-base-action-200: var(--onyx-color-themed-action-200);
   --onyx-color-base-action-300: var(--onyx-color-themed-action-300);
@@ -15,8 +16,9 @@
   --onyx-color-base-action-900: var(--onyx-color-themed-action-900);
   --onyx-color-base-background-blank: var(--onyx-color-universal-grayscale-white);
   --onyx-color-base-background-tinted: var(--onyx-color-themed-neutral-100);
-  --onyx-color-base-border-active: var(--onyx-color-base-action-300);
+  --onyx-color-base-border-active: var(--onyx-color-base-action-500);
   --onyx-color-base-border-default: var(--onyx-color-base-neutral-300);
+  --onyx-color-base-border-hover: var(--onyx-color-base-action-300);
   --onyx-color-base-brand-100: var(--onyx-color-themed-brand-100);
   --onyx-color-base-brand-200: var(--onyx-color-themed-brand-200);
   --onyx-color-base-brand-300: var(--onyx-color-themed-brand-300);

--- a/packages/sit-onyx/src/styles/variables-onyx.css
+++ b/packages/sit-onyx/src/styles/variables-onyx.css
@@ -1,9 +1,10 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "onyx" theme.
- * Imported from Figma API on Tue, 23 Jan 2024 12:10:50 GMT
+ * Imported from Figma API on Wed, 24 Jan 2024 15:57:36 GMT
  */
-:root {
+:where(:root),
+.onyx-default {
   --onyx-color-themed-action-100: #e9f7f1;
   --onyx-color-themed-action-200: #caf0df;
   --onyx-color-themed-action-300: #a0e7c8;


### PR DESCRIPTION
## Description

Update the CSS selectors for the default, light and dark theme as discussed in our last meeting to support more flexible usage.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
