### PR TITLE
feat: set browser color scheme depending on selected theme

### DIFF
--- a/.changeset/angry-teachers-tickle.md
+++ b/.changeset/angry-teachers-tickle.md
@@ -1,5 +1,5 @@
 ---
-"docs": minor
+"@sit-onyx/storybook-utils": minor
 ---
 
 feat: set browser color scheme depending on selected theme

--- a/.changeset/angry-teachers-tickle.md
+++ b/.changeset/angry-teachers-tickle.md
@@ -1,0 +1,5 @@
+---
+"docs": minor
+---
+
+feat: set browser color scheme depending on selected theme

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -63,9 +63,11 @@ export const createPreview = <T extends Preview = Preview>(overrides?: T) => {
           if (isDark) {
             document.body.classList.remove("light");
             document.body.classList.add("dark");
+            document.documentElement.style.colorScheme = "dark";
           } else {
             document.body.classList.remove("dark");
             document.body.classList.add("light");
+            document.documentElement.style.colorScheme = "light";
           }
 
           return isDark ? themes.dark : themes.light;


### PR DESCRIPTION
With this change browsers can render native elements like scrollbars in the selected theme. (light or dark)
Images show the difference:

<img width="551" alt="Bildschirmfoto 2024-03-01 um 10 22 35" src="https://github.com/SchwarzIT/onyx/assets/351824/dbfdb348-cb1a-4b28-9bab-f9689de809f8">

<img width="556" alt="Bildschirmfoto 2024-03-01 um 10 21 57" src="https://github.com/SchwarzIT/onyx/assets/351824/1b2d799e-c5a4-4886-8ac7-5cf391dd382d">

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [ ] All changes are documented in the documentation app (folder `apps/docs`)

