### PR TITLE
refactor(OnyxCheckbox): make `label` property required

### DIFF
--- a/.changeset/selfish-gifts-draw.md
+++ b/.changeset/selfish-gifts-draw.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": major
+---
+
+refactor(OnyxCheckbox): make `label` property required

--- a/.changeset/selfish-gifts-draw.md
+++ b/.changeset/selfish-gifts-draw.md
@@ -3,3 +3,7 @@
 ---
 
 refactor(OnyxCheckbox): make `label` property required
+
+Even if the label is visually hidden, it must be provided for accessibility reasons / screen readers.
+If you used a checkbox without a label previously, add a descriptive label and use the new `hideLabel`
+visually hide the label.

--- a/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.ct.tsx
@@ -213,3 +213,18 @@ for (const testCase of invalidTestCases) {
     await expect(component).toHaveScreenshot(`invalid-${testCase.name}.png`);
   });
 }
+
+test("should have aria-label if label is hidden", async ({ mount, makeAxeBuilder }) => {
+  // ARRANGE
+  const component = await mount(<OnyxCheckbox label="Test label" hideLabel />);
+
+  // ACT
+  const accessibilityScanResults = await makeAxeBuilder().analyze();
+
+  // ASSERT
+  expect(accessibilityScanResults.violations).toEqual([]);
+
+  // ASSERT
+  await expect(component).not.toContainText("Test label");
+  await expect(component.getByLabel("Test label")).toBeAttached();
+});

--- a/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.stories.ts
@@ -56,3 +56,13 @@ export const Required = {
     required: true,
   },
 } satisfies Story;
+
+/**
+ * A checkbox without a label.
+ */
+export const WithoutLabel = {
+  args: {
+    ...Default.args,
+    hideLabel: true,
+  },
+} satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.vue
+++ b/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.vue
@@ -35,6 +35,7 @@ const isTouched = ref(false);
     <div class="onyx-checkbox__container">
       <input
         v-model="isChecked"
+        :aria-label="props.hideLabel ? props.label : undefined"
         class="onyx-checkbox__input"
         :class="{ 'onyx-checkbox__input--touched': isTouched }"
         type="checkbox"
@@ -45,7 +46,7 @@ const isTouched = ref(false);
       />
     </div>
 
-    <p v-if="props.label" class="onyx-checkbox__label">{{ props.label }}</p>
+    <p v-if="props.label && !props.hideLabel" class="onyx-checkbox__label">{{ props.label }}</p>
   </label>
 </template>
 

--- a/packages/sit-onyx/src/components/OnyxCheckbox/types.ts
+++ b/packages/sit-onyx/src/components/OnyxCheckbox/types.ts
@@ -4,9 +4,10 @@ export type OnyxCheckboxProps = {
    */
   modelValue?: boolean;
   /**
-   * Label to show.
+   * Label to show. Required due to accessibility / screen readers.
+   * If you want to visually hide the label, use the `hideLabel` property.
    */
-  label?: string;
+  label: string;
   /**
    * If `true`, an indeterminate indicator is shown.
    */
@@ -19,4 +20,9 @@ export type OnyxCheckboxProps = {
    * Whether the checkbox is required / has to be checked.
    */
   required?: boolean;
+  /**
+   * If `true`, the label will be visually hidden.
+   * For accessibility / screen readers, the aria-label will still be set.
+   */
+  hideLabel?: boolean;
 };


### PR DESCRIPTION
#220

Make the label property required for accessibility / screen readers.
Add a new. `hideLabel` property to visually hide the label which will set the aria-label instead.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
