### PR TITLE
docs: remove required option for truncated example

### DIFF
--- a/packages/sit-onyx/src/components/OnyxRadioButtonGroup/OnyxRadioButtonGroup.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxRadioButtonGroup/OnyxRadioButtonGroup.stories.ts
@@ -71,7 +71,7 @@ export const WithTruncation = {
       { label: "Very long label that will be truncated", id: "id-1" },
       {
         label: "Very long label that will be truncated with multiline",
-        id: "id-3",
+        id: "id-2",
         truncation: "multiline",
       },
     ],

--- a/packages/sit-onyx/src/components/OnyxRadioButtonGroup/OnyxRadioButtonGroup.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxRadioButtonGroup/OnyxRadioButtonGroup.stories.ts
@@ -69,7 +69,6 @@ export const WithTruncation = {
     ...Default.args,
     options: [
       { label: "Very long label that will be truncated", id: "id-1" },
-      { label: "Very long required label that will be truncated", id: "id-2" },
       {
         label: "Very long label that will be truncated with multiline",
         id: "id-3",


### PR DESCRIPTION
Relates to #364 

A single radio option inside a radio group can not be required.