### PR TITLE
feat(storybook): add imports for onyx components in source code

### DIFF
--- a/.changeset/early-tools-melt.md
+++ b/.changeset/early-tools-melt.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/storybook-utils": minor
+---
+
+feat: add imports for used onyx components to generated source code

--- a/packages/storybook-utils/src/preview.spec.ts
+++ b/packages/storybook-utils/src/preview.spec.ts
@@ -6,11 +6,12 @@ import { replaceAll, sourceCodeTransformer } from "./preview";
 import * as sourceCodeGenerator from "./source-code-generator";
 
 describe("preview.ts", () => {
-  test("should transform source code and add icon imports", () => {
+  test("should transform source code and add icon/onyx imports", () => {
     // ARRANGE
     const generatorSpy = vi.spyOn(sourceCodeGenerator, "generateSourceCode")
       .mockReturnValue(`<template>
 <OnyxTest icon='${placeholder}' test='${bellRing}' :obj="{foo:'${replaceAll(calendar, '"', "\\'")}'}" />
+<OnyxOtherComponent />
 </template>`);
 
     // ACT
@@ -19,6 +20,7 @@ describe("preview.ts", () => {
     // ASSERT
     expect(generatorSpy).toHaveBeenCalledOnce();
     expect(sourceCode).toBe(`<script lang="ts" setup>
+import { OnyxOtherComponent, OnyxTest } from "sit-onyx";
 import bellRing from "@sit-onyx/icons/bell-ring.svg?raw";
 import calendar from "@sit-onyx/icons/calendar.svg?raw";
 import placeholder from "@sit-onyx/icons/placeholder.svg?raw";
@@ -26,6 +28,7 @@ import placeholder from "@sit-onyx/icons/placeholder.svg?raw";
 
 <template>
 <OnyxTest :icon="placeholder" :test="bellRing" :obj="{foo:calendar}" />
+<OnyxOtherComponent />
 </template>`);
   });
 });

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -170,6 +170,7 @@ export const sourceCodeTransformer = (
     }
   });
 
+  // Set is used here to only include unique components if they are used multiple times
   const usedOnyxComponents = [
     ...new Set(Array.from(code.matchAll(/<Onyx\S+/g)).map((match) => match[0].replace("<", ""))),
   ].sort();

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -170,12 +170,14 @@ export const sourceCodeTransformer = (
     }
   });
 
+  const additionalImports = iconImports.slice();
+
+  // add imports for all used onyx components
   // Set is used here to only include unique components if they are used multiple times
   const usedOnyxComponents = [
     ...new Set(Array.from(code.matchAll(/<Onyx\S+/g)).map((match) => match[0].replace("<", ""))),
   ].sort();
 
-  const additionalImports = iconImports.slice();
   if (usedOnyxComponents.length > 0) {
     additionalImports.unshift(`import { ${usedOnyxComponents.join(", ")} } from "sit-onyx";`);
   }

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -170,15 +170,24 @@ export const sourceCodeTransformer = (
     }
   });
 
-  if (iconImports.length === 0) return code;
+  const usedOnyxComponents = [
+    ...new Set(Array.from(code.matchAll(/<Onyx\S+/g)).map((match) => match[0].replace("<", ""))),
+  ].sort();
+
+  const additionalImports = iconImports.slice();
+  if (usedOnyxComponents.length > 0) {
+    additionalImports.unshift(`import { ${usedOnyxComponents.join(", ")} } from "sit-onyx";`);
+  }
+
+  if (additionalImports.length === 0) return code;
 
   if (code.startsWith("<script")) {
     const index = code.indexOf("\n");
-    return code.slice(0, index) + iconImports.join("\n") + "\n" + code.slice(index);
+    return code.slice(0, index) + additionalImports.join("\n") + "\n" + code.slice(index);
   }
 
   return `<script lang="ts" setup>
-${iconImports.join("\n")}
+${additionalImports.join("\n")}
 </script>
 
 ${code}`;

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -148,7 +148,7 @@ export const sourceCodeTransformer = (
 
   let code = generateSourceCode(ctx);
 
-  const iconImports: string[] = [];
+  const additionalImports: string[] = [];
 
   // add icon imports to the source code for all used onyx icons
   Object.entries(ALL_ICONS).forEach(([iconName, iconContent]) => {
@@ -158,19 +158,17 @@ export const sourceCodeTransformer = (
 
     if (code.includes(iconContent)) {
       code = code.replace(new RegExp(` (\\S+)=['"]${iconContent}['"]`), ` :$1="${importName}"`);
-      iconImports.push(`import ${importName} from "@sit-onyx/icons/${iconName}.svg?raw";`);
+      additionalImports.push(`import ${importName} from "@sit-onyx/icons/${iconName}.svg?raw";`);
     } else if (code.includes(singleQuotedIconContent)) {
       // support icons inside objects
       code = code.replace(singleQuotedIconContent, importName);
-      iconImports.push(`import ${importName} from "@sit-onyx/icons/${iconName}.svg?raw";`);
+      additionalImports.push(`import ${importName} from "@sit-onyx/icons/${iconName}.svg?raw";`);
     } else if (code.includes(escapedIconContent)) {
       // support icons inside objects
       code = code.replace(escapedIconContent, importName);
-      iconImports.push(`import ${importName} from "@sit-onyx/icons/${iconName}.svg?raw";`);
+      additionalImports.push(`import ${importName} from "@sit-onyx/icons/${iconName}.svg?raw";`);
     }
   });
-
-  const additionalImports = iconImports.slice();
 
   // add imports for all used onyx components
   // Set is used here to only include unique components if they are used multiple times


### PR DESCRIPTION
Relates to #414

Automatically add imports for all used onyx components for the generated source code.

## Checklist

- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
