### PR TITLE
chore(OnyxListbox): make `multiple`, `modelValue` and `checkAll` types directly dependent on each other

### DIFF
--- a/packages/sit-onyx/src/components/OnyxListbox/OnyxListbox.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxListbox/OnyxListbox.ct.tsx
@@ -95,15 +95,24 @@ test.describe("Densities screenshot tests", () => {
       // the following disabled rule should be removed.
       "nested-interactive",
     ],
-    component: (column, row) => (
-      <OnyxListbox
-        label={`${column} listbox`}
-        options={MOCK_VARIED_OPTIONS}
-        modelValue={row === "partial-selection" ? [2] : undefined}
-        multiple={row === "partial-selection"}
-        density={column}
-      />
-    ),
+    component: (column, row) =>
+      row === "partial-selection" ? (
+        <OnyxListbox
+          label={`${column} listbox`}
+          options={MOCK_VARIED_OPTIONS}
+          modelValue={[2]}
+          multiple={true}
+          density={column}
+        />
+      ) : (
+        <OnyxListbox
+          label={`${column} listbox`}
+          options={MOCK_VARIED_OPTIONS}
+          modelValue={undefined}
+          multiple={false}
+          density={column}
+        />
+      ),
   });
 });
 
@@ -118,7 +127,7 @@ test("should interact with multiselect", async ({ mount }) => {
   };
 
   // ARRANGE
-  const component = await mount(OnyxListbox<number, true>, {
+  const component = await mount(OnyxListbox, {
     props: {
       options: MOCK_VARIED_OPTIONS,
       label: "Test listbox",

--- a/packages/sit-onyx/src/components/OnyxListbox/OnyxListbox.vue
+++ b/packages/sit-onyx/src/components/OnyxListbox/OnyxListbox.vue
@@ -1,8 +1,4 @@
-<script
-  lang="ts"
-  setup
-  generic="TValue extends SelectOptionValue = SelectOptionValue, TMultiple extends boolean = false"
->
+<script lang="ts" setup generic="TValue extends SelectOptionValue = SelectOptionValue">
 import { useDensity } from "../../composables/density";
 import { createId, createListbox } from "@sit-onyx/headless";
 import { computed, ref, watch, watchEffect } from "vue";
@@ -16,7 +12,7 @@ import OnyxLoadingIndicator from "../OnyxLoadingIndicator/OnyxLoadingIndicator.v
 import type { OnyxListboxProps } from "./types";
 import { groupByKey } from "../../utils/objects";
 
-const props = withDefaults(defineProps<OnyxListboxProps<TValue, TMultiple>>(), {
+const props = withDefaults(defineProps<OnyxListboxProps<TValue>>(), {
   loading: false,
 });
 
@@ -76,7 +72,9 @@ const CHECK_ALL_ID = createId("ONYX_CHECK_ALL") as TValue;
  * Includes "select all" up front if it is used.
  */
 const allKeyboardOptionIds = computed(() => {
-  return (props.withCheckAll ? [CHECK_ALL_ID] : []).concat(enabledOptionValues.value);
+  return (props.multiple && props.withCheckAll ? [CHECK_ALL_ID] : []).concat(
+    enabledOptionValues.value,
+  );
 });
 
 const {
@@ -152,6 +150,9 @@ const checkAll = computed(() => {
 });
 
 const checkAllLabel = computed<string>(() => {
+  if (!props.multiple) {
+    return "";
+  }
   const defaultText = t.value("selections.selectAll");
   if (typeof props.withCheckAll === "boolean") return defaultText;
   return props.withCheckAll?.label ?? defaultText;

--- a/packages/sit-onyx/src/components/OnyxListbox/types.ts
+++ b/packages/sit-onyx/src/components/OnyxListbox/types.ts
@@ -2,15 +2,43 @@ import type { DensityProp } from "../../composables/density";
 import type { SelectOption, SelectOptionValue } from "../../types";
 import type { OnyxListboxOptionProps } from "../OnyxListboxOption/types";
 
-export type ListboxModelValue<
-  TValue extends SelectOptionValue = SelectOptionValue,
-  TMultiple extends boolean = false,
-> = TMultiple extends true ? TValue[] : TValue;
+type OnyxListboxSingleProps<TValue extends SelectOptionValue> = {
+  /**
+   * Allows the selection of multiple listbox options
+   */
+  multiple?: false;
+  /**
+   * Current value.
+   */
+  modelValue?: TValue;
+};
 
-export type OnyxListboxProps<
-  TValue extends SelectOptionValue = SelectOptionValue,
-  TMultiple extends boolean = false,
-> = DensityProp & {
+type OnyxListboxMultipleProps<TValue extends SelectOptionValue> = {
+  /**
+   * Allows the selection of multiple listbox options
+   */
+  multiple: true;
+  /**
+   * Current value / selected option(s).
+   */
+  modelValue?: TValue[];
+  /**
+   * If true, a checkbox will be displayed to check/uncheck all options.
+   * Disabled and skeleton checkboxes will be excluded from the check/uncheck behavior.
+   * Only available if "multiple" is true.
+   */
+  withCheckAll?:
+    | boolean
+    | {
+        /**
+         * Label for the `select all` checkbox.
+         * If unset, a default label will be shown depending on the current locale/language.
+         */
+        label?: string;
+      };
+};
+
+export type OnyxListboxProps<TValue extends SelectOptionValue = SelectOptionValue> = DensityProp & {
   /**
    * Aria label. Must be set for accessibility reasons.
    */
@@ -24,30 +52,6 @@ export type OnyxListboxProps<
    */
   message?: string;
   /**
-   * Current value / selected option(s).
-   */
-  modelValue?: ListboxModelValue<TValue, TMultiple>;
-  /**
-   * Allows the selection of multiple listbox options
-   */
-  multiple?: TMultiple;
-  /**
-   * If true, a checkbox will be displayed to check/uncheck all options.
-   * Disabled and skeleton checkboxes will be excluded from the check/uncheck behavior.
-   * Only available if "multiple" is true.
-   */
-  withCheckAll?: TMultiple extends true
-    ?
-        | boolean
-        | {
-            /**
-             * Label for the `select all` checkbox.
-             * If unset, a default label will be shown depending on the current locale/language.
-             */
-            label?: string;
-          }
-    : undefined;
-  /**
    * Whether to show a loading indicator.
    */
   loading?: boolean;
@@ -56,7 +60,7 @@ export type OnyxListboxProps<
    * If you want to use a button instead, use the `optionsEnd` slot.
    */
   lazyLoading?: ListboxLazyLoading;
-};
+} & (OnyxListboxMultipleProps<TValue> | OnyxListboxSingleProps<TValue>);
 
 export type ListboxOption<TValue extends SelectOptionValue = SelectOptionValue> = Pick<
   SelectOption<TValue>,


### PR DESCRIPTION
Changed the prop type of `OnyxListbox` so that `modelValue`, `multiple` and `checkAll` directly depending on each other.
E.g., checking for `multiple === false` will also infer that `modelValue` is not an array and `checkAll` doesn't exist.
