### PR TITLE
chore: gitignore temporary vitepress files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ playwright-report/
 /blob-report/
 **/.cache
 **/.vitepress/cache
+**/.vitepress/config.ts.timestamp-*.mjs
 storybook-static
 eslint-results.sarif


### PR DESCRIPTION
Sometimes some temporary vitepress files are created, which will appear in `git status` and git UIs (like VS Codes Source Control).
This can be annoying and could be problematic if they are accidentally committed.