### PR TITLE
chore(docs): optimize storybook docs template

### DIFF
--- a/packages/sit-onyx/.storybook/docs-template.mdx
+++ b/packages/sit-onyx/.storybook/docs-template.mdx
@@ -6,13 +6,9 @@ import { Meta, Title, Description, Stories, Controls, Primary } from "@storybook
 
 <Description />
 
-<br />
-
-Below you can find various pre-defined variations of the component for different use cases.
+_Below you can find various pre-defined variations of the component for different use cases._
 
 <Stories title="Examples" />
-
-<br />
 
 ## Properties, Events and Slots
 


### PR DESCRIPTION
Previously, we used `<br>` inside our storybook docs template. Those added up to the margins of the text and bloated the layout.
In this PR, those `<br>`s are removed and the standard text is distincted from the component specfic information by making it italic.
**Before**
![image](https://github.com/SchwarzIT/onyx/assets/151019977/3730b343-0547-4cbe-9aa9-b56f2bcb282b)

**After**
![image](https://github.com/SchwarzIT/onyx/assets/151019977/f96a7005-3a30-4fa5-8efa-bd446757b519)

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
