### PR TITLE
docs: remove empty pages

### DIFF
--- a/apps/docs/src/.vitepress/components/OnyxRoadmap.vue
+++ b/apps/docs/src/.vitepress/components/OnyxRoadmap.vue
@@ -45,12 +45,12 @@ const kpiTimestamp = Intl.DateTimeFormat("en-US", {
           <RoadmapCard
             :title="roadmapData.componentCount"
             :description="roadmapData.componentCount === 1 ? 'Component' : 'Components'"
-            href="/getting-started"
+            href="/development/"
           />
           <RoadmapCard
             :title="roadmapData.variantCount"
             description="Component variants"
-            href="/getting-started"
+            href="/development/"
           />
           <RoadmapCard :title="roadmapData.downloads" description="Downloads (last month)" />
           <RoadmapCard

--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -24,11 +24,10 @@ export default defineConfig({
     },
     lastUpdated: {}, // needed to show the last updated text with default settings
     nav: [
-      { text: "Brand", link: "/brand/", activeMatch: "/brand/" },
+      { text: "The Team", link: "/brand/team", activeMatch: "/brand/" },
       { text: "Basics", link: "/basics/", activeMatch: "/basics/" },
-      { text: "Tokens", link: "/tokens/", activeMatch: "/tokens/" },
+      { text: "Tokens", link: "/tokens/introduction", activeMatch: "/tokens/" },
       { text: "Development", link: "/development/", activeMatch: "/development/" },
-      { text: "Resources", link: "/resources/", activeMatch: "/resources/" },
       { text: "Report a bug", link: packageJson.bugs.url },
       { text: "Q&A", link: "https://github.com/schwarzit/onyx/discussions/categories/q-a" },
     ],
@@ -36,14 +35,8 @@ export default defineConfig({
     sidebar: {
       "/brand": [
         {
-          items: [
-            { text: "The Team", link: "/brand/team" },
-            { text: "Ideology", link: "/brand/ideology" },
-            { text: "Principles", link: "/brand/principles" },
-            { text: "Dependencies", link: "/brand/dependencies" },
-            { text: "Roadmap", link: "/brand/roadmap" },
-            { text: "Changelog", link: "/brand/changelog" },
-          ],
+          text: "Brand",
+          items: [{ text: "The Team", link: "/brand/team" }],
         },
       ],
       "/basics": [
@@ -82,6 +75,7 @@ export default defineConfig({
       ],
       "/tokens": [
         {
+          text: "Design Tokens",
           base: "/tokens",
           items: [
             { text: "Introduction", link: "/introduction" },
@@ -119,11 +113,6 @@ export default defineConfig({
             { text: "Storybook utilities", link: "/storybook-utils" },
             { text: "VitePress theme", link: "/vitepress-theme" },
           ],
-        },
-      ],
-      "/resources": [
-        {
-          items: [{ text: "test", link: "/resources" }],
         },
       ],
     },

--- a/apps/docs/src/basics/colors.md
+++ b/apps/docs/src/basics/colors.md
@@ -4,7 +4,7 @@ Colors play a crucial role in an user interface for enhancing the visual appeal 
 
 ## Understanding light & dark mode
 
-The onyx color scheme is tightly connect to the [design token systematic](/tokens/), that applies the values to the interface. Therefore, please get familiar with the logic of [token levels](/tokens/introduction) used in onyx. This will be the foundation of understanding how colors will be interpreted for light and dark mode.
+The onyx color scheme is tightly connect to the [design token systematic](/tokens/introduction), that applies the values to the interface. Therefore, please get familiar with the logic of [token levels](/tokens/introduction) used in onyx. This will be the foundation of understanding how colors will be interpreted for light and dark mode.
 
 ### Global color scheme
 

--- a/apps/docs/src/basics/infographics.md
+++ b/apps/docs/src/basics/infographics.md
@@ -1,1 +1,1 @@
-Currently onyx does not provide custom chart components. We recommend using [Chart.js](https://www.chartjs.org) instead and make use of the [onyx tokens](/tokens/) for styling.
+Currently onyx does not provide custom chart components. We recommend using [Chart.js](https://www.chartjs.org) instead and make use of the [onyx tokens](/tokens/introduction) for styling.

--- a/apps/docs/src/basics/units.md
+++ b/apps/docs/src/basics/units.md
@@ -4,7 +4,7 @@ A unit system helps to simplify the structure of components layouts. Employing a
 
 ## 4px system
 
-The onyx unit system is based on the value `4`, which is scaled by multiplication. This leads to a restricted set of values that guarantees a harmonious appearance. All of those values are described by [tokens](/tokens/), that can be used for building the interface.
+The onyx unit system is based on the value `4`, which is scaled by multiplication. This leads to a restricted set of values that guarantees a harmonious appearance. All of those values are described by [tokens](/tokens/introduction), that can be used for building the interface.
 
 ::: tip rem
 Although the unit system is based on pixel values, rem is used in development.

--- a/apps/docs/src/brand/changelog.md
+++ b/apps/docs/src/brand/changelog.md
@@ -1,3 +1,0 @@
-# Changelog
-
-<!--@include: @/.vitepress/to-be-done.md-->

--- a/apps/docs/src/brand/dependencies.md
+++ b/apps/docs/src/brand/dependencies.md
@@ -1,3 +1,0 @@
-# Dependencies
-
-<!--@include: @/.vitepress/to-be-done.md-->

--- a/apps/docs/src/brand/ideology.md
+++ b/apps/docs/src/brand/ideology.md
@@ -1,3 +1,0 @@
-# Ideology
-
-<!--@include: @/.vitepress/to-be-done.md-->

--- a/apps/docs/src/brand/index.md
+++ b/apps/docs/src/brand/index.md
@@ -1,5 +1,0 @@
-# Brand
-
-::: warning Work in progress
-Here will be a overview page with cards.
-:::

--- a/apps/docs/src/brand/principles.md
+++ b/apps/docs/src/brand/principles.md
@@ -1,3 +1,0 @@
-# Principles
-
-<!--@include: @/.vitepress/to-be-done.md-->

--- a/apps/docs/src/brand/roadmap.md
+++ b/apps/docs/src/brand/roadmap.md
@@ -1,3 +1,0 @@
-# Roadmap
-
-<!--@include: @/.vitepress/to-be-done.md-->

--- a/apps/docs/src/resources/index.md
+++ b/apps/docs/src/resources/index.md
@@ -1,5 +1,0 @@
-# Resources
-
-::: warning Work in progress
-Here will be a overview page with cards.
-:::

--- a/apps/docs/src/tokens/index.md
+++ b/apps/docs/src/tokens/index.md
@@ -1,5 +1,0 @@
-# Tokens
-
-::: warning Work in progress
-Here will be a overview page with cards.
-:::


### PR DESCRIPTION
Remove empty/placeholder pages for now so we do not blow up our documentation with dummy content.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
