### PR TITLE
docs: fix tab mobile layout on home page

### DIFF
--- a/apps/docs/src/.vitepress/components/TabGroup.vue
+++ b/apps/docs/src/.vitepress/components/TabGroup.vue
@@ -41,14 +41,7 @@ watchEffect(() => {
 </template>
 
 <style lang="scss" scoped>
-@use "@sit-onyx/vitepress-theme/mixins.scss";
-
 .tabs {
-  margin-bottom: 1rem;
-
-  @include mixins.breakpoint(max, s) {
-    margin-left: 0;
-    margin-right: 0;
-  }
+  margin: 0 0 1rem;
 }
 </style>

--- a/apps/docs/src/.vitepress/components/TabGroup.vue
+++ b/apps/docs/src/.vitepress/components/TabGroup.vue
@@ -41,7 +41,14 @@ watchEffect(() => {
 </template>
 
 <style lang="scss" scoped>
+@use "@sit-onyx/vitepress-theme/mixins.scss";
+
 .tabs {
   margin-bottom: 1rem;
+
+  @include mixins.breakpoint(max, s) {
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 </style>


### PR DESCRIPTION
Prevent the tabs on the home page to be full width on a small breakpoint.
<img width="695" alt="image" src="https://github.com/SchwarzIT/onyx/assets/67898185/006670d2-c8c6-485f-b125-239537335424">


## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
