### PR TITLE
fix: preserve disabled states when toggling "check all"

### DIFF
--- a/.changeset/witty-houses-promise.md
+++ b/.changeset/witty-houses-promise.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxCheckboxGroup,OnyxListbox): preserve disabled states when toggling "check all"

--- a/packages/sit-onyx/src/components/OnyxCheckboxGroup/OnyxCheckboxGroup.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxCheckboxGroup/OnyxCheckboxGroup.stories.ts
@@ -25,6 +25,7 @@ const DEMO_OPTIONS = [
   { label: "Required", value: 3, required: true },
   { label: "Disabled", value: 4, disabled: true },
   { label: "Loading", value: 5, loading: true },
+  { label: "Disabled checked", value: 6, disabled: true },
 ] satisfies CheckboxGroupOption[];
 
 /**
@@ -33,7 +34,7 @@ const DEMO_OPTIONS = [
 export const Default = {
   args: {
     headline: "Checkbox group headline",
-    modelValue: [2],
+    modelValue: [2, 6],
     options: DEMO_OPTIONS,
   },
 } satisfies Story;

--- a/packages/sit-onyx/src/composables/checkAll.ts
+++ b/packages/sit-onyx/src/composables/checkAll.ts
@@ -36,9 +36,16 @@ export const useCheckAll = <TValue extends SelectOptionValue = SelectOptionValue
      * Provides an update for the checkbox list with
      * - all option values if "select all" was checked
      * - an empty list if "select all" was unchecked
+     * Does not touch the state of disabled checkboxes
      */
     handleChange: (isChecked: boolean) => {
-      const newValue = isChecked ? enabledOptionValues.value : [];
+      // options that are currently in modelValue but not "enabled" shall not be touched
+      const checkedDisabledOptions = modelValue.value.filter(
+        (checkedValue) => !enabledOptionValues.value.includes(checkedValue),
+      );
+      const newValue = isChecked
+        ? checkedDisabledOptions.concat(enabledOptionValues.value)
+        : checkedDisabledOptions;
       onChangeCallback(newValue);
     },
   };


### PR DESCRIPTION
Closes to #1027 

Preserves the checked/unchecked state of disabled checkboxes in OnyxCheckboxGroup and OnyxListbox when using the "Check all" feature.

Reviewer info: test with
- http://localhost:6006/?path=/story/components-checkboxgroup--with-check-all
- http://localhost:6006/?path=/story/support-listbox--multiselect

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
