### PR TITLE
chore(dependabot): temporary ignore Storybook updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
+
 updates:
   - package-ecosystem: npm
     directory: /
@@ -16,6 +16,12 @@ updates:
       major:
         update-types:
           - major
+    # temporary ignore Storybook updates because we use a canary release (see packages/sit-onyx/package.json)
+    # until this PR is officially merged/released in Storybook:
+    # https://github.com/storybookjs/storybook/pull/22285
+    ignore:
+      - dependency-name: storybook
+      - dependency-name: "@storybook/*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Temporary ignore Storybook updates because we use a canary release (see packages/sit-onyx/package.json)

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
