### PR TITLE
docs(OnyxIcon): add rem base info

### DIFF
--- a/packages/sit-onyx/src/components/OnyxIcon/types.ts
+++ b/packages/sit-onyx/src/components/OnyxIcon/types.ts
@@ -7,7 +7,7 @@ export type OnyxIconProps = {
    */
   icon: string;
   /**
-   * Icon size. Pixel values will be translated to the according rem value.
+   * Icon size. Pixel values will be translated to the according `rem` value by the base of `16px`=`1rem`.
    * @default 24px
    */
   size?: IconSize;


### PR DESCRIPTION
closes #242

Adds an info about the onyx rem base to the icon size property.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
