### PR TITLE
docs(icons): Implement search functionality in icon library

### DIFF
--- a/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
+++ b/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
@@ -8,24 +8,26 @@ const ALL_ICONS = import.meta.glob("../../../node_modules/@sit-onyx/icons/src/as
   as: "raw",
   eager: true,
 });
-const ENRICHED_ICON_CATEGORY_LIST = getEnrichedIconCategoryList(ALL_ICONS);
+const enrichedIconCategoryList = getEnrichedIconCategoryList(ALL_ICONS);
 
 const search = ref("");
 
 const filteredCategories = computed(() => {
   const lowerCaseSearch = search.value.toLowerCase();
-  return ENRICHED_ICON_CATEGORY_LIST.map((category) => {
-    if (category.name.toLowerCase().includes(lowerCaseSearch)) return category;
+  return enrichedIconCategoryList
+    .map((category) => {
+      if (category.name.toLowerCase().includes(lowerCaseSearch)) return category;
 
-    return {
-      ...category,
-      icons: category.icons.filter(
-        (icon) =>
-          icon.iconName.toLowerCase().includes(lowerCaseSearch) ||
-          icon.metadata.aliases?.some((alias) => alias.includes(lowerCaseSearch)),
-      ),
-    };
-  }).filter((category) => category.icons.length);
+      return {
+        ...category,
+        icons: category.icons.filter(
+          (icon) =>
+            icon.iconName.toLowerCase().includes(lowerCaseSearch) ||
+            icon.metadata.aliases?.some((alias) => alias.includes(lowerCaseSearch)),
+        ),
+      };
+    })
+    .filter((category) => category.icons.length);
 });
 </script>
 

--- a/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
+++ b/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
@@ -1,64 +1,31 @@
 <script lang="ts" setup>
-import { ICON_CATEGORIES } from "@sit-onyx/icons";
+import { computed, ref } from "vue";
 import OnyxIcon from "~components/OnyxIcon/OnyxIcon.vue";
 import Search from "./Search.vue";
-import { capitalize, computed, ref } from "vue";
-
-const search = ref("");
+import { getEnrichedIconCategoryList } from "../utils-icons";
 
 const ALL_ICONS = import.meta.glob("../../../node_modules/@sit-onyx/icons/src/assets/*.svg", {
   as: "raw",
   eager: true,
 });
+const ENRICHED_ICON_CATEGORY_LIST = getEnrichedIconCategoryList(ALL_ICONS);
 
-const getIconContent = (iconName: string) => {
-  return ALL_ICONS[`../../../node_modules/@sit-onyx/icons/src/assets/${iconName}.svg`];
-};
+const search = ref("");
 
-const getIconContextData = (iconName: string) => {
-  const parts = iconName.split("-");
-  // bell-disabled => Bell Disabled
-  const tooltipName = parts.map((word) => capitalize(word)).join(" ");
-  // bell-disabled => bellDisabled
-  const importName = parts
-    .map((word, index) => {
-      if (index === 0) return word;
-      return capitalize(word);
-    })
-    .join("");
-
-  return { tooltipName, importName, content: getIconContent(iconName) };
-};
-
-// collects the icon contents once for all icons
-const enrichedIconCategories = Object.entries(ICON_CATEGORIES).map(([category, icons]) => ({
-  name: category,
-  icons: icons.map((icon) => ({
-    ...icon,
-    ...getIconContextData(icon.iconName),
-    metadata: {
-      ...icon.metadata,
-      // make the search more reliable
-      aliases: icon.metadata.aliases?.map((alias) => alias.toLowerCase()),
-    },
-  })),
-}));
 const filteredCategories = computed(() => {
   const lowerCaseSearch = search.value.toLowerCase();
-  return enrichedIconCategories
-    .map((category) => {
-      if (category.name.toLowerCase().includes(lowerCaseSearch)) return category;
+  return ENRICHED_ICON_CATEGORY_LIST.map((category) => {
+    if (category.name.toLowerCase().includes(lowerCaseSearch)) return category;
 
-      return {
-        ...category,
-        icons: category.icons.filter(
-          (icon) =>
-            icon.iconName.toLowerCase().includes(lowerCaseSearch) ||
-            icon.metadata.aliases?.some((alias) => alias.includes(lowerCaseSearch)),
-        ),
-      };
-    })
-    .filter((category) => category.icons.length);
+    return {
+      ...category,
+      icons: category.icons.filter(
+        (icon) =>
+          icon.iconName.toLowerCase().includes(lowerCaseSearch) ||
+          icon.metadata.aliases?.some((alias) => alias.includes(lowerCaseSearch)),
+      ),
+    };
+  }).filter((category) => category.icons.length);
 });
 </script>
 
