### PR TITLE
fix labelling issue of OnyxFormElement

### DIFF
--- a/.changeset/polite-hats-mate.md
+++ b/.changeset/polite-hats-mate.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxFormElement): fix label being applied to all interactive elment of a complex form element

--- a/packages/sit-onyx/src/components/OnyxFormElement/OnyxFormElement.vue
+++ b/packages/sit-onyx/src/components/OnyxFormElement/OnyxFormElement.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { createId } from "@sit-onyx/headless";
 import { computed } from "vue";
 import { useRequired } from "../../composables/required";
 import { injectI18n } from "../../i18n";
@@ -7,6 +8,7 @@ import type { OnyxFormElementProps } from "./types";
 
 const props = withDefaults(defineProps<OnyxFormElementProps>(), {
   required: false,
+  id: createId("onyx-form-element"),
 });
 
 const { t } = injectI18n();
@@ -23,39 +25,32 @@ const counterText = computed(() => {
 
 defineSlots<{
   /** The place for the actual form element */
-  default(): unknown;
+  default(props: { id: string }): unknown;
 }>();
 </script>
 
 <template>
   <div :class="['onyx-form-element', requiredTypeClass]">
-    <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-    <label>
-      <div
-        v-if="!props.hideLabel"
-        class="onyx-form-element__label onyx-text--small"
-        :class="[!props.required ? requiredMarkerClass : undefined]"
-      >
-        <div class="onyx-form-element__header">
-          <span class="onyx-truncation-ellipsis">{{ props.label }}</span>
-          <span
-            v-if="props.required"
-            :class="[props.required ? requiredMarkerClass : undefined]"
-          ></span>
-          <OnyxInfoTooltip
-            v-if="props.labelTooltip"
-            class="onyx-form-element__label-tooltip"
-            :text="props.labelTooltip"
-          />
-          <span v-if="!props.required" class="onyx-form-element__optional">{{
-            t("optional")
-          }}</span>
-        </div>
+    <div
+      v-if="!props.hideLabel"
+      class="onyx-form-element__label onyx-text--small"
+      :class="[!props.required ? requiredMarkerClass : undefined]"
+    >
+      <div class="onyx-form-element__header">
+        <label :for="props.id" class="onyx-truncation-ellipsis">{{ props.label }}</label>
+        <span
+          v-if="props.required"
+          :class="[props.required ? requiredMarkerClass : undefined]"
+        ></span>
+        <OnyxInfoTooltip
+          v-if="props.labelTooltip"
+          class="onyx-form-element__label-tooltip"
+          :text="props.labelTooltip"
+        />
+        <span v-if="!props.required" class="onyx-form-element__optional">{{ t("optional") }}</span>
       </div>
-
-      <slot></slot>
-    </label>
-
+    </div>
+    <slot :id="props.id"></slot>
     <div
       v-if="props.message || errorMessages?.shortMessage || counterText"
       class="onyx-form-element__footer onyx-text--small"

--- a/packages/sit-onyx/src/components/OnyxFormElement/types.ts
+++ b/packages/sit-onyx/src/components/OnyxFormElement/types.ts
@@ -3,6 +3,12 @@ import type { FormErrorMessages } from "../../composables/useCustomValidity";
 
 export type OnyxFormElementProps = RequiredMarkerProp & {
   /**
+   * The id of a labelable form-related element.
+   * If not given an id will be generated.
+   * The id is passed as a `default` slot property.
+   */
+  id?: string;
+  /**
    * Current value of the form element.
    */
   modelValue?: unknown;

--- a/packages/sit-onyx/src/components/OnyxInput/OnyxInput.vue
+++ b/packages/sit-onyx/src/components/OnyxInput/OnyxInput.vue
@@ -72,33 +72,35 @@ const patternSource = computed(() => {
 
   <div v-else :class="['onyx-input', densityClass]">
     <OnyxFormElement v-bind="props" :error-messages="errorMessages">
-      <div class="onyx-input__wrapper">
-        <OnyxLoadingIndicator v-if="props.loading" class="onyx-input__loading" type="circle" />
-
-        <input
-          v-model="value"
-          v-custom-validity
-          class="onyx-input__native"
-          :placeholder="props.placeholder"
-          :type="props.type"
-          :required="props.required"
-          :autocapitalize="props.autocapitalize"
-          :autocomplete="props.autocomplete"
-          :autofocus="props.autofocus"
-          :name="props.name"
-          :pattern="patternSource"
-          :readonly="props.readonly"
-          :disabled="props.disabled || props.loading"
-          :minlength="props.minlength"
-          :maxlength="props.maxlength"
-          :aria-label="props.hideLabel ? props.label : undefined"
-          :title="props.hideLabel ? props.label : undefined"
-          @change="handleChange"
-          @focus="emit('focus')"
-          @blur="emit('blur')"
-        />
-        <!-- eslint-enable vuejs-accessibility/no-autofocus -->
-      </div>
+      <template #default="{ id }">
+        <div class="onyx-input__wrapper">
+          <OnyxLoadingIndicator v-if="props.loading" class="onyx-input__loading" type="circle" />
+          <input
+            :id="id"
+            v-model="value"
+            v-custom-validity
+            :placeholder="props.placeholder"
+            class="onyx-input__native"
+            :type="props.type"
+            :required="props.required"
+            :autocapitalize="props.autocapitalize"
+            :autocomplete="props.autocomplete"
+            :autofocus="props.autofocus"
+            :name="props.name"
+            :pattern="patternSource"
+            :readonly="props.readonly"
+            :disabled="props.disabled || props.loading"
+            :minlength="props.minlength"
+            :maxlength="props.maxlength"
+            :aria-label="props.hideLabel ? props.label : undefined"
+            :title="props.hideLabel ? props.label : undefined"
+            @change="handleChange"
+            @focus="emit('focus')"
+            @blur="emit('blur')"
+          />
+          <!-- eslint-enable vuejs-accessibility/no-autofocus -->
+        </div>
+      </template>
     </OnyxFormElement>
   </div>
 </template>

--- a/packages/sit-onyx/src/components/OnyxSelectInput/OnyxSelectInput.vue
+++ b/packages/sit-onyx/src/components/OnyxSelectInput/OnyxSelectInput.vue
@@ -123,60 +123,63 @@ const blockTyping = (event: KeyboardEvent) => {
     v-bind="rootAttrs"
   >
     <OnyxFormElement v-bind="props" :error-messages="errorMessages">
-      <div class="onyx-select-input__wrapper">
-        <OnyxLoadingIndicator
-          v-if="props.loading"
-          class="onyx-select-input__loading"
-          type="circle"
-        />
+      <template #default="{ id }">
+        <div class="onyx-select-input__wrapper">
+          <OnyxLoadingIndicator
+            v-if="props.loading"
+            class="onyx-select-input__loading"
+            type="circle"
+          />
 
-        <input
-          ref="input"
-          v-custom-validity
-          :class="{
-            'onyx-select-input__native': true,
-            'onyx-select-input__native--show-focus': props.showFocus,
-            'onyx-truncation-ellipsis': true,
-            'onyx-select-input__native--force-invalid': errorMessages && wasTouched,
-          }"
-          v-bind="restAttrs"
-          type="text"
-          :readonly="props.readonly"
-          :placeholder="props.placeholder"
-          :required="props.required"
-          :disabled="props.disabled || props.loading"
-          :aria-label="props.hideLabel ? props.label : undefined"
-          :title="props.hideLabel ? props.label : undefined"
-          :value="selectionText"
-          :autofocus="props.autofocus"
-          @click="emit('click')"
-          @keydown="blockTyping"
-        />
+          <input
+            :id="id"
+            ref="input"
+            v-custom-validity
+            :class="{
+              'onyx-select-input__native': true,
+              'onyx-select-input__native--show-focus': props.showFocus,
+              'onyx-truncation-ellipsis': true,
+              'onyx-select-input__native--force-invalid': errorMessages && wasTouched,
+            }"
+            v-bind="restAttrs"
+            type="text"
+            :readonly="props.readonly"
+            :placeholder="props.placeholder"
+            :required="props.required"
+            :disabled="props.disabled || props.loading"
+            :aria-label="props.hideLabel ? props.label : undefined"
+            :title="props.hideLabel ? props.label : undefined"
+            :value="selectionText"
+            :autofocus="props.autofocus"
+            @click="emit('click')"
+            @keydown="blockTyping"
+          />
 
-        <!-- TODO: figure out how the tooltip width can be sized to the select-input
+          <!-- TODO: figure out how the tooltip width can be sized to the select-input
         while the trigger arrow needs to point to the badge in the future.
         https://github.com/SchwarzIT/onyx/issues/763 -->
-        <OnyxTooltip
-          v-if="props.textMode === 'preview' && selectionCount > 0"
-          :text="selectionText"
-          position="bottom"
-        >
-          <OnyxBadge class="onyx-select-input__badge" color="neutral">
-            {{ selectionCount }}
-          </OnyxBadge>
-        </OnyxTooltip>
+          <OnyxTooltip
+            v-if="props.textMode === 'preview' && selectionCount > 0"
+            :text="selectionText"
+            position="bottom"
+          >
+            <OnyxBadge class="onyx-select-input__badge" color="neutral">
+              {{ selectionCount }}
+            </OnyxBadge>
+          </OnyxTooltip>
 
-        <button
-          class="onyx-select-input__button"
-          type="button"
-          :aria-label="t('select.toggleDropDown')"
-          tabindex="-1"
-          :disabled="props.readonly || props.disabled || props.loading"
-          @click="emit('click')"
-        >
-          <OnyxIcon :icon="chevronDownUp" />
-        </button>
-      </div>
+          <button
+            class="onyx-select-input__button"
+            type="button"
+            :aria-label="t('select.toggleDropDown')"
+            tabindex="-1"
+            :disabled="props.readonly || props.disabled || props.loading"
+            @click="emit('click')"
+          >
+            <OnyxIcon :icon="chevronDownUp" />
+          </button>
+        </div>
+      </template>
     </OnyxFormElement>
   </div>
 </template>

--- a/packages/sit-onyx/src/components/OnyxTextarea/OnyxTextarea.vue
+++ b/packages/sit-onyx/src/components/OnyxTextarea/OnyxTextarea.vue
@@ -88,34 +88,37 @@ const handleInput = (event: Event) => {
 
   <div v-else :class="['onyx-textarea', densityClass]" :style="autosizeMinMaxStyles">
     <OnyxFormElement v-bind="props" :error-messages="errorMessages">
-      <div class="onyx-textarea__wrapper" :data-autosize-value="value">
-        <!-- eslint-disable vuejs-accessibility/no-autofocus -
-         We want to provide the flexibility to have the autofocus property.
-         The JSDoc description includes a warning that it should be used carefully.
-      -->
-        <textarea
-          v-model="value"
-          v-custom-validity
-          class="onyx-textarea__native"
-          :class="{ 'onyx-textarea__native--no-resize': props.disableManualResize }"
-          :placeholder="props.placeholder"
-          :required="props.required"
-          :autocapitalize="props.autocapitalize"
-          :autofocus="props.autofocus"
-          :name="props.name"
-          :readonly="props.readonly"
-          :disabled="props.disabled"
-          :minlength="props.minlength"
-          :maxlength="props.maxlength"
-          :aria-label="props.hideLabel ? props.label : undefined"
-          :title="props.hideLabel ? props.label : undefined"
-          @input="handleInput"
-          @change="handleChange"
-          @focus="emit('focus')"
-          @blur="emit('blur')"
-        ></textarea>
-        <!-- eslint-enable vuejs-accessibility/no-autofocus -->
-      </div>
+      <template #default="{ id }">
+        <div class="onyx-textarea__wrapper" :data-autosize-value="value">
+          <!-- eslint-disable vuejs-accessibility/no-autofocus -
+          We want to provide the flexibility to have the autofocus property.
+          The JSDoc description includes a warning that it should be used carefully.
+          -->
+          <textarea
+            :id="id"
+            v-model="value"
+            v-custom-validity
+            class="onyx-textarea__native"
+            :class="{ 'onyx-textarea__native--no-resize': props.disableManualResize }"
+            :placeholder="props.placeholder"
+            :required="props.required"
+            :autocapitalize="props.autocapitalize"
+            :autofocus="props.autofocus"
+            :name="props.name"
+            :readonly="props.readonly"
+            :disabled="props.disabled"
+            :minlength="props.minlength"
+            :maxlength="props.maxlength"
+            :aria-label="props.hideLabel ? props.label : undefined"
+            :title="props.hideLabel ? props.label : undefined"
+            @input="handleInput"
+            @change="handleChange"
+            @focus="emit('focus')"
+            @blur="emit('blur')"
+          ></textarea>
+          <!-- eslint-enable vuejs-accessibility/no-autofocus -->
+        </div>
+      </template>
     </OnyxFormElement>
   </div>
 </template>


### PR DESCRIPTION
Relates to #1568, #1348 

We now use a explicit label instead of an implicit one, as we now have components consisting of multiple interactive elements.
Our current approach with the implicit label creates issues, as it labels all interactive elements in it's slot.