### PR TITLE
feat: support quantitative colors 1000-1200 for `getDatasetColors()`

### DIFF
--- a/.changeset/afraid-avocados-hear.md
+++ b/.changeset/afraid-avocados-hear.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/chartjs-plugin": minor
+---
+
+feat: support quantitative colors 1000-1200 for `getDatasetColors()`

--- a/packages/chartjs-plugin/src/utils.ts
+++ b/packages/chartjs-plugin/src/utils.ts
@@ -19,7 +19,9 @@ import type { OnyxColor } from "sit-onyx/types";
  * ```
  */
 export const getDatasetColors = (
-  color: OnyxColor | `quantitatives-${100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900}`,
+  color:
+    | OnyxColor
+    | `quantitatives-${100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000 | 1100 | 1200}`,
 ) => {
   const cssVariable = `--onyx-color-base-${color.startsWith("quantitatives-") ? color : `${color}-500`}`;
   // we use arrow functions here so the value is updated / re-evaluated when


### PR DESCRIPTION
onyx has quantitative colors 100-1200 but currently we only supported 100-900 with no reason so I added 1000, 1100 and 1200 as well

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
