### PR TITLE
Fix/peer dependencies

### DIFF
--- a/.changeset/big-ears-cheer.md
+++ b/.changeset/big-ears-cheer.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix: define fonts as peerDependency

--- a/.changeset/large-scissors-rhyme.md
+++ b/.changeset/large-scissors-rhyme.md
@@ -1,0 +1,7 @@
+---
+"@sit-onyx/storybook-utils": patch
+"@sit-onyx/vitepress-theme": patch
+"@sit-onyx/headless": patch
+---
+
+fix: prevent type error when importing as library

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -8,13 +8,10 @@
   "files": [
     "src"
   ],
+  "types": "./src/index.ts",
   "exports": {
-    ".": {
-      "default": "./src/index.ts"
-    },
-    "./playwright": {
-      "default": "./src/playwright.ts"
-    }
+    ".": "./src/index.ts",
+    "./playwright": "./src/playwright.ts"
   },
   "scripts": {
     "build": "vue-tsc --build --force",

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -39,12 +39,12 @@
     "type-check": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false"
   },
   "peerDependencies": {
+    "@fontsource-variable/source-code-pro": ">= 5",
+    "@fontsource-variable/source-sans-3": ">= 5",
     "vue": ">= 3"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.8.4",
-    "@fontsource-variable/source-code-pro": "^5.0.17",
-    "@fontsource-variable/source-sans-3": "^5.0.19",
     "@sit-onyx/headless": "workspace:^",
     "@sit-onyx/storybook-utils": "workspace:^",
     "@storybook/addon-essentials": "^7.6.10",

--- a/packages/storybook-utils/package.json
+++ b/packages/storybook-utils/package.json
@@ -8,6 +8,7 @@
   "files": [
     "src"
   ],
+  "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
     "./style.css": "./src/index.css"

--- a/packages/vitepress-theme/package.json
+++ b/packages/vitepress-theme/package.json
@@ -8,6 +8,7 @@
   "files": [
     "src"
   ],
+  "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
     "./mixins.scss": "./src/mixins.scss"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,12 @@ importers:
 
   packages/sit-onyx:
     dependencies:
+      '@fontsource-variable/source-code-pro':
+        specifier: '>= 5'
+        version: 5.0.17
+      '@fontsource-variable/source-sans-3':
+        specifier: '>= 5'
+        version: 5.0.19
       vue:
         specifier: '>= 3'
         version: 3.4.15(typescript@5.3.3)
@@ -163,12 +169,6 @@ importers:
       '@axe-core/playwright':
         specifier: ^4.8.4
         version: 4.8.4(playwright-core@1.41.1)
-      '@fontsource-variable/source-code-pro':
-        specifier: ^5.0.17
-        version: 5.0.17
-      '@fontsource-variable/source-sans-3':
-        specifier: ^5.0.19
-        version: 5.0.19
       '@sit-onyx/headless':
         specifier: workspace:^
         version: link:../headless
@@ -2299,11 +2299,11 @@ packages:
 
   /@fontsource-variable/source-code-pro@5.0.17:
     resolution: {integrity: sha512-O1Hn0QamTJDfFauR68ALijno0xTOy/sJAE/cORyP2s5unEiJOZj0EBQIhHymHdS7XI+xccAfSEdaZNmz9rhttA==}
-    dev: true
+    dev: false
 
   /@fontsource-variable/source-sans-3@5.0.19:
     resolution: {integrity: sha512-tLw2C4Su5gY+xZLQgkia/EdtsU/Sx5PnFGI+nUzcQPN2Nd2vCXu9gc819Eop+hU9uKeS2RPzja+fKoAJM+QpDg==}
-    dev: true
+    dev: false
 
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}


### PR DESCRIPTION
Add `types` property to `package.json` files to prevent a type error when importing the package as library.
![image](https://github.com/SchwarzIT/onyx/assets/67898185/21488437-9ab5-466c-842a-b943e41aec33)

Also define the font families as peerDependency so they are automatically downloaded when e.g. using `@sit-onyx/vitepress-theme` which depends on those fonts.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
