### PR TITLE
fix(playground): optimize mobile header

### DIFF
--- a/apps/playground/src/components/TheHeader.vue
+++ b/apps/playground/src/components/TheHeader.vue
@@ -32,17 +32,17 @@ const copyLink = async () => {
     <div class="header__actions">
       <VersionSelect
         v-model="onyxVersion"
-        class="version"
+        class="header__version"
         pkg="sit-onyx"
         label="onyx version"
         include-pre-releases
       />
 
-      <VersionSelect v-model="vueVersion" class="version" pkg="vue" label="Vue version" />
+      <VersionSelect v-model="vueVersion" class="header__version" pkg="vue" label="Vue version" />
 
       <VersionSelect
         v-model="typescriptVersion"
-        class="version"
+        class="header__version"
         pkg="typescript"
         label="TypeScript version"
       />
@@ -102,7 +102,7 @@ const copyLink = async () => {
     width: 100%;
   }
 
-  .version {
+  &__version {
     width: 10rem;
   }
 
@@ -114,7 +114,7 @@ const copyLink = async () => {
       justify-content: flex-start;
     }
 
-    .version {
+    .header__version {
       width: 8rem;
     }
   }

--- a/apps/playground/src/components/TheHeader.vue
+++ b/apps/playground/src/components/TheHeader.vue
@@ -32,14 +32,20 @@ const copyLink = async () => {
     <div class="header__actions">
       <VersionSelect
         v-model="onyxVersion"
+        class="version"
         pkg="sit-onyx"
         label="onyx version"
         include-pre-releases
       />
 
-      <VersionSelect v-model="vueVersion" pkg="vue" label="Vue version" />
+      <VersionSelect v-model="vueVersion" class="version" pkg="vue" label="Vue version" />
 
-      <VersionSelect v-model="typescriptVersion" pkg="typescript" label="TypeScript version" />
+      <VersionSelect
+        v-model="typescriptVersion"
+        class="version"
+        pkg="typescript"
+        label="TypeScript version"
+      />
 
       <HeaderIconButton
         label="Toggle dark mode"
@@ -63,6 +69,8 @@ const copyLink = async () => {
 </template>
 
 <style lang="scss" scoped>
+@use "sit-onyx/breakpoints.scss" as onyx;
+
 .header {
   box-sizing: border-box;
   padding: var(--onyx-spacing-2xs) var(--onyx-spacing-md);
@@ -72,6 +80,7 @@ const copyLink = async () => {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--onyx-spacing-sm);
 
   &__brand {
     display: flex;
@@ -89,8 +98,25 @@ const copyLink = async () => {
     flex-wrap: wrap;
     align-items: flex-end;
     justify-content: flex-end;
-    gap: var(--onyx-spacing-md);
+    gap: var(--onyx-spacing-sm) var(--onyx-spacing-md);
     width: 100%;
+  }
+
+  .version {
+    width: 10rem;
+  }
+
+  @include onyx.breakpoint(max, md) {
+    flex-direction: column;
+    align-items: flex-start;
+
+    .header__actions {
+      justify-content: flex-start;
+    }
+
+    .version {
+      width: 8rem;
+    }
   }
 }
 </style>

--- a/apps/playground/src/components/VersionSelect.vue
+++ b/apps/playground/src/components/VersionSelect.vue
@@ -92,10 +92,6 @@ onBeforeUnmount(() => {
 .version {
   position: relative;
 
-  :deep(.onyx-select__input) {
-    width: 8rem;
-  }
-
   .onyx-listbox {
     position: absolute;
     right: 0;


### PR DESCRIPTION
Relates to #704

Make playground header more responsive.

Old:
![image](https://github.com/SchwarzIT/onyx/assets/67898185/3216ec76-caaa-4926-9fde-ba2820a40452)


New:
![image](https://github.com/SchwarzIT/onyx/assets/67898185/8cd555b9-1dca-44da-8535-dd43085c7690)
