### PR TITLE
chore: update GitHub actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,6 @@
 
 closes #
 
-## Description
-
 <!-- Briefly describe the changes of this PR. -->
 
 ## Checklist

--- a/.github/templates/playwright/action.yml
+++ b/.github/templates/playwright/action.yml
@@ -25,7 +25,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Upload test results artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always() # needed to also upload test results when they failed (useful for debugging)
       with:
         name: test-results

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,20 +50,20 @@ jobs:
         run: pnpm run publint:all
 
       - name: Upload code coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() # needed to also upload test results when they failed (useful for debugging)
         with:
           name: coverage
           path: packages/sit-onyx/coverage
 
       - name: Upload Storybook artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: storybook-static
           path: packages/sit-onyx/storybook-static
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: apps/docs/src/.vitepress/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,13 @@ jobs:
           VITEPRESS_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Storybook artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: storybook-static
           path: packages/sit-onyx/storybook-static
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: apps/docs/src/.vitepress/dist


### PR DESCRIPTION
## Description

Update GitHub actions to use a node 20 based version instead of node 16 to prevent warnings in CI.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
