### PR TITLE
fix: prevent "Cannot find module '../composables/density' or its corresponding type declarations." error

### DIFF
--- a/.changeset/nice-clocks-kneel.md
+++ b/.changeset/nice-clocks-kneel.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": major
+---
+
+fix: prevent "Cannot find module '../composables/density' or its corresponding type declarations." error

--- a/.changeset/nice-clocks-kneel.md
+++ b/.changeset/nice-clocks-kneel.md
@@ -3,3 +3,5 @@
 ---
 
 fix: prevent "Cannot find module '../composables/density' or its corresponding type declarations." error
+
+We removed the `sit-onyx/types` alias, please import directly from `sit-onyx` instead

--- a/apps/docs/src/.vitepress/components/ColorPalette.vue
+++ b/apps/docs/src/.vitepress/components/ColorPalette.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { OnyxColor } from "sit-onyx/types";
+import type { OnyxColor } from "sit-onyx";
 import { capitalize, computed, ref } from "vue";
 import ColorPaletteValue, { type ColorPaletteValueProps } from "./ColorPaletteValue.vue";
 import DesignToken from "./DesignToken.vue";

--- a/packages/chartjs-plugin/src/utils.ts
+++ b/packages/chartjs-plugin/src/utils.ts
@@ -1,4 +1,4 @@
-import type { OnyxColor } from "sit-onyx/types";
+import type { OnyxColor } from "sit-onyx";
 
 export const QUANTITATIVE_COLOR_STEPS = [
   100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200,

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -23,7 +23,6 @@
     "./locales/*": "./src/i18n/locales/*",
     "./src/styles/*": "./src/styles/*",
     "./breakpoints.scss": "./src/styles/breakpoints.scss",
-    "./types": "./src/types/index.ts",
     "./themes/*": "./src/styles/themes/*"
   },
   "homepage": "https://onyx.schwarz",

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -8,8 +8,7 @@
   "files": [
     "dist",
     "src/i18n/locales",
-    "src/styles",
-    "src/types"
+    "src/styles"
   ],
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/storybook-utils/src/theme.ts
+++ b/packages/storybook-utils/src/theme.ts
@@ -1,5 +1,5 @@
+import { ONYX_BREAKPOINTS as RAW_ONYX_BREAKPOINTS, type OnyxBreakpoint } from "sit-onyx";
 import onyxVariables from "sit-onyx/themes/onyx.json";
-import { ONYX_BREAKPOINTS as RAW_ONYX_BREAKPOINTS, type OnyxBreakpoint } from "sit-onyx/types";
 import { create, type ThemeVars, type ThemeVarsPartial } from "storybook/internal/theming";
 import onyxLogo from "./assets/logo-onyx.svg";
 


### PR DESCRIPTION
We included the plain .ts files from the `src/types` folder because we used them in other packages like the storybook-utils.
But this causes build errors when used in projects because we import other types there which can not be resolved.

I removed the alias/mapping since we should not directly expose .ts files from our src folder in the build output.

![image](https://github.com/user-attachments/assets/6c77dbd2-956b-40ce-b39b-930736486220)


## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
