### PR TITLE
Increase instances count to two for increased failover

### DIFF
--- a/apps/docs/.cloud-foundry/manifest-prod.yml
+++ b/apps/docs/.cloud-foundry/manifest-prod.yml
@@ -2,4 +2,5 @@
 applications:
   - name: onyx-documentation-prod
     memory: 64M
+    instances: 2
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack

--- a/apps/playground/.cloud-foundry/manifest-prod.yml
+++ b/apps/playground/.cloud-foundry/manifest-prod.yml
@@ -2,4 +2,5 @@
 applications:
   - name: onyx-playground-prod
     memory: 64M
+    instances: 2
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack

--- a/packages/sit-onyx/.cloud-foundry/manifest-prod.yml
+++ b/packages/sit-onyx/.cloud-foundry/manifest-prod.yml
@@ -2,4 +2,5 @@
 applications:
   - name: onyx-storybook-prod
     memory: 64M
+    instances: 2
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack


### PR DESCRIPTION
Increase instances count to two for increased failover, as recommended.
This also allows us to make use of the multiple geolocations of stackit.