### PR TITLE
refactor(OnyxSelect): use line-height variable + remove closed TODO

### DIFF
--- a/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
+++ b/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
@@ -195,7 +195,7 @@ const { densityClass } = useDensity(props);
     box-sizing: border-box;
 
     padding: var(--onyx-select-padding-vertical) var(--onyx-spacing-sm);
-    height: calc(1lh + 2 * var(--onyx-select-padding-vertical));
+    height: calc($line-height + 2 * var(--onyx-select-padding-vertical));
   }
 
   &__input {
@@ -288,7 +288,6 @@ const { densityClass } = useDensity(props);
     }
     &__input {
       width: 17rem;
-      // TODO: apply height based on density
       height: calc($line-height + 2 * var(--onyx-select-padding-vertical));
     }
   }


### PR DESCRIPTION
Relates to #762 

Refactors the usage of lh to $line-height and removes a closed TODO for the skeleton density.
