### PR TITLE
fix(OnyxSelect): do not submit form when pressing Enter

### DIFF
--- a/.changeset/moody-kiwis-swim.md
+++ b/.changeset/moody-kiwis-swim.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxSelect): do not submit form when pressing Enter

--- a/.changeset/rotten-apricots-battle.md
+++ b/.changeset/rotten-apricots-battle.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/headless": patch
+---
+
+fix(createComboBox): prevent submitting form when pressing enter

--- a/packages/headless/src/composables/comboBox/createComboBox.ts
+++ b/packages/headless/src/composables/comboBox/createComboBox.ts
@@ -173,6 +173,11 @@ export const createComboBox = createBuilder(
     };
 
     const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key === "Enter") {
+        // prevent submitting the form when pressing enter
+        event.preventDefault();
+      }
+
       if (!isExpanded.value && isKeyOfGroup(event, OPENING_KEYS)) {
         onToggle?.();
         if (event.key === " ") {

--- a/packages/headless/src/composables/comboBox/createComboBox.ts
+++ b/packages/headless/src/composables/comboBox/createComboBox.ts
@@ -174,7 +174,7 @@ export const createComboBox = createBuilder(
 
     const handleKeydown = (event: KeyboardEvent) => {
       if (event.key === "Enter") {
-        // prevent submitting the form when pressing enter
+        // prevent submitting on pressing enter when the combo box is used inside a <form>
         event.preventDefault();
       }
 

--- a/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.ct.tsx
@@ -1,13 +1,13 @@
 import type { MountResultJsx } from "@playwright/experimental-ct-vue";
+import type { Locator } from "@playwright/test";
 import { comboboxSelectOnlyTesting, comboboxTesting } from "@sit-onyx/headless/playwright";
+import type { FormErrorMessages } from "src/composables/useCustomValidity";
 import { DENSITIES } from "../../composables/density";
 import { expect, test } from "../../playwright/a11y";
 import { executeMatrixScreenshotTest } from "../../playwright/screenshots";
 import OnyxButton from "../OnyxButton/OnyxButton.vue";
 import OnyxSelect from "./OnyxSelect.vue";
 import type { OnyxSelectProps, SelectOption } from "./types";
-import type { FormErrorMessages } from "src/composables/useCustomValidity";
-import type { Locator } from "@playwright/test";
 
 const DISABLED_ACCESSIBILITY_RULES = [
   // TODO: color-contrast: remove when contrast issues are fixed in https://github.com/SchwarzIT/onyx/issues/410
@@ -650,4 +650,25 @@ test("should show custom option slot content", async ({ mount }) => {
   for (const option of MOCK_VARIED_OPTIONS) {
     await expect(component.getByLabel(option.label)).toContainText("Custom content");
   }
+});
+
+test("should not submit form when selecting via keyboard", async ({ page, mount }) => {
+  let submitEventCount = 0;
+
+  // ARRANGE
+  await mount(
+    <form onSubmit={() => submitEventCount++}>
+      <OnyxSelect options={MOCK_VARIED_OPTIONS} label="Test label" listLabel="List label" />
+    </form>,
+  );
+
+  // ACT
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Enter");
+
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("Enter");
+
+  // ASSERT
+  await expect(submitEventCount).toBe(0);
 });


### PR DESCRIPTION
closes #1431

- do not submit form when pressing Enter

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
