### PR TITLE
docs: add missing changelog for chartjs-plugin

### DIFF
--- a/apps/docs/src/development/packages/changelogs/[name].md
+++ b/apps/docs/src/development/packages/changelogs/[name].md
@@ -41,6 +41,12 @@ const { params } = useData();
 
 </div>
 
+<div v-else-if="params.name === 'chartjs-plugin'">
+
+<!--@include: @/../../../packages/chartjs-plugin/CHANGELOG.md-->
+
+</div>
+
 <div v-else>
   <h1>Changelogs</h1>
   <p>No changelog found for package "{{ params.name }}".</p>


### PR DESCRIPTION
Add missing changelog for chartjs-plugin in our VitePress docs.