### PR TITLE
fix(OnyxFormElement): hide message while error is shown + prevent error overflow

### DIFF
--- a/.changeset/curvy-hornets-jam.md
+++ b/.changeset/curvy-hornets-jam.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxFormElement): hide message while error is shown + prevent error overflow

--- a/packages/sit-onyx/src/components/OnyxFormElement/OnyxFormElement.vue
+++ b/packages/sit-onyx/src/components/OnyxFormElement/OnyxFormElement.vue
@@ -44,7 +44,7 @@ defineSlots<{
           ></span>
           <OnyxInfoTooltip
             v-if="props.labelTooltip"
-            class="onyx-form-element__tooltip"
+            class="onyx-form-element__label-tooltip"
             :text="props.labelTooltip"
           />
           <span v-if="!props.required" class="onyx-form-element__optional">{{
@@ -60,22 +60,24 @@ defineSlots<{
       v-if="props.message || errorMessages?.shortMessage || counterText"
       class="onyx-form-element__footer onyx-text--small"
     >
-      <span v-if="errorMessages" class="onyx-form-element__error-message">
-        <span class="onyx-truncation-ellipsis">{{ errorMessages.shortMessage }}</span>
-
-        <OnyxInfoTooltip
-          v-if="errorMessages.longMessage"
-          class="onyx-form-element__tooltip onyx-form-element__tooltip--bottom"
-          color="danger"
-          position="bottom"
-          :label="t('showTooltip.error')"
-          :text="errorMessages.longMessage"
-        />
+      <span v-if="errorMessages" class="onyx-form-element__error-message onyx-truncation-ellipsis">
+        {{ errorMessages.shortMessage }}
       </span>
-      <span v-if="props.message" class="onyx-truncation-ellipsis">{{ props.message }}</span>
+      <OnyxInfoTooltip
+        v-if="errorMessages?.longMessage"
+        class="onyx-form-element__error-tooltip"
+        color="danger"
+        position="bottom"
+        :label="t('showTooltip.error')"
+        :text="errorMessages.longMessage"
+      />
+
+      <span v-if="props.message" class="onyx-form-element__message onyx-truncation-ellipsis">
+        {{ props.message }}
+      </span>
       <OnyxInfoTooltip
         v-if="props.messageTooltip"
-        class="onyx-form-element__tooltip onyx-form-element__tooltip--bottom"
+        class="onyx-form-element__message-tooltip"
         position="bottom"
         :text="props.messageTooltip"
       />
@@ -98,12 +100,16 @@ defineSlots<{
 .onyx-form-element {
   @include layers.component() {
     /**
-     * input/textarea/... will overwrite this to only be visible
+     * input.scss will overwrite this to only be visible
      * after the user interacted with the component.
      * can also be overwritten if a project
      * needs to enforce to show an error immediately    
      */
-    --error-message-display: flex;
+    --error-message-display: block;
+    /** input.scss will overwrite this so that
+     * message and error message are not be shown simultaneously 
+     */
+    --message-display: block;
 
     font-family: var(--onyx-font-family);
     display: flex;
@@ -142,12 +148,15 @@ defineSlots<{
       width: 100%;
     }
 
-    &__tooltip {
+    &__label-tooltip,
+    &__message-tooltip,
+    &__error-tooltip {
       margin-left: var(--onyx-spacing-2xs);
-      &--bottom {
-        height: 1rem;
-        align-self: center;
-      }
+    }
+    &__message-tooltip,
+    &__error-tooltip {
+      height: 1rem;
+      align-self: center;
     }
 
     &__footer {
@@ -163,10 +172,14 @@ defineSlots<{
       margin-left: var(--onyx-spacing-2xs);
     }
 
-    &__error-message {
-      // todo use variable for display toggling to avoid overwritten styles
+    &__error-message,
+    &__error-tooltip {
       display: var(--error-message-display);
       color: var(--onyx-color-base-danger-500);
+    }
+    &__message,
+    &__message-tooltip {
+      display: var(--message-display);
     }
   }
 }

--- a/packages/sit-onyx/src/i18n/locales/de-DE.json
+++ b/packages/sit-onyx/src/i18n/locales/de-DE.json
@@ -4,56 +4,56 @@
   "apply": "Anwenden",
   "validations": {
     "tooShort": {
-      "shortError": "Zu kurz",
+      "preview": "Zu kurz",
       "fullError": "Verlängere diesen Text auf mindestens {minLength} Zeichen. Derzeit verwendest du {n} Zeichen."
     },
     "tooLong": {
-      "shortError": "Zu lang",
+      "preview": "Zu lang",
       "fullError": "Kürze diesen Text auf max. {maxLength} Zeichen. Zurzeit verwendest du {n} Zeichen."
     },
     "rangeUnderflow": {
-      "shortError": "Zu niedrig",
+      "preview": "Zu niedrig",
       "fullError": "Wert muss größer als oder gleich {min} sein."
     },
     "rangeOverflow": {
-      "shortError": "Zu hoch",
+      "preview": "Zu hoch",
       "fullError": "Wert muss kleiner als oder gleich {max} sein."
     },
     "patternMismatch": {
-      "shortError": "Ungültiges Format",
+      "preview": "Ungültiges Format",
       "fullError": "Deine Eingabe muss mit dem geforderten Format übereinstimmen."
     },
     "valueMissing": {
-      "shortError": "Pflichtfeld",
+      "preview": "Pflichtfeld",
       "fullError": "Fülle dieses Feld aus."
     },
     "stepMismatch": {
-      "shortError": "Ungültige Zahl",
+      "preview": "Ungültige Zahl",
       "fullError": "Wert muss ein Vielfaches von {step} sein."
     },
     "badInput": {
-      "shortError": "Ungültige Eingabe",
+      "preview": "Ungültige Eingabe",
       "fullError": "\"{value}\" entspricht nicht dem erwarteten Typ."
     },
     "typeMismatch": {
       "generic": {
-        "shortError": "Ungültiges Eingabeformat",
+        "preview": "Ungültiges Eingabeformat",
         "fullError": "\"{value}\" entspricht nicht dem erwarteten Typ."
       },
       "email": {
-        "shortError": "Ungültige E-Mail",
+        "preview": "Ungültige E-Mail",
         "fullError": "\"{value}\" muss eine valide E-Mail-Adresse sein."
       },
       "number": {
-        "shortError": "Ungültige Zahl",
+        "preview": "Ungültige Zahl",
         "fullError": "\"{value}\" muss eine Zahl sein."
       },
       "tel": {
-        "shortError": "Ungültige Telefonnummer",
+        "preview": "Ungültige Telefonnummer",
         "fullError": "\"{value}\" muss eine gültige Telefonnummer sein."
       },
       "url": {
-        "shortError": "Ungültige URL",
+        "preview": "Ungültige URL",
         "fullError": "\"{value}\" muss eine gültige URL sein."
       }
     }

--- a/packages/sit-onyx/src/styles/grid.scss
+++ b/packages/sit-onyx/src/styles/grid.scss
@@ -64,7 +64,7 @@ $screenOffset: 1;
     }
   }
 
-  @mixin generateGridProperties($columns, $gutter, $margin) {
+  @mixin generate-grid-properties($columns, $gutter, $margin) {
     :where(:root) {
       --onyx-grid-columns: #{$columns};
       --onyx-grid-gutter: #{$gutter};
@@ -75,7 +75,7 @@ $screenOffset: 1;
   /**
   * Grid element class for defining breakpoint specific column count
   */
-  @mixin generateSpans($first, $last, $name) {
+  @mixin generate-spans($first, $last, $name) {
     @for $span from $first through $last {
       .onyx-grid-#{$name}-span-#{$span} {
         grid-column-end: span min($span, var(--onyx-grid-columns));
@@ -86,7 +86,7 @@ $screenOffset: 1;
   /**
   * Grid container class for defining breakpoint specific max width
   */
-  @mixin generateGridMax($name, $maxVariant, $margin) {
+  @mixin generate-grid-max($name, $maxVariant, $margin) {
     .onyx-grid-max-#{$maxVariant} {
       --onyx-grid-max-width: #{map-get($breakpoints, $name)};
     }
@@ -94,19 +94,19 @@ $screenOffset: 1;
 
   @each $name, $maxVariant, $columns, $gutter, $margin in $gridVariants {
     @if $name == "2xs" {
-      @include generateGridProperties($columns, $gutter, $margin);
-      @include generateSpans(1, $columns, $name);
+      @include generate-grid-properties($columns, $gutter, $margin);
+      @include generate-spans(1, $columns, $name);
     } @else {
       @include screen(min, $name, $screenOffset) {
-        @include generateGridProperties($columns, $gutter, $margin);
-        @include generateSpans(1, $columns, $name);
+        @include generate-grid-properties($columns, $gutter, $margin);
+        @include generate-spans(1, $columns, $name);
 
         @if $maxVariant != none {
-          @include generateGridMax($name, $maxVariant, $margin);
+          @include generate-grid-max($name, $maxVariant, $margin);
         }
 
         @if $name == "xl" {
-          @include generateSpans(17, 20, $name);
+          @include generate-spans(17, 20, $name);
         }
       }
     }

--- a/packages/sit-onyx/src/styles/mixins/input.scss
+++ b/packages/sit-onyx/src/styles/mixins/input.scss
@@ -65,12 +65,14 @@
     }
   }
 
-  .onyx-form-element__error-message {
+  .onyx-form-element {
     --error-message-display: none;
   }
   &:has(#{$base-selector}__native:user-invalid) {
-    .onyx-form-element__error-message {
-      --error-message-display: flex;
+    .onyx-form-element {
+      --error-message-display: block;
+      // hide the default message once an error is shown
+      --message-display: none;
     }
   }
 


### PR DESCRIPTION
Relates to #1355 

- hide a standard message below form elements when an error is shown
- fix german translations for error previews
- add component tests

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
