### PR TITLE
Support headline style independent of headline level

### DIFF
--- a/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
+++ b/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
@@ -12,7 +12,7 @@ defineSlots<{
   default(): unknown;
 }>();
 
-const headlineSize = computed( () => (props.style || props.level)  );
+const headlineSize = computed( () => (props.size || props.level)  );
 </script>
 
 <template>

--- a/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
+++ b/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
@@ -17,7 +17,7 @@ const headlineSize = computed( () => (props.style || props.level)  );
 
 <template>
   <component
-    :is="props.is"
+    :is="props.level"
     :class="[
       'onyx-headline',
       `onyx-headline--${headlineSize}`,

--- a/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
+++ b/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
@@ -11,6 +11,8 @@ defineSlots<{
    */
   default(): unknown;
 }>();
+
+const headlineSize = computed( () => (props.style || props.level)  );
 </script>
 
 <template>
@@ -18,7 +20,7 @@ defineSlots<{
     :is="props.is"
     :class="[
       'onyx-headline',
-      `onyx-headline--${props.is}`,
+      `onyx-headline--${headlineSize}`,
       props.monospace ? 'onyx-headline--monospace' : '',
     ]"
   >

--- a/packages/sit-onyx/src/components/OnyxHeadline/types.ts
+++ b/packages/sit-onyx/src/components/OnyxHeadline/types.ts
@@ -3,7 +3,9 @@ export type OnyxHeadlineProps = {
    * Headline type. Please note that only h1-h4 are intended to be used from UX perspective.
    * h5 and h6 will have the same styles as h4 and should only be used for semantic reasons.
    */
-  is: HeadlineType;
+  level: HeadlineType;
+  /*+ if defined the style can different from the level  */
+  style?: HeadlineType;
   /** If `true`, the monospace font family will be used instead of the default one. */
   monospace?: boolean;
 };

--- a/packages/sit-onyx/src/components/OnyxHeadline/types.ts
+++ b/packages/sit-onyx/src/components/OnyxHeadline/types.ts
@@ -4,7 +4,7 @@ export type OnyxHeadlineProps = {
    * h5 and h6 will have the same styles as h4 and should only be used for semantic reasons.
    */
   level: HeadlineType;
-  /*+ if defined the style can different from the level  */
+  /*+ if defined the size overrides the level (visually) */
   size?: HeadlineType;
   /** If `true`, the monospace font family will be used instead of the default one. */
   monospace?: boolean;

--- a/packages/sit-onyx/src/components/OnyxHeadline/types.ts
+++ b/packages/sit-onyx/src/components/OnyxHeadline/types.ts
@@ -5,7 +5,7 @@ export type OnyxHeadlineProps = {
    */
   level: HeadlineType;
   /*+ if defined the style can different from the level  */
-  style?: HeadlineType;
+  size?: HeadlineType;
   /** If `true`, the monospace font family will be used instead of the default one. */
   monospace?: boolean;
 };


### PR DESCRIPTION

There are cases when a headline style should be different from the headline level. 
Here is an example. The level should be "2", but the visual size of the headline should be level 3.

<img width="765" alt="" src="https://github.com/SchwarzIT/onyx/assets/351824/b4157432-13b5-453f-8f4d-28967afb8d2b">

## Checklist

- [ ] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [ ] All changes are documented in the documentation app (folder `apps/docs`)
- [ ] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
