### PR TITLE
fix(OnyxNavItem): Hide nested children when navItem is closed

### DIFF
--- a/.changeset/loud-plants-deliver.md
+++ b/.changeset/loud-plants-deliver.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+Hide nested children when nav item is closed

--- a/packages/sit-onyx/src/components/OnyxNavItem/OnyxNavItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavItem/OnyxNavItem.vue
@@ -111,6 +111,7 @@ const shouldShowExternalIcon = computed(() => {
 
       .onyx-nav-item__flyout {
         opacity: 1;
+        visibility: visible;
       }
     }
 
@@ -137,7 +138,9 @@ const shouldShowExternalIcon = computed(() => {
       margin-top: var(--onyx-spacing-sm);
       position: absolute;
       opacity: 0;
-      transition: opacity var(--onyx-duration-sm);
+      visibility: hidden;
+      transition-duration: var(--onyx-duration-sm);
+      transition-property: opacity, visibility;
 
       &:hover,
       &:focus-within {


### PR DESCRIPTION
<!-- Is your PR related to an issue? Then please link it via the "Relates to #" below. Else, remove it. -->

Relates to #

The OnyxNavItem only used opacity 0 when not hovered, so the nested children were still visible and clickable.

## Checklist

- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
