### PR TITLE
refactor: replace 1px with css variable

### DIFF
--- a/apps/docs/src/.vitepress/components/ColorPalette.vue
+++ b/apps/docs/src/.vitepress/components/ColorPalette.vue
@@ -134,7 +134,7 @@ const handleCopy = async (color: string) => {
   &__content {
     padding: var(--onyx-spacing-xl);
     border-radius: var(--onyx-radius-md);
-    border: 1px solid var(--onyx-color-base-neutral-300);
+    border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
     background: var(--onyx-color-base-background-blank);
 
     @include mixins.breakpoint(max, s) {

--- a/apps/docs/src/.vitepress/components/ColorPaletteValue.vue
+++ b/apps/docs/src/.vitepress/components/ColorPaletteValue.vue
@@ -102,7 +102,7 @@ const emit = defineEmits<{
     width: calc(100% - 2 * var(--onyx-spacing-md));
 
     &--with-border {
-      border: 1px solid var(--onyx-color-base-neutral-300);
+      border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
       min-height: calc(1.5rem - 2px);
       height: calc(1.5rem - 2px);
     }

--- a/apps/docs/src/.vitepress/components/ComponentCard.vue
+++ b/apps/docs/src/.vitepress/components/ComponentCard.vue
@@ -30,7 +30,7 @@ const props = defineProps<ComponentCardProps>();
 
 <style lang="scss" scoped>
 .card {
-  border: 1px solid var(--vp-c-default-soft);
+  border: var(--onyx-1px-in-rem) solid var(--vp-c-default-soft);
   border-radius: 0.75rem;
   height: 100%;
   background-color: var(--vp-c-bg);

--- a/apps/docs/src/.vitepress/components/DesignToken.vue
+++ b/apps/docs/src/.vitepress/components/DesignToken.vue
@@ -71,7 +71,7 @@ const emit = defineEmits<{
     padding: var(--onyx-spacing-4xs) var(--onyx-spacing-2xs) var(--onyx-spacing-4xs)
       var(--onyx-spacing-md);
     border-radius: var(--onyx-radius-sm);
-    border: 1px solid var(--onyx-color-base-neutral-300);
+    border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
     font-family: var(--onyx-font-family-mono);
     width: max-content;
     display: flex;
@@ -106,7 +106,7 @@ const emit = defineEmits<{
     &:focus-within {
       .token {
         &__name {
-          border: 1px solid var(--onyx-color-base-primary-300);
+          border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-primary-300);
         }
 
         &__copy {
@@ -127,7 +127,7 @@ const emit = defineEmits<{
           height: 1.25rem;
           background-color: v-bind("props.value");
           border-radius: var(--onyx-radius-sm);
-          border: 1px solid var(--onyx-color-base-neutral-300);
+          border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
         }
       }
     }

--- a/apps/docs/src/.vitepress/components/DesignTokenCard.vue
+++ b/apps/docs/src/.vitepress/components/DesignTokenCard.vue
@@ -52,7 +52,7 @@ const handleCopy = async () => {
 
 .card {
   border-radius: var(--onyx-radius-md);
-  border: 1px solid var(--onyx-color-base-neutral-300);
+  border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
   background: var(--onyx-color-base-background-blank);
   display: grid;
   grid-template-columns: 1fr 25%;
@@ -75,7 +75,7 @@ const handleCopy = async () => {
       align-items: center;
 
       &:last-child {
-        border-left: 1px solid var(--onyx-color-base-neutral-300);
+        border-left: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
         justify-content: center;
       }
     }

--- a/apps/docs/src/.vitepress/components/HorizontalColorStripCard.vue
+++ b/apps/docs/src/.vitepress/components/HorizontalColorStripCard.vue
@@ -24,7 +24,7 @@ const colors = computed(() => {
 .card {
   padding: var(--onyx-spacing-lg);
   border-radius: var(--onyx-radius-md);
-  border: 1px solid var(--onyx-color-base-neutral-300);
+  border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
   background: var(--onyx-color-base-background-blank);
   margin: var(--onyx-spacing-md) 0;
 }

--- a/apps/docs/src/.vitepress/components/IconLibraryItem.vue
+++ b/apps/docs/src/.vitepress/components/IconLibraryItem.vue
@@ -37,7 +37,7 @@ const handleCopy = async () => {
   display: flex;
   justify-content: center;
   align-items: center;
-  border: 0.0625rem solid transparent;
+  border: var(--onyx-1px-in-rem) solid transparent;
   position: relative;
 
   &__tooltip {
@@ -59,7 +59,7 @@ const handleCopy = async () => {
   &:hover,
   &:focus-visible {
     border-radius: var(--onyx-radius-md);
-    border: 0.0625rem solid var(--onyx-color-base-neutral-300);
+    border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
     background: var(--onyx-color-base-background-blank);
     outline-style: unset;
 

--- a/apps/docs/src/.vitepress/components/OnyxBorderRadiusTokens.vue
+++ b/apps/docs/src/.vitepress/components/OnyxBorderRadiusTokens.vue
@@ -38,7 +38,7 @@ const tokens = [
   &__preview {
     width: 4rem;
     height: 4rem;
-    border-width: 1px 1px 1px 0;
+    border-width: var(--onyx-1px-in-rem) var(--onyx-1px-in-rem) var(--onyx-1px-in-rem) 0;
     border-color: var(--onyx-color-base-warning-500);
     border-style: solid;
     background: var(--onyx-color-base-neutral-100);

--- a/apps/docs/src/.vitepress/components/OnyxColorThemeDefinitions.vue
+++ b/apps/docs/src/.vitepress/components/OnyxColorThemeDefinitions.vue
@@ -99,7 +99,7 @@ const infoColors = Array.from({ length: 9 }, (_, index) => {
 
   &__content {
     border-radius: var(--onyx-radius-md);
-    border: 1px solid var(--onyx-color-base-neutral-300);
+    border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
     background: var(--onyx-color-base-background-blank);
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -117,7 +117,7 @@ const infoColors = Array.from({ length: 9 }, (_, index) => {
 
     &:last-child {
       @include mixins.breakpoint(min, s, 1) {
-        border-left: 1px solid var(--onyx-color-base-neutral-300);
+        border-left: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
       }
     }
   }

--- a/apps/docs/src/.vitepress/components/OnyxRoadmap.vue
+++ b/apps/docs/src/.vitepress/components/OnyxRoadmap.vue
@@ -83,7 +83,7 @@ const kpiTimestamp = Intl.DateTimeFormat("en-US", {
 @use "@sit-onyx/vitepress-theme/mixins.scss";
 
 .roadmap {
-  border-top: 1px solid var(--vp-c-gutter);
+  border-top: var(--onyx-1px-in-rem) solid var(--vp-c-gutter);
   background-color: var(--vp-c-bg);
 
   // padding and max-width are aligned with the top "home" section of the page

--- a/apps/docs/src/.vitepress/components/OnyxSpacingTokens.vue
+++ b/apps/docs/src/.vitepress/components/OnyxSpacingTokens.vue
@@ -39,15 +39,15 @@ const spacings = [
   width: 4rem;
   min-height: 4rem;
   border-radius: var(--onyx-radius-sm);
-  border: 1px solid var(--onyx-color-base-neutral-300);
+  border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
   background: var(--onyx-color-base-neutral-100);
   display: flex;
   flex-direction: column;
   justify-content: center;
 
   &__area {
-    border-top: 1px solid var(--onyx-color-base-warning-500);
-    border-bottom: 1px solid var(--onyx-color-base-warning-500);
+    border-top: var(--onyx-1px-in-rem) solid var(--onyx-color-base-warning-500);
+    border-bottom: var(--onyx-1px-in-rem) solid var(--onyx-color-base-warning-500);
     background: var(--onyx-color-base-warning-200);
     width: 100%;
     margin: var(--onyx-spacing-2xs) 0;

--- a/apps/docs/src/.vitepress/components/RoadmapCard.vue
+++ b/apps/docs/src/.vitepress/components/RoadmapCard.vue
@@ -31,7 +31,7 @@ const target = computed(() => (props.href?.startsWith("http") ? "_blank" : "_sel
 
 <style lang="scss" scoped>
 .card {
-  border: 1px solid var(--vp-c-default-soft);
+  border: var(--onyx-1px-in-rem) solid var(--vp-c-default-soft);
   border-radius: 0.75rem;
   height: 100%;
   background-color: var(--vp-c-bg-soft);

--- a/apps/docs/src/.vitepress/components/Search.vue
+++ b/apps/docs/src/.vitepress/components/Search.vue
@@ -31,7 +31,7 @@ const value = computed({
   padding: var(--onyx-spacing-3xs);
   justify-content: space-between;
   border-radius: var(--onyx-radius-md);
-  border: 1px solid var(--onyx-color-base-neutral-300);
+  border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
   background: var(--onyx-color-base-background-blank);
 
   &__input {

--- a/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.vue
+++ b/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.vue
@@ -74,7 +74,7 @@ const isChecked = computed({
     appearance: none;
     margin: 0;
     border-radius: var(--onyx-radius-sm);
-    border: 1px solid var(--onyx-color-base-neutral-400);
+    border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-400);
     outline: none;
     background: var(--onyx-color-base-background-blank);
     cursor: inherit;

--- a/packages/sit-onyx/src/components/OnyxRadioButton/OnyxRadioButton.vue
+++ b/packages/sit-onyx/src/components/OnyxRadioButton/OnyxRadioButton.vue
@@ -112,7 +112,7 @@ watchEffect(() => selectorRef.value?.setCustomValidity(props.errorMessage ?? "")
 
     border: {
       style: solid;
-      width: 1px;
+      width: var(--onyx-1px-in-rem);
       color: var(--onyx-radio-button-selector-border-color);
     }
     border-radius: 100%;

--- a/packages/sit-onyx/src/styles/index.scss
+++ b/packages/sit-onyx/src/styles/index.scss
@@ -10,4 +10,5 @@
 :root {
   --onyx-font-family: "Source Sans 3 Variable", sans-serif;
   --onyx-font-family-mono: "Source Code Pro Variable", monospace;
+  --onyx-1px-in-rem: 0.0625rem;
 }


### PR DESCRIPTION
closes #292

Replaced all occurrences of `1px` with the newly introduced CSS variable `--onyx-1px-in-rem`

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
