### PR TITLE
perf: speed up playwright tests in CI

### DIFF
--- a/packages/sit-onyx/playwright.config.ts
+++ b/packages/sit-onyx/playwright.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI, // fail build on CI if we left test.only in the source code
   retries: process.env.CI ? 2 : 0, // retry on CI only
-  workers: process.env.CI ? "75%" : undefined, // increase used workers in CI to speed up workflow times
   reporter: [["html", { open: "never" }]],
   use: {
     trace: process.env.CI ? "retain-on-failure" : "off",

--- a/packages/sit-onyx/playwright.config.ts
+++ b/packages/sit-onyx/playwright.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI, // fail build on CI if we left test.only in the source code
   retries: process.env.CI ? 2 : 0, // retry on CI only
+  workers: process.env.CI ? "75%" : undefined, // increase used workers in CI to speed up workflow times
   reporter: [["html", { open: "never" }]],
   use: {
     trace: process.env.CI ? "retain-on-failure" : "off",

--- a/packages/sit-onyx/playwright.config.ts
+++ b/packages/sit-onyx/playwright.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI, // fail build on CI if we left test.only in the source code
   retries: process.env.CI ? 2 : 0, // retry on CI only
-  workers: process.env.CI ? 1 : undefined, // opt out of parallel tests on CI
   reporter: [["html", { open: "never" }]],
   use: {
     trace: process.env.CI ? "retain-on-failure" : "off",


### PR DESCRIPTION
The [default GitHub runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) have 4 CPU cores so can make use of them to speed up our workflows.

Previously we have limited Playwright to only use 1 core (which does not make sense).

The time for our current code check pipeline is reduced by 1 minute (25%).