### PR TITLE
feat(grid-layout): implemented class generation for grid layouting

### DIFF
--- a/apps/docs/src/development/grid.md
+++ b/apps/docs/src/development/grid.md
@@ -1,0 +1,30 @@
+# Grid System
+
+::: warning Work in progress / Active development
+This library is currently in early / active development.
+:::
+
+The grid implementation in **onyx** differs from more popular grid system implementation, that you might know.
+Instead of having a fixed 12 column grid, we have a dynamic grid with 4, 8, 12, 16 and optionally 20 columns.
+The amount of columns differs based on the active breakpoint.
+You can find a detailed description of the system in the [design system docs]() (TODO: Add link to grid UX definition).
+
+::: info
+The dynamic grid has the following advantages over a fixed column grid:
+
+- Elements in the grid are wrapped on smaller breakpoints per default
+- Single Elements keep their approximate size over multiple breakpoints per default
+- Ensures reasonable minimal and maximal size for individual elements
+  :::
+
+## Usage
+
+The grid layout is configured via the following classes. They must be set on the main element of your application.
+
+- `onyx-grid`: Sets up the Grid wrapper, which configures the grid layout depending on the breakpoint. Should be set on the main element of an application.
+
+Additionally there are some optional modifier classes available.
+
+- `onyx-grid-xl-20`: Increases the column count from 16 to 20 for the `xl` breakpoint.
+- `onyx-grid-max-md`: Caps the width before the `lg` breakpoint
+- `onyx-grid-max-lg`: Caps the width before the `xl` breakpoint

--- a/packages/sit-onyx/src/styles/grid.scss
+++ b/packages/sit-onyx/src/styles/grid.scss
@@ -1,5 +1,3 @@
-@use "sass:map";
-
 //
 // Default Grid Variants
 //

--- a/packages/sit-onyx/src/styles/grid.scss
+++ b/packages/sit-onyx/src/styles/grid.scss
@@ -1,0 +1,59 @@
+@use "sass:map";
+
+//
+// Default Grid Variants
+//
+
+// prettier-ignore
+$gridVariants: (
+//  NAME     BREAKPOINT  COLUMNS  GUTTER  MARGIN
+    "2xs"    0px         4        16px    16px,
+    "xs"     576px       8        16px    16px,
+    "sm"     768px       8        24px    32px,
+    "md"     992px       12       24px    64px,
+    "lg"     1440px      16       32px    64px,
+    "xl"     1920px      16       32px    64px,
+);
+
+.onyx-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--onyx-grid-columns), minmax(0, 1fr));
+  gap: var(--onyx-grid-gutter);
+  margin: var(--onyx-grid-margin);
+  max-width: var(--onyx-grid-max-width, none);
+}
+
+@each $name, $breakpoint, $columns, $gutter, $margin in $gridVariants {
+  @media screen and (min-width: $breakpoint) {
+    :where(:root) {
+      --onyx-grid-columns: #{$columns};
+      --onyx-grid-gutter: #{$gutter};
+      --onyx-grid-margin: #{$margin};
+    }
+  }
+}
+
+//
+// Grid variants with max width
+//
+
+// prettier-ignore
+$gridMaxVariants: (
+//  NAME  MAX-WIDTH
+    "md"  1440px,
+    "lg"  1920px,
+);
+
+@each $name, $maxWidth in $gridMaxVariants {
+  .onyx-grid-max-#{$name} {
+    --onyx-grid-max-width: #{$maxWidth};
+  }
+}
+
+//
+// Alternative grid variants
+//
+
+.onyx-grid-xl-20 {
+  --onyx-grid-columns: 20;
+}

--- a/packages/sit-onyx/src/styles/index.scss
+++ b/packages/sit-onyx/src/styles/index.scss
@@ -2,6 +2,7 @@
 // DO NOT ADD ANY STYLES HERE THAT HAVE SIDE EFFECTS ON THE GLOBAL APPLICATION (e.g. body, <a> etc.)
 @use "@fontsource-variable/source-code-pro";
 @use "@fontsource-variable/source-sans-3";
+@use "grid.scss";
 @use "variables-onyx.css";
 @use "variables-light.css";
 @use "variables-dark.css";


### PR DESCRIPTION
Implements the grid layout as defined by UX.
We provide the following classes:

- `onyx-grid`: Sets up the Grid wrapper, which configures the grid layout depending on the breakpoint. Should be set on the main element of an application.

Additionally there are some optional modifier classes available. They all must be set with and on the same element as the `onyx-grid` class.

- `onyx-grid-xl-20`: Increases the column count from 16 to 20 for the `xl` breakpoint.
- `onyx-grid-max-md`:  Caps the width before the `lg` breakpoint
- `onyx-grid-max-lg`:  Caps the width before the `xl` breakpoint