### PR TITLE
docs(icon-library): update icon color

### DIFF
--- a/apps/docs/src/.vitepress/components/IconLibraryItem.vue
+++ b/apps/docs/src/.vitepress/components/IconLibraryItem.vue
@@ -39,6 +39,7 @@ const handleCopy = async () => {
   align-items: center;
   border: var(--onyx-1px-in-rem) solid transparent;
   position: relative;
+  color: var(--onyx-color-text-icons-neutral-soft);
 
   &__tooltip {
     position: absolute;
@@ -62,6 +63,7 @@ const handleCopy = async () => {
     border: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
     background: var(--onyx-color-base-background-blank);
     outline-style: unset;
+    color: unset;
 
     .icon__tooltip {
       visibility: inherit;


### PR DESCRIPTION
Update icon color to neutral-soft when not hovered/focussed to match the Figma design: https://www.figma.com/file/YfEUBOHk4J4nYrk04geswG/onyx---Design-System-Figma-Library?type=design&node-id=662-5755&mode=dev

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
