### PR TITLE
fix(nuxt): disable postcss plugin calc to resolve issue caused by onyx using the calc-constant infinity

### DIFF
--- a/.changeset/lovely-wasps-compete.md
+++ b/.changeset/lovely-wasps-compete.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt": patch
+---
+
+fix build issue in nuxt projects using @sit-onyx/nuxt

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ blob-report/
 storybook-static
 eslint-results.sarif
 .nuxt
+.output
 
 # Development config
 .env*

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -10,6 +10,14 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {},
   setup(_options, nuxt) {
+    /**
+     * The calc plugin of cssnano doesn't work with calc constants (https://developer.mozilla.org/en-US/docs/Web/CSS/calc-constant) used within onyx.
+     * Therefor it needs to be disabled temporarily until they are either no longer used inside onyx or the calc plugin is fixed.
+     * An issue was raised for inside the calc plugin: https://github.com/postcss/postcss-calc/issues/210
+     */
+    nuxt.options.postcss.plugins.cssnano ??= {};
+    nuxt.options.postcss.plugins.cssnano.preset = ["default", { calc: false }];
+
     nuxt.options.css.push("sit-onyx/style.css");
 
     Object.keys(onyx)


### PR DESCRIPTION
Building a nuxt project using the module would just hang up due to an issue within the postcss plugin "calc" used by nanocss which is used by nuxt's default postcss config.
This fix simply disables the plugin for nuxt projects using the module for now. An issue was created for the postcss plugin (see: https://github.com/postcss/postcss-calc/issues/210)

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [y] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
