### PR TITLE
refactor(OnyxLink): remove noopener from rel when link target is _blank

### DIFF
--- a/apps/docs/src/.vitepress/components/RoadmapCard.vue
+++ b/apps/docs/src/.vitepress/components/RoadmapCard.vue
@@ -18,7 +18,7 @@ const target = computed(() => (props.href?.startsWith("http") ? "_blank" : "_sel
     :is="props.href ? 'a' : 'div'"
     :href="props.href"
     :target="target"
-    :rel="target === '_blank' ? 'noopener noreferrer' : undefined"
+    :rel="target === '_blank' ? 'noreferrer' : undefined"
     class="card"
     :class="{ 'card--clickable': props.href }"
   >

--- a/packages/sit-onyx/src/components/OnyxLink/OnyxLink.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxLink/OnyxLink.stories.ts
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/vue3";
 import OnyxLink from "./OnyxLink.vue";
 
 /**
- * Links are a navigational elements that direct users to other pages, whether they are internal or external.
+ * Links are navigational elements that direct users to other pages, whether they are internal or external.
  */
 const meta: Meta<typeof OnyxLink> = {
   title: "components/OnyxLink",

--- a/packages/sit-onyx/src/components/OnyxLink/OnyxLink.vue
+++ b/packages/sit-onyx/src/components/OnyxLink/OnyxLink.vue
@@ -35,7 +35,7 @@ const shouldShowExternalIcon = computed(() => {
     class="onyx-link"
     :href="props.href"
     :target="props.target"
-    :rel="props.target === '_blank' ? 'noopener noreferrer' : undefined"
+    :rel="props.target === '_blank' ? 'noreferrer' : undefined"
     @click="emit('click')"
   >
     <slot></slot>

--- a/packages/sit-onyx/src/components/OnyxLink/types.ts
+++ b/packages/sit-onyx/src/components/OnyxLink/types.ts
@@ -5,7 +5,7 @@ export type OnyxLinkProps = {
   href: string;
   /**
    * Where to display the linked URL (same tab, new tab etc.).
-   * For `_blank`, the `rel="noopener noreferrer"` will be set automatically.
+   * For `_blank`, the `rel="noreferrer"` will be set automatically.
    */
   target?: LinkTarget;
   /**


### PR DESCRIPTION
<!-- Is your PR related to an issue? Then please link it via the "relates to #" below. Else, remove it. -->

relates to https://github.com/SchwarzIT/onyx/issues/237#issuecomment-1978329032

Remove the noopener rel attribute when the link target is _blank since this is automatically done when noreferrer is set