### PR TITLE
chore: update deprecated GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,21 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    versioning-strategy: "increase"
+  - package-ecosystem: npm
+    directory: /
+    versioning-strategy: increase
     schedule:
-      interval: "daily"
+      interval: daily
     groups:
       minor:
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
       major:
         update-types:
-          - "major"
+          - major
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -27,7 +27,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload eslint results to GitHub
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/import-figma.yml
+++ b/.github/workflows/import-figma.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/playwright-screenshots.yml
+++ b/.github/workflows/playwright-screenshots.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           ssh-key: ${{ secrets.GH_PUSH_PROTECTED_KEY }}
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Update deprecated GitHub actions to remove warnings inside workflow runs.
Also updated dependabot to also check for GitHub action updates.

![image](https://github.com/SchwarzIT/onyx/assets/67898185/d2eb33ac-ecb9-4ce3-978b-e894f849720b)


## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
