### PR TITLE
feat(docs): improve nav highlighting

### DIFF
--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -24,9 +24,9 @@ export default defineConfig({
     },
     lastUpdated: {}, // needed to show the last updated text with default settings
     nav: [
-      { text: "Brand", link: "/brand/team" },
-      { text: "Basics", link: "/basics/" },
-      { text: "Tokens", link: "/tokens/" },
+      { text: "Brand", link: "/brand/team", activeMatch: "/brand/" },
+      { text: "Basics", link: "/basics/", activeMatch: "/basics/" },
+      { text: "Tokens", link: "/tokens/", activeMatch: "/tokens/" },
       { text: "Development", link: "/development/getting-started" },
       { text: "Report a bug", link: packageJson.bugs.url },
       { text: "Q&A", link: "https://github.com/schwarzit/onyx/discussions/categories/q-a" },

--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
       { text: "Brand", link: "/brand/team", activeMatch: "/brand/" },
       { text: "Basics", link: "/basics/", activeMatch: "/basics/" },
       { text: "Tokens", link: "/tokens/", activeMatch: "/tokens/" },
-      { text: "Development", link: "/development/getting-started" },
+      { text: "Development", link: "/development/getting-started", activeMatch: "/development/" },
       { text: "Report a bug", link: packageJson.bugs.url },
       { text: "Q&A", link: "https://github.com/schwarzit/onyx/discussions/categories/q-a" },
     ],


### PR DESCRIPTION
Highlight the nav items when a child of the nav section is currently active.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
