### PR TITLE
docs: fix default storybook theme

### DIFF
--- a/packages/sit-onyx/.storybook/theme-switch.ts
+++ b/packages/sit-onyx/.storybook/theme-switch.ts
@@ -31,7 +31,8 @@ const currentOnyxTheme = ref<string>();
 
 export const withOnyxTheme: Decorator = (Story, context) => {
   watchEffect(() => {
-    currentOnyxTheme.value = context.globals.onyxTheme;
+    const theme = context.globals.onyxTheme ?? ONYX_THEMES[0];
+    currentOnyxTheme.value = theme === ONYX_THEMES[0] ? "default" : theme;
   });
 
   return {


### PR DESCRIPTION
Relates to #764

The class for the default theme is `onyx-theme-default` but we are currently applying `onyx-theme-onyx` which does not work so the twogo theme is used as default currently because its the last registered theme