### PR TITLE
fix(nuxt): fix dev mode

### DIFF
--- a/.changeset/light-lemons-cough.md
+++ b/.changeset/light-lemons-cough.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt": patch
+---
+
+fix dev mode of module caused by postcss issue

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -15,8 +15,7 @@ export default defineNuxtModule<ModuleOptions>({
      * Therefor it needs to be disabled temporarily until they are either no longer used inside onyx or the calc plugin is fixed.
      * An issue was raised for inside the calc plugin: https://github.com/postcss/postcss-calc/issues/210
      */
-    nuxt.options.postcss.plugins.cssnano ??= {};
-    nuxt.options.postcss.plugins.cssnano.preset = ["default", { calc: false }];
+    nuxt.options.postcss.plugins.cssnano = { preset: ["default", { calc: false }] };
 
     nuxt.options.css.push("sit-onyx/style.css");
 


### PR DESCRIPTION
Relates to #1261 

After fixing the build sadly the dev mode got broken by the postcss config. This PR fixes that by explicitly overwriting the cssnano config.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
