### PR TITLE
fix(OnyxIconButton): remove size prop

### DIFF
--- a/packages/sit-onyx/src/components/OnyxIconButton/OnyxIconButton.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxIconButton/OnyxIconButton.stories.ts
@@ -1,5 +1,5 @@
 import { createIconSourceCodeTransformer, defineIconSelectArgType } from "@/utils/storybook";
-import messageDots from "@sit-onyx/icons/message-dots.svg?raw";
+import trash from "@sit-onyx/icons/trash.svg?raw";
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
 import OnyxIconButton from "./OnyxIconButton.vue";
@@ -36,7 +36,7 @@ type Story = StoryObj<typeof OnyxIconButton>;
 export const Primary = {
   args: {
     label: "Button",
-    icon: messageDots,
+    icon: trash,
   },
 } satisfies Story;
 
@@ -47,7 +47,7 @@ export const Secondary = {
   args: {
     label: "Button",
     variation: "secondary",
-    icon: messageDots,
+    icon: trash,
   },
 } satisfies Story;
 
@@ -58,7 +58,7 @@ export const Danger = {
   args: {
     label: "Button",
     variation: "danger",
-    icon: messageDots,
+    icon: trash,
   },
 } satisfies Story;
 
@@ -84,6 +84,6 @@ export const Loading = {
   args: {
     label: "Button",
     loading: true,
-    icon: messageDots,
+    icon: trash,
   },
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxIconButton/OnyxIconButton.vue
+++ b/packages/sit-onyx/src/components/OnyxIconButton/OnyxIconButton.vue
@@ -7,7 +7,6 @@ const props = withDefaults(defineProps<OnyxIconButtonProps>(), {
   disabled: false,
   type: "button",
   variation: "primary",
-  size: "24px",
 });
 
 defineSlots<{
@@ -33,7 +32,7 @@ const emit = defineEmits<{
     @click="emit('click')"
   >
     <OnyxLoadingIndicator v-if="props.loading" type="circle" />
-    <OnyxIcon v-else-if="props.icon" :icon="props.icon" :size="props.size" />
+    <OnyxIcon v-else-if="props.icon" :icon="props.icon" />
     <slot v-else></slot>
   </button>
 </template>

--- a/packages/sit-onyx/src/components/OnyxIconButton/types.ts
+++ b/packages/sit-onyx/src/components/OnyxIconButton/types.ts
@@ -1,5 +1,4 @@
 import type { ButtonType, ButtonVariation } from "../OnyxButton/types";
-import type { IconSize } from "../OnyxIcon/types";
 
 export type OnyxIconButtonProps = {
   /**
@@ -27,9 +26,4 @@ export type OnyxIconButtonProps = {
    * The icon which will be displayed. The custom content in the `default` won't have an effect if the `icon` property is set.
    */
   icon?: string;
-  /**
-   * Icon size. Pixel values will be translated to the according `rem` value by the base of `16px`=`1rem`.
-   * @default 24px
-   */
-  size?: IconSize;
 };


### PR DESCRIPTION
Relates to #386 

Based on UX review:
- Change Story default icon to `trash`
- Restrict icon size to 24px
