### PR TITLE
chore: fix screenshot workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,11 +24,11 @@ jobs:
         run: echo ${{ inputs.update-snapshots }}
 
       - name: If false
-        if: ${{ inputs.update-snapshots == 'false' }}
+        if: ${{ inputs.update-snapshots == false }}
         run: echo ${{ inputs.update-snapshots }} && exit 1
 
       - name: If true
-        if: ${{ inputs.update-snapshots == 'true' }}
+        if: ${{ inputs.update-snapshots == true }}
         run: echo ${{ inputs.update-snapshots }} && exit 1
 
       - uses: actions/checkout@v4
@@ -50,19 +50,19 @@ jobs:
         run: pnpm exec playwright install-deps
 
       - name: 🔎 Run Playwright tests
-        run: pnpm run test:components:all --shard=${{ matrix.shard }}/${{ strategy.job-total }} ${{ inputs.update-snapshots == 'true' && '--update-snapshots' || '' }}
+        run: pnpm run test:components:all --shard=${{ matrix.shard }}/${{ strategy.job-total }} ${{ inputs.update-snapshots == true && '--update-snapshots' || '' }}
 
       # we only want to include actual changed screenshots in the artifact to prevent that old/unchanged screenshots
       # override changed screenshots from other shards when creating the pull request
       - name: Copy changed files
-        if: ${{ inputs.update-snapshots == 'true' }}
+        if: ${{ inputs.update-snapshots == true }}
         run: |
           mkdir ./changed-screenshots
           rsync -R $(git ls-files --others --modified --exclude-standard) ./changed-screenshots/ || echo "no changed files found"
 
       - name: Upload screenshots artifact
         uses: actions/upload-artifact@v4
-        if: ${{ inputs.update-snapshots == 'true' }}
+        if: ${{ inputs.update-snapshots == true }}
         with:
           name: screenshots-${{ matrix.shard }}
           path: changed-screenshots

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm exec playwright install-deps
 
       - name: 🔎 Run Playwright tests
-        run: pnpm run test:components:all --update-snapshots --shard=${{ matrix.shard }}/${{ strategy.job-total }} ${{ inputs.update-snapshots == 'true' && '--update-snapshots' || '' }}
+        run: pnpm run test:components:all --shard=${{ matrix.shard }}/${{ strategy.job-total }} ${{ inputs.update-snapshots == 'true' && '--update-snapshots' || '' }}
 
       # we only want to include actual changed screenshots in the artifact to prevent that old/unchanged screenshots
       # override changed screenshots from other shards when creating the pull request

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Debug
-        run: echo ${{ inputs.update-snapshots }} && exit 1
+        run: echo ${{ inputs.update-snapshots }}
 
       - name: If false
         if: ${{ inputs.update-snapshots == 'false' }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,3 +55,19 @@ jobs:
         with:
           name: screenshots-${{ matrix.shard }}
           path: changed-screenshots
+
+  # this final step is needed to we can set make the Playwright tests a required check in pull requests
+  # because we don't want to add each parallel matrix job individually
+  playwright-result:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Collect Playwright result
+    needs: playwright
+    steps:
+      - run: |
+          result="${{ needs.build.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,6 +23,14 @@ jobs:
       - name: Debug
         run: echo ${{ inputs.update-snapshots }} && exit 1
 
+      - name: If false
+        if: ${{ inputs.update-snapshots == 'false' }}
+        run: echo ${{ inputs.update-snapshots }} && exit 1
+
+      - name: If true
+        if: ${{ inputs.update-snapshots == 'true' }}
+        run: echo ${{ inputs.update-snapshots }} && exit 1
+
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,17 +20,6 @@ jobs:
     name: Playwright shard
     runs-on: ubuntu-latest
     steps:
-      - name: Debug
-        run: echo ${{ inputs.update-snapshots }}
-
-      - name: If false
-        if: ${{ inputs.update-snapshots == false }}
-        run: echo ${{ inputs.update-snapshots }} && exit 1
-
-      - name: If true
-        if: ${{ inputs.update-snapshots == true }}
-        run: echo ${{ inputs.update-snapshots }} && exit 1
-
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,6 +58,7 @@ jobs:
 
   # this final step is needed to we can set make the Playwright tests a required check in pull requests
   # because we don't want to add each parallel matrix job individually
+  # see: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
   playwright-result:
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,6 +20,9 @@ jobs:
     name: Playwright shard
     runs-on: ubuntu-latest
     steps:
+      - name: Debug
+        run: echo ${{ inputs.update-snapshots }} && exit 1
+
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -66,7 +66,7 @@ jobs:
     needs: playwright
     steps:
       - run: |
-          result="${{ needs.build.result }}"
+          result="${{ needs.playwright.result }}"
           if [[ $result == "success" || $result == "skipped" ]]; then
             exit 0
           else


### PR DESCRIPTION
Fix workflow condition when checking whether to update snapshots.

The final step is needed to we can set make the Playwright tests a required check in pull requests because we don't want to add each parallel matrix job individually.