### PR TITLE
docs: update truncation examples

### DIFF
--- a/packages/sit-onyx/src/components/OnyxBadge/OnyxBadge.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxBadge/OnyxBadge.stories.ts
@@ -1,7 +1,7 @@
 import placeholder from "@sit-onyx/icons/placeholder.svg?raw";
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { createTruncationDecorator, defineIconSelectArgType } from "../../utils/storybook";
+import { defineIconSelectArgType } from "../../utils/storybook";
 import OnyxBadge from "./OnyxBadge.vue";
 
 /**
@@ -74,6 +74,6 @@ export const Dot = {
 export const WithTruncation = {
   args: {
     default: "Badge with a very long text that gets truncated",
+    style: "max-width: 16rem",
   },
-  decorators: createTruncationDecorator("16rem"),
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxButton/OnyxButton.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxButton/OnyxButton.stories.ts
@@ -1,7 +1,7 @@
 import checkSmall from "@sit-onyx/icons/check-small.svg?raw";
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { createTruncationDecorator, defineIconSelectArgType } from "../../utils/storybook";
+import { defineIconSelectArgType } from "../../utils/storybook";
 import OnyxButton from "./OnyxButton.vue";
 
 /**
@@ -82,8 +82,8 @@ export const WithIcon = {
 export const WithTruncation = {
   args: {
     label: "Button with a very long text that gets truncated",
+    style: "max-width: 16rem",
   },
-  decorators: createTruncationDecorator("16rem"),
 } satisfies Story;
 
 /**

--- a/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.stories.ts
@@ -1,6 +1,5 @@
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { createTruncationDecorator } from "../../utils/storybook";
 import OnyxCheckbox from "./OnyxCheckbox.vue";
 
 /**
@@ -75,8 +74,8 @@ export const WithTruncation = {
   args: {
     ...Default.args,
     label: "Very long label that will be truncated",
+    style: "max-width: 12rem",
   },
-  decorators: [createTruncationDecorator("12rem")],
 } satisfies Story;
 
 /**

--- a/packages/sit-onyx/src/components/OnyxCheckboxGroup/OnyxCheckboxGroup.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxCheckboxGroup/OnyxCheckboxGroup.stories.ts
@@ -1,6 +1,5 @@
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { createTruncationDecorator } from "../../utils/storybook";
 import OnyxCheckboxGroup from "./OnyxCheckboxGroup.vue";
 import type { CheckboxGroupOption } from "./types";
 
@@ -77,6 +76,7 @@ export const Disabled = {
 export const WithTruncation = {
   args: {
     ...Default.args,
+    style: "max-width: 16rem",
     options: [
       { label: "Very long label that will be truncated", value: 1 },
       { label: "Very long required label that will be truncated", value: 2, required: true },
@@ -93,7 +93,6 @@ export const WithTruncation = {
       },
     ],
   },
-  decorators: [createTruncationDecorator("16rem")],
 } satisfies Story;
 
 /**

--- a/packages/sit-onyx/src/components/OnyxEmpty/OnyxEmpty.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxEmpty/OnyxEmpty.stories.ts
@@ -3,7 +3,6 @@ import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
 import { h } from "vue";
 import { OnyxLink } from "../../index";
-import { createTruncationDecorator } from "../../utils/storybook";
 import OnyxIcon from "../OnyxIcon/OnyxIcon.vue";
 import OnyxEmpty from "./OnyxEmpty.vue";
 
@@ -56,6 +55,6 @@ export const CustomContent = {
 export const Truncation = {
   args: {
     default: "Place a text for empty state here",
+    style: "max-width: 12rem",
   },
-  decorators: [createTruncationDecorator("12rem")],
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxRadioButton/OnyxRadioButton.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxRadioButton/OnyxRadioButton.stories.ts
@@ -1,6 +1,5 @@
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { createTruncationDecorator } from "../../utils/storybook";
 import OnyxRadioButton from "./OnyxRadioButton.vue";
 
 /**
@@ -36,8 +35,8 @@ export const WithTruncation = {
   args: {
     ...Default.args,
     label: "Very long label that will be truncated",
+    style: "max-width: 12rem",
   },
-  decorators: [createTruncationDecorator("12rem")],
 } satisfies Story;
 
 /**

--- a/packages/sit-onyx/src/components/OnyxRadioButtonGroup/OnyxRadioButtonGroup.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxRadioButtonGroup/OnyxRadioButtonGroup.stories.ts
@@ -1,7 +1,6 @@
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
 import type { BaseSelectOption } from "../../types";
-import { createTruncationDecorator } from "../../utils/storybook";
 import OnyxRadioButtonGroup from "./OnyxRadioButtonGroup.vue";
 
 /**
@@ -68,6 +67,7 @@ export const Horizontal = {
 export const WithTruncation = {
   args: {
     ...Default.args,
+    style: "max-width: 16rem",
     options: [
       { label: "Very long label that will be truncated", value: 1 },
       {
@@ -77,7 +77,6 @@ export const WithTruncation = {
       },
     ],
   },
-  decorators: [createTruncationDecorator("16rem")],
 } satisfies Story;
 
 /**

--- a/packages/sit-onyx/src/components/OnyxSelectOption/OnyxSelectOption.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxSelectOption/OnyxSelectOption.stories.ts
@@ -2,7 +2,7 @@ import settings from "@sit-onyx/icons/settings.svg?raw";
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
 import type { AriaAttributes } from "vue";
-import { createTruncationDecorator, defineIconSelectArgType } from "../../utils/storybook";
+import { defineIconSelectArgType } from "../../utils/storybook";
 import OnyxSelectOption from "./OnyxSelectOption.vue";
 
 /**
@@ -13,7 +13,6 @@ const meta: Meta<typeof OnyxSelectOption> = {
   ...defineStorybookActionsAndVModels({
     component: OnyxSelectOption,
     events: [],
-    decorators: [createTruncationDecorator("16rem")],
     argTypes: {
       default: { control: { type: "text" } },
       icon: defineIconSelectArgType(),
@@ -28,6 +27,7 @@ export const Default = {
   args: {
     "aria-label": "Example option",
     default: "Example option",
+    style: "max-width: 16rem",
   },
 } satisfies Story;
 

--- a/packages/sit-onyx/src/components/OnyxSwitch/OnyxSwitch.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxSwitch/OnyxSwitch.stories.ts
@@ -1,6 +1,5 @@
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { createTruncationDecorator } from "../../utils/storybook";
 import OnyxSwitch from "./OnyxSwitch.vue";
 
 /**
@@ -76,8 +75,8 @@ export const WithTruncation = {
   args: {
     ...Default.args,
     label: "Very long label that will be truncated",
+    style: "max-width: 12rem",
   },
-  decorators: [createTruncationDecorator("12rem")],
 } satisfies Story;
 
 /**

--- a/packages/sit-onyx/src/components/OnyxTable/OnyxTable.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxTable/OnyxTable.stories.ts
@@ -1,7 +1,6 @@
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
-import type { Decorator, Meta, StoryObj } from "@storybook/vue3";
+import type { Meta, StoryObj } from "@storybook/vue3";
 import { h } from "vue";
-import { createTruncationDecorator } from "../../utils/storybook";
 import OnyxTable from "./OnyxTable.vue";
 
 /**
@@ -17,18 +16,29 @@ const meta: Meta<typeof OnyxTable> = {
         control: { disable: true },
       },
     },
-    decorators: [createTruncationDecorator("max-content")],
   }),
 };
 
 export default meta;
 type Story = StoryObj<typeof OnyxTable>;
 
+const getTableHeader = () => {
+  return h("thead", [
+    h("tr", [
+      h("th", "Fruit"),
+      h("th", "Price (€/kg)"),
+      h("th", "Inventory (kg)"),
+      h("th", "Inventory (pieces)"),
+      h("th", "Rating"),
+    ]),
+  ]);
+};
+
 const getTableBody = () => {
   return h("tbody", [
-    h("tr", [h("td", "Strawberry"), h("td", "4.50"), h("td", "200")]),
-    h("tr", [h("td", "Apple"), h("td", "1.99"), h("td", "3000")]),
-    h("tr", [h("td", "Banana"), h("td", "3.75"), h("td", "18000")]),
+    h("tr", [h("td", "Strawberry"), h("td", "4.50"), h("td", "200"), h("td", "100"), h("td", "5")]),
+    h("tr", [h("td", "Apple"), h("td", "1.99"), h("td", "3000"), h("td", "200"), h("td", "3")]),
+    h("tr", [h("td", "Banana"), h("td", "3.75"), h("td", "18000"), h("td", "300"), h("td", "4")]),
   ]);
 };
 
@@ -37,10 +47,7 @@ const getTableBody = () => {
  */
 export const Default = {
   args: {
-    default: () => [
-      h("thead", [h("tr", [h("th", "Fruit"), h("th", "Price (€/kg)"), h("th", "Inventory (kg)")])]),
-      getTableBody(),
-    ],
+    default: () => [getTableHeader(), getTableBody()],
   },
 } satisfies Story;
 
