### PR TITLE
docs: fix Storybook code snippets

### DIFF
--- a/.changeset/metal-radios-rush.md
+++ b/.changeset/metal-radios-rush.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/storybook-utils": patch
+---
+
+docs: fix Storybook code snippets

--- a/.changeset/metal-radios-rush.md
+++ b/.changeset/metal-radios-rush.md
@@ -3,3 +3,6 @@
 ---
 
 docs: fix Storybook code snippets
+
+- remove unnecessary new line before `import { ref } from "vue";`
+- fix onyx component imports when component has no props, e.g. `<OnyxComponent>Test</OnyxComponent>`

--- a/packages/storybook-utils/src/preview.spec.ts
+++ b/packages/storybook-utils/src/preview.spec.ts
@@ -12,6 +12,7 @@ describe("preview.ts", () => {
       .mockReturnValue(`<template>
 <OnyxTest icon='${placeholder}' test='${bellRing}' :obj="{foo:'${replaceAll(calendar, '"', "\\'")}'}" />
 <OnyxOtherComponent />
+<OnyxComp>Test</OnyxComp>
 </template>`);
 
     // ACT
@@ -20,7 +21,7 @@ describe("preview.ts", () => {
     // ASSERT
     expect(generatorSpy).toHaveBeenCalledOnce();
     expect(sourceCode).toBe(`<script lang="ts" setup>
-import { OnyxOtherComponent, OnyxTest } from "sit-onyx";
+import { OnyxComp, OnyxOtherComponent, OnyxTest } from "sit-onyx";
 import bellRing from "@sit-onyx/icons/bell-ring.svg?raw";
 import calendar from "@sit-onyx/icons/calendar.svg?raw";
 import placeholder from "@sit-onyx/icons/placeholder.svg?raw";
@@ -29,6 +30,7 @@ import placeholder from "@sit-onyx/icons/placeholder.svg?raw";
 <template>
 <OnyxTest :icon="placeholder" :test="bellRing" :obj="{foo:calendar}" />
 <OnyxOtherComponent />
+<OnyxComp>Test</OnyxComp>
 </template>`);
   });
 });

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -173,7 +173,7 @@ export const sourceCodeTransformer = (
   // add imports for all used onyx components
   // Set is used here to only include unique components if they are used multiple times
   const usedOnyxComponents = [
-    ...new Set(Array.from(code.matchAll(/<Onyx\S+/g)).map((match) => match[0].replace("<", ""))),
+    ...new Set(Array.from(code.matchAll(/<(Onyx\w+)(?:\s*\/?)/g)).map((match) => match[1])),
   ].sort();
 
   if (usedOnyxComponents.length > 0) {
@@ -184,7 +184,13 @@ export const sourceCodeTransformer = (
 
   if (code.startsWith("<script")) {
     const index = code.indexOf("\n");
-    return code.slice(0, index) + additionalImports.join("\n") + "\n" + code.slice(index);
+    const hasOtherImports = code.includes("import {");
+    return (
+      code.slice(0, index) +
+      additionalImports.join("\n") +
+      (!hasOtherImports ? "\n" : "") +
+      code.slice(index)
+    );
   }
 
   return `<script lang="ts" setup>


### PR DESCRIPTION
- remove unnecessary new line before `import { ref } from "vue";`
- fix onyx component imports when component has no props, e.g. `<OnyxComponent>Test</OnyxComponent>`

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
