### PR TITLE
chore: update GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download Storybook artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: storybook-static
           path: packages/sit-onyx/.cloud-foundry/storybook-static
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download Storybook artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: documentation
           path: apps/docs/.cloud-foundry/dist


### PR DESCRIPTION
Our release workflow currently fails because it can not find the docs/storybook artifacts. I guess this is because we use version 4 to upload the artifact but version 3 to download it.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
