### PR TITLE
fix(OnyxSwitch): add missing semantic switch role

### DIFF
--- a/packages/sit-onyx/src/components/OnyxSwitch/OnyxSwitch.vue
+++ b/packages/sit-onyx/src/components/OnyxSwitch/OnyxSwitch.vue
@@ -73,11 +73,15 @@ watch(
     :class="[requiredTypeClass]"
     :title="props.hideLabel ? props.label : undefined"
   >
+    <!-- Linter incorrectly finds an error. For a native `input` the `aria-checked` is not necessary. There is an open issue about it: https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/issues/932  -->
+    <!-- eslint-disable vuejs-accessibility/role-has-required-aria-props -->
+    <!-- TODO: disable can be merged when https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/pull/1071 was released -->
     <input
       ref="inputElement"
       v-model="isChecked"
-      :class="{ 'onyx-switch__input': true, 'onyx-switch__loading': props.loading }"
       type="checkbox"
+      role="switch"
+      :class="{ 'onyx-switch__input': true, 'onyx-switch__loading': props.loading }"
       :aria-label="props.hideLabel ? props.label : undefined"
       :disabled="props.disabled || props.loading"
       :required="props.required"


### PR DESCRIPTION
Relates to #754 

Add optional, but semantically helpful `role="switch"` to the OnyxSwitch.
The “switch” role can be used directly on a native `<input type="checkbox" />` as shown in the example on https://www.w3.org/WAI/ARIA/apg/patterns/switch/examples/switch-checkbox/.
