### PR TITLE
fix: add borders in alpha-test-app

### DIFF
--- a/apps/alpha-test-app/src/style.css
+++ b/apps/alpha-test-app/src/style.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}

--- a/apps/alpha-test-app/src/views/HomeView.vue
+++ b/apps/alpha-test-app/src/views/HomeView.vue
@@ -133,9 +133,12 @@ const radioState = ref<SelectionOption | undefined>();
   display: flex;
   align-items: center;
   padding-left: var(--onyx-spacing-xs);
+  border-bottom: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
 }
 .sidebar {
   padding: var(--onyx-spacing-md);
+  border-right: var(--onyx-1px-in-rem) solid var(--onyx-color-base-neutral-300);
+  height: calc(100% - var(--onyx-spacing-xl));
 }
 .page {
   padding: var(--onyx-spacing-xl);

--- a/apps/alpha-test-app/src/views/LayoutDemoView.vue
+++ b/apps/alpha-test-app/src/views/LayoutDemoView.vue
@@ -122,9 +122,3 @@ const footerAsideSidebar = computed<boolean>(
     </template>
   </OnyxAppLayout>
 </template>
-
-<style lang="scss">
-body {
-  margin: 0;
-}
-</style>


### PR DESCRIPTION
Relates to #505 

Adds borders to the sidebar and nav bar placeholders of the alpha-test-app.
