### PR TITLE
docs(playground): fix missing global styles

### DIFF
--- a/apps/playground/src/App.vue
+++ b/apps/playground/src/App.vue
@@ -14,6 +14,13 @@ const reloadPage = () => replRef.value?.reload();
 
 const isDark = useDark();
 const theme = computed(() => (isDark.value ? "dark" : "light"));
+
+const previewOptions = computed<InstanceType<typeof Repl>["previewOptions"]>(() => {
+  return {
+    headHTML: `<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/sit-onyx@${onyxVersion.value}/dist/style.css' />
+    <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/sit-onyx@${onyxVersion.value}/src/styles/global.css' />`,
+  };
+});
 </script>
 
 <template>
@@ -39,9 +46,7 @@ const theme = computed(() => (isDark.value ? "dark" : "light"));
       :store="store"
       :clear-console="false"
       :show-compile-output="false"
-      :preview-options="{
-        headHTML: `<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/sit-onyx@${onyxVersion}/dist/style.css' />`,
-      }"
+      :preview-options="previewOptions"
       preview-theme
       auto-resize
       @keydown.ctrl.s.prevent

--- a/apps/playground/src/template/App.vue
+++ b/apps/playground/src/template/App.vue
@@ -6,10 +6,8 @@ const value = ref("");
 </script>
 
 <template>
-  <p>You can edit the code on the left and see the live results here.</p>
-  <OnyxInput v-model="value" label="Example input" />
+  <div>
+    <p>You can edit the code on the left and see the live results here.</p>
+    <OnyxInput v-model="value" label="Example input" />
+  </div>
 </template>
-
-<style>
-@import "sit-onyx/global.css";
-</style>

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -10,10 +10,10 @@
 
 # @sit-onyx/nuxt
 
-A Nuxt module to easily integrate onyx into [Nuxt Js](https://nuxt.com/) projects.
+A Nuxt module to easily integrate onyx into [Nuxt](https://nuxt.com/) projects.
 Created by [Schwarz IT](https://it.schwarz).
 
-## Adding it to a nuxt project
+## Adding it to a Nuxt project
 
 Install the module in your Nuxt application with one command:
 


### PR DESCRIPTION
Seems like the Playground does not support importing CSS files inside `<style>` so we need to import them in the preview options instead