@@ -76,6 +43,7 @@ const filteredCategories = computed(() => {
           :icon="icon.content"
           size="md"
           :title="icon.tooltipName"
+          :color="icon.metadata.deprecated ? 'secondary' : 'currentColor'"
         />
       </div>
     </section>

--- a/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
+++ b/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
@@ -41,7 +41,6 @@ const filteredCategories = computed(() => {
           v-for="icon in category.icons"
           :key="icon.iconName"
           :icon="icon.content"
-          size="md"
           :title="icon.tooltipName"
           :color="icon.metadata.deprecated ? 'secondary' : 'currentColor'"
         />

--- a/apps/docs/src/.vitepress/components/Search.vue
+++ b/apps/docs/src/.vitepress/components/Search.vue
@@ -1,0 +1,27 @@
+<script lang="ts" setup>
+import { computed } from "vue";
+import OnyxIcon from "~components/OnyxIcon/OnyxIcon.vue";
+import searchIcon from "@sit-onyx/icons/search.svg?raw";
+
+const props = defineProps<{
+  modelValue?: string;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+
+const value = computed({
+  get: () => props.modelValue,
+  set: (value) => emit("update:modelValue", value as string),
+});
+</script>
+
+<template>
+  <label aria-label="Search">
+    <input placeholder="Search" type="search" v-model="value" />
+    <OnyxIcon :icon="searchIcon" />
+  </label>
+</template>
+
+<style lang="scss" scoped></style>

--- a/apps/docs/src/.vitepress/components/Search.vue
+++ b/apps/docs/src/.vitepress/components/Search.vue
@@ -27,10 +27,10 @@ const value = computed({
 <style lang="scss" scoped>
 .search {
   display: flex;
-  width: 296px;
-  padding: var(--onyx-spacing-2xs, 8px);
+  width: 18.5rem;
+  padding: var(--onyx-spacing-2xs, 0.5rem);
   justify-content: space-between;
-  border-radius: var(--onyx-radius-md, 8px);
+  border-radius: var(--onyx-radius-md, 0.5rem);
   border: 1px solid var(--onyx-color-base-neutral-300);
   background: var(--onyx-color-base-background-blank);
 
@@ -38,7 +38,7 @@ const value = computed({
     color: var(--onyx-color-text-icons-neutral-intense);
     font-size: 1rem;
     font-weight: 400;
-    line-height: 24px;
+    line-height: 1.5rem;
   }
 }
 </style>

--- a/apps/docs/src/.vitepress/components/Search.vue
+++ b/apps/docs/src/.vitepress/components/Search.vue
@@ -18,10 +18,27 @@ const value = computed({
 </script>
 
 <template>
-  <label aria-label="Search">
-    <input placeholder="Search" type="search" v-model="value" />
+  <label aria-label="Search" class="search">
+    <input class="search__input" placeholder="Search" type="search" v-model="value" size="31" />
     <OnyxIcon :icon="searchIcon" />
   </label>
 </template>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.search {
+  display: flex;
+  width: 296px;
+  padding: var(--onyx-spacing-2xs, 8px);
+  justify-content: space-between;
+  border-radius: var(--onyx-radius-md, 8px);
+  border: 1px solid var(--onyx-color-base-neutral-300);
+  background: var(--onyx-color-base-background-blank);
+
+  &__input {
+    color: var(--onyx-color-text-icons-neutral-intense);
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 24px;
+  }
+}
+</style>

--- a/apps/docs/src/.vitepress/utils-icons.ts
+++ b/apps/docs/src/.vitepress/utils-icons.ts
@@ -1,0 +1,33 @@
+import { ICON_CATEGORIES } from "@sit-onyx/icons";
+import { capitalize } from "vue";
+
+const getIconContextData = (iconName: string, ALL_ICONS: Record<string, string>) => {
+  const parts = iconName.split("-");
+  // bell-disabled => `Bell Disabled`
+  const tooltipName = parts.map((word) => capitalize(word)).join(" ");
+  // bell-disabled => `bellDisabled`
+  const importName = parts
+    .map((word, index) => {
+      if (index === 0) return word;
+      return capitalize(word);
+    })
+    .join("");
+  // svg content for OnyxIcon `icon` prop
+  const content = ALL_ICONS[`../../../node_modules/@sit-onyx/icons/src/assets/${iconName}.svg`];
+  return { tooltipName, importName, content };
+};
+
+// Collects all needed icon context data and provides them as a list.
+export const getEnrichedIconCategoryList = (ALL_ICONS: Record<string, string>) =>
+  Object.entries(ICON_CATEGORIES).map(([category, icons]) => ({
+    name: category,
+    icons: icons.map((icon) => ({
+      ...icon,
+      ...getIconContextData(icon.iconName, ALL_ICONS),
+      metadata: {
+        ...icon.metadata,
+        // make the search more reliable
+        aliases: icon.metadata.aliases?.map((alias) => alias.toLowerCase()),
+      },
+    })),
+  }));

--- a/apps/docs/src/.vitepress/utils-icons.ts
+++ b/apps/docs/src/.vitepress/utils-icons.ts
@@ -26,7 +26,7 @@ export const getEnrichedIconCategoryList = (ALL_ICONS: Record<string, string>) =
       ...getIconContextData(icon.iconName, ALL_ICONS),
       metadata: {
         ...icon.metadata,
-        // make the search more reliable
+        // make the searchability more reliable
         aliases: icon.metadata.aliases?.map((alias) => alias.toLowerCase()),
       },
     })),

--- a/apps/docs/src/.vitepress/utils-icons.ts
+++ b/apps/docs/src/.vitepress/utils-icons.ts
@@ -1,7 +1,7 @@
 import { ICON_CATEGORIES } from "@sit-onyx/icons";
 import { capitalize } from "vue";
 
-const getIconContextData = (iconName: string, ALL_ICONS: Record<string, string>) => {
+const getIconContextData = (iconName: string, allIconContents: Record<string, string>) => {
   const parts = iconName.split("-");
   // bell-disabled => `Bell Disabled`
   const tooltipName = parts.map((word) => capitalize(word)).join(" ");
@@ -13,17 +13,18 @@ const getIconContextData = (iconName: string, ALL_ICONS: Record<string, string>)
     })
     .join("");
   // svg content for OnyxIcon `icon` prop
-  const content = ALL_ICONS[`../../../node_modules/@sit-onyx/icons/src/assets/${iconName}.svg`];
+  const content =
+    allIconContents[`../../../node_modules/@sit-onyx/icons/src/assets/${iconName}.svg`];
   return { tooltipName, importName, content };
 };
 
 // Collects all needed icon context data and provides them as a list.
-export const getEnrichedIconCategoryList = (ALL_ICONS: Record<string, string>) =>
+export const getEnrichedIconCategoryList = (allIconContents: Record<string, string>) =>
   Object.entries(ICON_CATEGORIES).map(([category, icons]) => ({
     name: category,
     icons: icons.map((icon) => ({
       ...icon,
-      ...getIconContextData(icon.iconName, ALL_ICONS),
+      ...getIconContextData(icon.iconName, allIconContents),
       metadata: {
         ...icon.metadata,
         // make the searchability more reliable


### PR DESCRIPTION
Part of #242 

Implements a search functionality for our icon library documentation. Supports lower case search for icon name, icon alias and category name.

<img width="470" alt="image" src="https://github.com/SchwarzIT/onyx/assets/151019977/394379ad-7af6-4fa6-8ab9-8ad958e8e8d1">