### PR TITLE
chore: add missing density docs page to development chapter

### DIFF
--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -124,6 +124,7 @@ export default defineConfig({
             { text: "Getting Started", link: "/" },
             { text: "i18n", link: "/i18n" },
             { text: "Grid", link: "/grid" },
+            { text: "Density", link: "/density" },
             { text: "Typography", link: "/typography" },
             { text: "Changelog", link: "/packages/changelogs/sit-onyx" },
           ],


### PR DESCRIPTION
- add density docs page to development chapter

Relates to #246 
