### PR TITLE
chore: fix GitHub rate limit in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,9 +44,8 @@ jobs:
       - name: 🛠️ Build packages
         run: pnpm run build:all
         env:
-          # needed for increase rate limit for the GitHub API that is used when building
-          # the VitePress documentation
-          VITEPRESS_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # skip fetching statistics for our docs here so we don't exceed GitHub rate limits which may fail in CI
+          VITEPRESS_SKIP_GITHUB_FETCH: true
 
       - name: 🚨 Run unit tests
         run: pnpm run test:all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
           # needed for increase rate limit for the GitHub API that is used when building
           # the VitePress documentation
           VITEPRESS_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VITE_STORYBOOK_HOST: ${{ vars.VITE_STORYBOOK_HOST }}
 
       - name: Upload Storybook artifact
         uses: actions/upload-artifact@v4

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "pnpm run dev",
-    "dev": "vitepress dev src",
+    "dev": "VITEPRESS_SKIP_GITHUB_FETCH=true vitepress dev src",
     "build": "pnpm run '/type-check|build-only/'",
     "build-only": "vitepress build src",
     "type-check": "vue-tsc --noEmit",

--- a/apps/docs/src/index.data.ts
+++ b/apps/docs/src/index.data.ts
@@ -51,11 +51,13 @@ export default defineLoader({
 
     // we only want to fetch the data from GitHub / npmjs API on build, not when running locally
     // to improve the startup time and prevent rate limits
-    const isDev = process.env.NODE_ENV === "development";
+    const skipGitHubFetch = process.env.VITEPRESS_SKIP_GITHUB_FETCH === "true";
 
-    const downloads = isDev ? 0 : await getNpmDownloadCount(npmPackageNames);
-    const mergedPRCount = isDev ? 0 : await searchGitHub("issues", "type:pr is:merged");
-    const closedIssueCount = isDev ? 0 : await searchGitHub("issues", "type:issue is:closed");
+    const downloads = skipGitHubFetch ? 0 : await getNpmDownloadCount(npmPackageNames);
+    const mergedPRCount = skipGitHubFetch ? 0 : await searchGitHub("issues", "type:pr is:merged");
+    const closedIssueCount = skipGitHubFetch
+      ? 0
+      : await searchGitHub("issues", "type:issue is:closed");
 
     /**
      * Checks whether the given component is implemented (meaning a Storybook file exists).


### PR DESCRIPTION
Sometimes our GitHub action workflows for PRs fail due to a GitHub rate limit.
I changed it to skip the GitHub API during PR pipelines and only fetch it when deploying.
