### PR TITLE
fix(OnyxUserMenu): hide mobile footer when it does not exist

### DIFF
--- a/.changeset/sour-birds-kneel.md
+++ b/.changeset/sour-birds-kneel.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxUserMenu): hide mobile footer when it does not exist

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/UserMenuLayout.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/UserMenuLayout.vue
@@ -23,7 +23,7 @@ const { t } = injectI18n();
     <template v-if="props.isMobile">
       <slot name="header"></slot>
       <slot name="options"></slot>
-      <OnyxListItem class="onyx-user-menu__mobile-footer" disabled>
+      <OnyxListItem v-if="!!slots.footer" class="onyx-user-menu__mobile-footer" disabled>
         <slot name="footer"> </slot>
       </OnyxListItem>
     </template>


### PR DESCRIPTION
fix(OnyxUserMenu): hide mobile footer when it does not exist

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
