### PR TITLE
chore(docs): Add imprint link to footer

### DIFF
--- a/apps/docs/src/.vitepress/config.ts
+++ b/apps/docs/src/.vitepress/config.ts
@@ -27,10 +27,6 @@ export default defineConfig({
     externalLinkIcon: true,
     logo: "/images/logo.svg",
     siteTitle: false,
-    footer: {
-      message: "Released under the Apache-2.0 License.",
-      copyright: "Copyright © 2023-present Schwarz IT KG",
-    },
     search: {
       provider: "local",
     },

--- a/apps/docs/src/.vitepress/theme/TheLayout.vue
+++ b/apps/docs/src/.vitepress/theme/TheLayout.vue
@@ -10,7 +10,7 @@ const { Layout } = DefaultTheme;
       <footer class="footer">
         <p class="footer__message">Released under the Apache-2.0 License.</p>
         <p class="footer__copyright">Copyright © 2023-present Schwarz IT KG</p>
-        <a class="footer__imprint" href="https://it.schwarz/impressum"> Imprint </a>
+        <a class="footer__imprint" href="https://it.schwarz/impressum" target="_blank"> Imprint </a>
       </footer>
     </template>
   </Layout>

--- a/apps/docs/src/.vitepress/theme/TheLayout.vue
+++ b/apps/docs/src/.vitepress/theme/TheLayout.vue
@@ -1,0 +1,45 @@
+<script lang="ts" setup>
+import DefaultTheme from "vitepress/theme";
+
+const { Layout } = DefaultTheme;
+</script>
+
+<template>
+  <Layout>
+    <template #layout-bottom>
+      <footer class="footer">
+        <p class="footer__message">Released under the Apache-2.0 License.</p>
+        <p class="footer__copyright">Copyright © 2023-present Schwarz IT KG</p>
+        <a class="footer__imprint" href="https://it.schwarz/impressum"> Imprint </a>
+      </footer>
+    </template>
+  </Layout>
+</template>
+
+<style lang="scss">
+.footer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-top: 1px solid var(--vp-c-gutter);
+  padding: 32px;
+
+  &__message,
+  &__copyright,
+  &__imprint {
+    line-height: 24px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--vp-c-text-2);
+  }
+
+  &__imprint {
+    text-decoration: underline;
+  }
+
+  &__imprint:hover {
+    color: var(--vp-c-text-3);
+  }
+}
+</style>

--- a/apps/docs/src/.vitepress/theme/index.ts
+++ b/apps/docs/src/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import OnyxTheme from "@sit-onyx/vitepress-theme";
 import type { Theme } from "vitepress";
 import TopicOverviewCard from "../components/TopicOverviewCard.vue";
+import TheLayout from "./TheLayout.vue";
 
 // custom styles must be imported after the theme
 import "./theme.scss";
@@ -12,6 +13,7 @@ const theme: Theme = {
     // be used without needing to import them
     ctx.app.component("TopicOverviewCard", TopicOverviewCard);
   },
+  Layout: TheLayout,
 };
 
 export default theme;


### PR DESCRIPTION
Relates to #1349

Provided custom footer with the original vitepress style.
A custom footer was necessary, as it is shown on every page.
The default footer was not shown on pages where the side-bar was opened.