@@ -73,21 +80,12 @@ export const WithoutHeader = {
   },
 } satisfies Story;
 
-const limitSizeDecorator = (maxHeight: string, maxWidth: string): Decorator => {
-  return (story) => ({
-    components: { story },
-    template: `
-    <div>
-      <story  style="max-height: ${maxHeight}; max-width: ${maxWidth};"/>
-    </div>`,
-  });
-};
-
 /**
  * This example shows a table which has a vertical scroll bar.
  */
 export const LimitedHeight = {
   args: {
+    style: "max-height: 16rem",
     default: () => [
       h("thead", [
         h("tr", [
@@ -113,13 +111,6 @@ export const LimitedHeight = {
           h("td", "18000"),
           h("td", "300"),
           h("td", "4"),
-        ]),
-        h("tr", [
-          h("td", "Strawberry"),
-          h("td", "4.50"),
-          h("td", "200"),
-          h("td", "400"),
-          h("td", "5"),
         ]),
         h("tr", [h("td", "Apple"), h("td", "1.99"), h("td", "3000"), h("td", "600"), h("td", "3")]),
         h("tr", [
@@ -147,21 +138,24 @@ export const LimitedHeight = {
       ]),
     ],
   },
-  decorators: limitSizeDecorator("20rem", "unset"),
 } satisfies Story;
 
 /**
  * This example shows a table which has a horizontal scroll bar.
  */
 export const LimitedWidth = {
-  ...LimitedHeight,
-  decorators: limitSizeDecorator("unset", "20rem"),
+  args: {
+    ...LimitedHeight.args,
+    style: "max-width: 20rem",
+  },
 } satisfies Story;
 
 /**
  * This example shows a table which has a vertical and horizontal scroll bar.
  */
 export const LimitedHeightAndWidth = {
-  ...LimitedHeight,
-  decorators: limitSizeDecorator("20rem", "20rem"),
+  args: {
+    ...LimitedHeight.args,
+    style: "max-width: 20rem; max-height: 16rem",
+  },
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxTable/OnyxTable.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxTable/OnyxTable.stories.ts
@@ -34,12 +34,12 @@ const getTableHeader = () => {
   ]);
 };
 
-const getTableBody = () => {
-  return h("tbody", [
+const getTableBodyRows = () => {
+  return [
     h("tr", [h("td", "Strawberry"), h("td", "4.50"), h("td", "200"), h("td", "100"), h("td", "5")]),
     h("tr", [h("td", "Apple"), h("td", "1.99"), h("td", "3000"), h("td", "200"), h("td", "3")]),
     h("tr", [h("td", "Banana"), h("td", "3.75"), h("td", "18000"), h("td", "300"), h("td", "4")]),
-  ]);
+  ];
 };
 
 /**
@@ -47,7 +47,7 @@ const getTableBody = () => {
  */
 export const Default = {
   args: {
-    default: () => [getTableHeader(), getTableBody()],
+    default: () => [getTableHeader(), h("tbody", getTableBodyRows())],
   },
 } satisfies Story;
 
@@ -76,7 +76,7 @@ export const GridBorders = {
  */
 export const WithoutHeader = {
   args: {
-    default: () => getTableBody(),
+    default: () => h("tbody", getTableBodyRows()),
   },
 } satisfies Story;
 
@@ -86,56 +86,9 @@ export const WithoutHeader = {
 export const LimitedHeight = {
   args: {
     style: "max-height: 16rem",
-    default: () => [
-      h("thead", [
-        h("tr", [
-          h("th", "Fruit"),
-          h("th", "Price (€/kg)"),
-          h("th", "Inventory (kg)"),
-          h("th", "Inventory (pieces)"),
-          h("th", "Rating"),
-        ]),
-      ]),
-      h("tbody", [
-        h("tr", [
-          h("td", "Strawberry"),
-          h("td", "4.50"),
-          h("td", "200"),
-          h("td", "100"),
-          h("td", "5"),
-        ]),
-        h("tr", [h("td", "Apple"), h("td", "1.99"), h("td", "3000"), h("td", "200"), h("td", "3")]),
-        h("tr", [
-          h("td", "Banana"),
-          h("td", "3.75"),
-          h("td", "18000"),
-          h("td", "300"),
-          h("td", "4"),
-        ]),
-        h("tr", [h("td", "Apple"), h("td", "1.99"), h("td", "3000"), h("td", "600"), h("td", "3")]),
-        h("tr", [
-          h("td", "Banana"),
-          h("td", "3.75"),
-          h("td", "18000"),
-          h("td", "300"),
-          h("td", "4"),
-        ]),
-        h("tr", [
-          h("td", "Strawberry"),
-          h("td", "4.50"),
-          h("td", "200"),
-          h("td", "1500"),
-          h("td", "5"),
-        ]),
-        h("tr", [h("td", "Apple"), h("td", "1.99"), h("td", "3000"), h("td", "300"), h("td", "3")]),
-        h("tr", [
-          h("td", "Banana"),
-          h("td", "3.75"),
-          h("td", "18000"),
-          h("td", "600"),
-          h("td", "4"),
-        ]),
-      ]),
+    default: [
+      getTableHeader(),
+      h("tbody", [...getTableBodyRows(), ...getTableBodyRows(), ...getTableBodyRows()]),
     ],
   },
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxTag/OnyxTag.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxTag/OnyxTag.stories.ts
@@ -1,7 +1,7 @@
 import check from "@sit-onyx/icons/check.svg?raw";
 import { defineStorybookActionsAndVModels } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { createTruncationDecorator, defineIconSelectArgType } from "../../utils/storybook";
+import { defineIconSelectArgType } from "../../utils/storybook";
 import OnyxTag from "./OnyxTag.vue";
 
 /**
@@ -47,6 +47,6 @@ export const WithIcon = {
 export const WithTruncation = {
   args: {
     label: "Tag with a very long text that gets truncated",
+    style: "max-width: 10rem",
   },
-  decorators: createTruncationDecorator("10rem"),
 } satisfies Story;

--- a/packages/sit-onyx/src/utils/storybook.ts
+++ b/packages/sit-onyx/src/utils/storybook.ts
@@ -53,16 +53,3 @@ export const textColorDecorator: Decorator = (story) => ({
     <story />
   </div>`,
 });
-
-/**
- * Storybook decorator that limits the width of the component to showcase truncation behavior.
- */
-export const createTruncationDecorator = (maxWidth: string): Decorator => {
-  return (story) => ({
-    components: { story },
-    template: `
-    <div style="max-width: ${maxWidth};">
-      <story />
-    </div>`,
-  });
-};


### PR DESCRIPTION
Relates to #1266

- Update truncation examples to use the `style` attribute instead of a Storybook decorator so it is included in the generated source code
- remove code duplication for the OnyxTable examples
