### PR TITLE
fix(OnyxNavItem): Fix gap in nav item with external link

### DIFF
--- a/packages/sit-onyx/src/components/OnyxNavItem/OnyxNavItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavItem/OnyxNavItem.vue
@@ -66,6 +66,7 @@ const shouldShowExternalIcon = (args: OnyxNavItemProps) => {
         v-for="option in props.options"
         :key="option.label"
         :active="option.active"
+        class="onyx-nav-item__option"
         @click="emit('click', option.href)"
       >
         {{ option.label }}
@@ -139,6 +140,11 @@ const shouldShowExternalIcon = (args: OnyxNavItemProps) => {
 
     &__icon {
       align-self: flex-start;
+    }
+
+    &:has(&__icon) .onyx-nav-item__trigger,
+    &:has(&__icon) .onyx-nav-item__option {
+      gap: 0;
     }
 
     &__flyout {


### PR DESCRIPTION
<!-- Is your PR related to an issue? Then please link it via the "Relates to #" below. Else, remove it. -->

Relates to #1148 

Removed the gap between label and external link icon for the nav item and nested nav item option.

## Checklist

- [ ] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [ ] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
