### PR TITLE
docs(storybook): fix code snippets for slot bindings

### DIFF
--- a/.changeset/curvy-mails-promise.md
+++ b/.changeset/curvy-mails-promise.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/storybook-utils": patch
+---
+
+fix: generate correct code for slot bindings

--- a/packages/sit-onyx/src/components/OnyxAppLayout/OnyxAppLayout.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxAppLayout/OnyxAppLayout.stories.ts
@@ -27,18 +27,10 @@ const meta: Meta<typeof OnyxAppLayout> = {
         control: { disable: true },
       },
     },
-    // storybook adds 1rem padding. The app layout fills the full available space
-    // so we need to counteract the padding with a negative margin.
-    decorators: [
-      (story) => ({
-        components: { story },
-        template: `
-          <div style="margin: -1rem;" >
-            <story />
-          </div>`,
-      }),
-    ],
   }),
+  parameters: {
+    layout: "fullscreen",
+  },
 };
 
 export default meta;

--- a/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.stories.ts
@@ -31,14 +31,16 @@ const meta: Meta<typeof OnyxPageLayout> = {
     (story) => ({
       components: { story },
       template: `
-        <div style="margin: -1rem; height: 15rem;
+        <div style="height: 15rem;
                     font-family: var(--onyx-font-family);
-                    color: var(--onyx-color-text-icons-neutral-intense);
-                    border: 1px solid var(--onyx-color-text-icons-neutral-soft);" >
+                    color: var(--onyx-color-text-icons-neutral-intense);" >
           <story />
         </div>`,
     }),
   ],
+  parameters: {
+    layout: "fullscreen",
+  },
 };
 
 export default meta;

--- a/packages/storybook-utils/src/source-code-generator.spec.ts
+++ b/packages/storybook-utils/src/source-code-generator.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 //
 // This file is only a temporary copy of the improved source code generation for Storybook.
 // It is intended to be deleted once its officially released in Storybook itself, see:
@@ -9,6 +10,7 @@ import {
   generatePropsSourceCode,
   generateSlotSourceCode,
   generateSourceCode,
+  getFunctionParamNames,
   parseDocgenInfo,
   type SourceCodeGeneratorContext,
 } from "./source-code-generator";
@@ -233,4 +235,24 @@ test.each([
 ])("should parse event names from __docgenInfo", ({ __docgenInfo, eventNames }) => {
   const docgenInfo = parseDocgenInfo({ __docgenInfo });
   expect(docgenInfo.eventNames).toStrictEqual(eventNames);
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+test.each<{ fn: (...args: any[]) => unknown; expectedNames: string[] }>([
+  { fn: () => ({}), expectedNames: [] },
+  { fn: (a) => ({}), expectedNames: ["a"] },
+  { fn: (a, b) => ({}), expectedNames: ["a", "b"] },
+  { fn: (a, b, { c }) => ({}), expectedNames: ["a", "b", "{", "c", "}"] },
+  { fn: ({ a, b }) => ({}), expectedNames: ["{", "a", "b", "}"] },
+  {
+    fn: {
+      // simulate minified function after running "storybook build"
+      toString: () => "({a:foo,b:bar})=>({})",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as (...args: any[]) => unknown,
+    expectedNames: ["{", "a", "b", "}"],
+  },
+])("should extract function parameter names", ({ fn, expectedNames }) => {
+  const paramNames = getFunctionParamNames(fn);
+  expect(paramNames).toStrictEqual(expectedNames);
 });


### PR DESCRIPTION
Merge latest changes of https://github.com/storybookjs/storybook/pull/27194.
Fixes code snippets when using slot bindings on a deployed Storybook
<img width="305" alt="image" src="https://github.com/SchwarzIT/onyx/assets/67898185/15230312-5c5e-46eb-90a5-c9c9d422b604">


## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
