### PR TITLE
docs: fix Storybook copy button not working

### DIFF
--- a/apps/docs/src/.vitepress/components/StorybookIFrame.vue
+++ b/apps/docs/src/.vitepress/components/StorybookIFrame.vue
@@ -25,7 +25,7 @@ const iframeSrc = computed(() => {
 </script>
 
 <template>
-  <iframe class="iframe" :src="iframeSrc" :title="props.component"></iframe>
+  <iframe class="iframe" :src="iframeSrc" :title="props.component" allow="clipboard-write"></iframe>
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
closes #265

Fix copy button in embedded Storybook components inside the VitePress docs.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
