### PR TITLE
docs: set Storybook dark mode correctly when switching VitePress theme

### DIFF
--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -59,6 +59,16 @@ export const createPreview = <T extends Preview = Preview>(overrides?: T) => {
           const isDark = themeParam
             ? themeParam === "dark"
             : parent.document.body.classList.contains("dark");
+          console.log(isDark);
+
+          if (isDark) {
+            document.body.classList.remove("light");
+            document.body.classList.add("dark");
+          } else {
+            document.body.classList.remove("dark");
+            document.body.classList.add("light");
+          }
+
           return isDark ? themes.dark : themes.light;
         },
         source: {

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -59,7 +59,6 @@ export const createPreview = <T extends Preview = Preview>(overrides?: T) => {
           const isDark = themeParam
             ? themeParam === "dark"
             : parent.document.body.classList.contains("dark");
-          console.log(isDark);
 
           if (isDark) {
             document.body.classList.remove("light");


### PR DESCRIPTION
The embedded Storybook component docs did not correctly switch to dark mode when the theme is toggled in VitePress.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
