### PR TITLE
fix(OnyxSelect): fix item hidden beneath sticky search when using keyboard

### DIFF
--- a/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
+++ b/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
@@ -420,7 +420,7 @@ const selectInputProps = computed(() => {
 
     &__wrapper:has(.onyx-mini-search) {
       // Add scroll padding, so items are not hidden beneath the search input
-      scroll-padding-top: 40px;
+      scroll-padding-top: var(--option-height);
     }
 
     &__slot {

--- a/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
+++ b/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
@@ -418,6 +418,11 @@ const selectInputProps = computed(() => {
       outline: $outline-size solid var(--onyx-color-base-primary-200);
     }
 
+    &__wrapper:has(.onyx-mini-search) {
+      // Add scroll padding, so items are not hidden beneath the search input
+      scroll-padding-top: 40px;
+    }
+
     &__slot {
       padding: 0 $wrapper-padding;
       display: flex;


### PR DESCRIPTION
* added `scroll-padding-top` when search is enabled, so the scrollTo function considers the height of the sticky search