### PR TITLE
Feat/i18n ko

### DIFF
--- a/.changeset/fresh-socks-type.md
+++ b/.changeset/fresh-socks-type.md
@@ -1,0 +1,6 @@
+---
+"sit-onyx": minor
+"docs": minor
+---
+
+feat(i18n): support Korean Language for i18n

--- a/apps/docs/src/development/i18n.md
+++ b/apps/docs/src/development/i18n.md
@@ -47,7 +47,7 @@ import deDE from "./i18n/locales/de-DE.json";
 const i18n = createI18n({
   legacy: false,
   locale: "en-US",
-  messages: { "en-US": enUS, "de-DE": deDE },
+  messages: { "en-US": enUS, "de-DE": deDE, "ko-KR": koKR },
 });
 
 const onyx = createOnyx({

--- a/packages/sit-onyx/src/i18n/locales/ko-KR.json
+++ b/packages/sit-onyx/src/i18n/locales/ko-KR.json
@@ -1,0 +1,21 @@
+{
+  "optional": "(optional)",
+  "validations": {
+    "tooShort": "{minLength}자 이상으로 입력하세요. (현재 1글자 입력 중) | {minLength}자 이상으로 입력하세요. (현재 {n}글자 입력 중)",
+    "tooLong": "{maxLength}자 이하로 입력하세요. (현재 1글자 입력 중) | {maxLength}자 이하로 입력하세요. (현재 {n}글자 입력 중)",
+    "rangeUnderflow": "입력값이 {min}보다 크거나 동일해야 합니다",
+    "rangeOverflow": "입력값이 {max}보다 작거나 동일해야 합니다",
+    "patternMismatch": "올바른 형식을 입력해주세요.",
+    "valueMissing": "입력란에 내용을 입력해주세요.",
+    "stepMismatch": "{step}의 배수에 해당하는 값을 입력해주세요.",
+    "badInput": "\"{value}\"는 올바른 타입이 아닙니다.",
+    "typeMismatch": {
+      "generic": "\"{value}\"는 올바른 타입이 아닙니다.",
+      "email": "\"{value}\"는 올바른 이메일 형식이어야 합니다.",
+      "number": "\"{value}\"는 반드시 숫자이어야 합니다.",
+      "tel": "\"{value}\"는 올바른 전화번호 형식이어야 합니다.",
+      "url": "\"{value}\"는 올바른 URL 형식이어야 합니다."
+    }
+  },
+  "selectAll": "모두 선택"
+}


### PR DESCRIPTION
<!-- Is your PR related to an issue? Then please link it via the "relates to #" below. Else, remove it. -->

relates to #75 

## Description
What things are added:
* a Korean language json for `i18n`
* the i18n usage doc for `ko-KR`

## Checklist

- [ ] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [ ] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
