### PR TITLE
fix(OnyxNavBar): make bottom border full width

### DIFF
--- a/.changeset/thin-badgers-compare.md
+++ b/.changeset/thin-badgers-compare.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxNavBar): make bottom border full width when grid width is limited

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.vue
@@ -199,10 +199,6 @@ $gap: var(--onyx-spacing-md);
     position: relative;
     container-type: size;
 
-    // sync with grid
-    max-width: var(--onyx-grid-max-width);
-    margin-inline: var(--onyx-grid-margin-inline);
-
     // implement bottom border with ::after so it does not add to the height
     &::after {
       content: " ";
@@ -221,6 +217,10 @@ $gap: var(--onyx-spacing-md);
       gap: $gap;
       height: 100%;
       padding-inline: var(--onyx-grid-margin);
+
+      // sync with grid
+      max-width: var(--onyx-grid-max-width);
+      margin-inline: var(--onyx-grid-margin-inline);
 
       &:has(.onyx-nav-bar__back) {
         grid-template-columns: max-content max-content 1fr auto;


### PR DESCRIPTION
Fix nav bar bottom bar to be full width when grid width is limited. Regression caused by #1566

![image](https://github.com/user-attachments/assets/532e216c-e745-474f-93f5-6310e8a3474e)


## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
