### PR TITLE
docs: fix Storybook table overflow

### DIFF
--- a/packages/sit-onyx/.storybook/docs-template.scss
+++ b/packages/sit-onyx/.storybook/docs-template.scss
@@ -2,5 +2,18 @@
   > .sbdocs {
     // adjust padding to better fit in our VitePress documentation when embedded
     padding: 32px 24px;
+
+    // fix responsive overflow for the props/events table
+    // to be horizontally scrollable instead of overflowing the page width
+    div {
+      &:has(> .docblock-argstable) {
+        overflow-x: auto;
+
+        > .docblock-argstable {
+          margin-left: 0;
+          margin-right: 0;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Fix responsive overflow for the props/events table to be horizontally scrollable instead of overflowing the page width.

Before:
![image](https://github.com/SchwarzIT/onyx/assets/67898185/34ba1172-7af3-4a58-b915-3d714b315b90)

After:
![image](https://github.com/SchwarzIT/onyx/assets/67898185/928fa84e-3a6d-4fca-b859-2c759ea1731c)

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
