### PR TITLE
refactor: remove redundant scheme setting

### DIFF
--- a/.changeset/big-insects-tap.md
+++ b/.changeset/big-insects-tap.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/storybook-utils": patch
+---
+
+refactor: remove redundant scheme setting

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -62,11 +62,9 @@ export const createPreview = <T extends Preview = Preview>(overrides?: T) => {
           if (isDark) {
             document.body.classList.remove("light");
             document.body.classList.add("dark");
-            document.documentElement.style.colorScheme = "dark";
           } else {
             document.body.classList.remove("dark");
             document.body.classList.add("light");
-            document.documentElement.style.colorScheme = "light";
           }
 
           return isDark ? themes.dark : themes.light;


### PR DESCRIPTION
Closes #618

Now that the onyx theme takes care of setting the color scheme, we can remove the redundant scheme setting in the storybook utils

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
