### PR TITLE
fix(docs): bundle top nav content

### DIFF
--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -47,10 +47,12 @@ export default defineConfig({
       {
         text: "Resources",
         activeMatch: "/resources/",
-        items: [{ text: "Icons", link: "/resources/icons" }],
+        items: [
+          { text: "Icons", link: "/resources/icons" },
+          { text: "Report a bug", link: packageJson.bugs.url },
+          { text: "Q&A", link: "https://github.com/schwarzit/onyx/discussions/categories/q-a" },
+        ],
       },
-      { text: "Report a bug", link: packageJson.bugs.url },
-      { text: "Q&A", link: "https://github.com/schwarzit/onyx/discussions/categories/q-a" },
     ],
     socialLinks: [{ icon: "github", link: packageJson.repository.url }],
     sidebar: {


### PR DESCRIPTION
closes #243 

Prevents an overflow of the nav content of our vitepress documentation by moving the "Report a Bug" and "Q&A" links into the "Resources" drop-down.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
