### PR TITLE
docs(storybook): hide controls section if no arg table exists

### DIFF
--- a/packages/sit-onyx/.storybook/docs-template.mdx
+++ b/packages/sit-onyx/.storybook/docs-template.mdx
@@ -8,6 +8,7 @@ import { Controls, Description, Meta, Primary, Stories, Title } from "@storybook
 
 <Primary />
 
+<section class="onyx-storybook-controls">
 ### Properties, Events and Slots
 
 Below you can find all available properties, events and slots of the component.
@@ -20,6 +21,7 @@ Below you can find all available properties, events and slots of the component.
 <Controls />
 
 <div style={{ marginTop: "3rem" }}></div>
+</section>
 
 ## Examples
 

--- a/packages/sit-onyx/.storybook/docs-template.scss
+++ b/packages/sit-onyx/.storybook/docs-template.scss
@@ -24,3 +24,8 @@
     display: none;
   }
 }
+
+// hide controls section if the story does not have any args
+.onyx-storybook-controls:not(:has(.docblock-argstable)) {
+  display: none;
+}

--- a/packages/sit-onyx/src/components/OnyxToast/OnyxToast.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxToast/OnyxToast.stories.ts
@@ -18,7 +18,7 @@ import StorybookExampleSourceCode from "./StorybookExample.vue?raw";
  *
  * #### Step 2: Create the toast provider
  *
- * **If you are using the `createOnyx()` Vue plugin, you can skip this step since this will already be set up for you.**
+ * **If you are using the [createOnyx()](https://onyx.schwarz/development/#installation) Vue plugin, you can skip this step since this will already be set up for you.**
  *
  * The toast works with Vue's [provide/inject](https://vuejs.org/guide/components/provide-inject) API so you need to create a toast provider once.
  * To do so, add the following code to your `main.ts` file to set up the toasts globally:


### PR DESCRIPTION
Relates to https://github.com/SchwarzIT/onyx/issues/1301#issuecomment-2219815724

- hide controls section in Storybook docs page when the component does not have any args/props (like the OnyxToast)
- add link to `createOnyx()` plugin for toast
