### PR TITLE
chore: cancel previous GitHub workflows if PR is pushed

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 # cancel previous runs if new changes are pushed to the branch/PR
-# see: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+# see: https://stackoverflow.com/a/72408109
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# cancel previous runs if new changes are pushed to the branch/PR
+# see: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Check code quality

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,7 @@ on:
 
 # cancel previous runs if new changes are pushed to the branch/PR
 # see: https://stackoverflow.com/a/72408109
+# test
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,7 +5,6 @@ on:
 
 # cancel previous runs if new changes are pushed to the branch/PR
 # see: https://stackoverflow.com/a/72408109
-# test
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Currently when quickly pushing multiple commits to a PR, a new GitHub workflow run will be triggered so they all run in parallel and maybe need to wait for each other.

With this change, the previous run will be cancelled if a new commit is pushed

See the below screenshot where the previous run is canceled after I pushed a new commit:
![image](https://github.com/SchwarzIT/onyx/assets/67898185/447c69a2-7ed3-497a-900d-0a0ef0316b06)
![image](https://github.com/SchwarzIT/onyx/assets/67898185/bc1b358e-0db7-487b-bcbd-753a2949598a)
