### PR TITLE
docs (OnyxSelect): extend description on listLabel

### DIFF
--- a/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.stories.ts
@@ -128,6 +128,16 @@ export const Default = {
 } satisfies Story;
 
 /**
+ * This example shows a select with a hidden label.
+ */
+export const HiddenLabel = {
+  args: {
+    ...Default.args,
+    hideLabel: true,
+  },
+} satisfies Story;
+
+/**
  * This example shows a select with a message / help text at the bottom.
  */
 export const WithMessage = {

--- a/packages/sit-onyx/src/components/OnyxSelect/types.ts
+++ b/packages/sit-onyx/src/components/OnyxSelect/types.ts
@@ -65,11 +65,8 @@ export type OnyxSelectProps<TValue extends SelectOptionValue = SelectOptionValue
   Omit<OnyxSelectInputProps<TValue>, "density" | "modelValue"> &
   AutofocusProp & {
     /**
-     * Aria label. Must be set for accessibility reasons.
-     */
-    label: string;
-    /**
-     * Label describing the selection list, must be set to support assistive technologies.
+     * Label describing the list of options to support assistive technologies.
+     * @example: { label: "Your Animal", listLabel: "List of animals" }
      */
     listLabel: string;
     /**


### PR DESCRIPTION
Relates to #1266

Extend the description on `listLabel` of OnyxSelect.
Remove the duplicate `label` type declaration (it's already provided by `OnyxFormElementProps`).
