### PR TITLE
fix(OnyxPageLayout): bind root `style` and `class` attributes to `<main>` element

### DIFF
--- a/.changeset/quiet-taxis-pay.md
+++ b/.changeset/quiet-taxis-pay.md
@@ -3,3 +3,19 @@
 ---
 
 fix(OnyxPageLayout): bind root `style` and `class` attributes to `<main>` element
+
+This change now allows that you don't need redundant wrapper elements for your page to e.g. apply grid styles etc.
+
+Old:
+
+```html
+<OnyxPageLayout>
+  <div class="onyx-grid-container">Page content...</div>
+</OnyxPageLayout>
+```
+
+New:
+
+```html
+<OnyxPageLayout class="onyx-grid-container"> Page content... </OnyxPageLayout>
+```

--- a/.changeset/quiet-taxis-pay.md
+++ b/.changeset/quiet-taxis-pay.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxPageLayout): bind root `style` and `class` attributes to `<main>` element

--- a/apps/demo-app/src/views/FormDemoView.vue
+++ b/apps/demo-app/src/views/FormDemoView.vue
@@ -26,24 +26,22 @@ const invalidFormData = ref<FormData>({
 </script>
 
 <template>
-  <OnyxPageLayout>
-    <div class="onyx-grid-container">
-      <section class="header">
-        <OnyxHeadline is="h1" element="h1">Form Demos</OnyxHeadline>
+  <OnyxPageLayout class="onyx-grid-container">
+    <section class="header">
+      <OnyxHeadline is="h1" element="h1">Form Demos</OnyxHeadline>
 
-        <LanguageSelection v-model="locale" />
-      </section>
+      <LanguageSelection v-model="locale" />
+    </section>
 
-      <OnyxHeadline is="h2" element="h1">Initially Invalid example</OnyxHeadline>
-      <FormDemo v-model="invalidFormData" />
-      <pre class="state">State: {{ invalidFormData }}</pre>
+    <OnyxHeadline is="h2" element="h1">Initially Invalid example</OnyxHeadline>
+    <FormDemo v-model="invalidFormData" />
+    <pre class="state">State: {{ invalidFormData }}</pre>
 
-      <hr />
+    <hr />
 
-      <OnyxHeadline is="h2" element="h1">Initially Valid example</OnyxHeadline>
-      <FormDemo v-model="validFormData" />
-      <pre class="state">State: {{ validFormData }}</pre>
-    </div>
+    <OnyxHeadline is="h2" element="h1">Initially Valid example</OnyxHeadline>
+    <FormDemo v-model="validFormData" />
+    <pre class="state">State: {{ validFormData }}</pre>
   </OnyxPageLayout>
 </template>
 

--- a/apps/demo-app/src/views/HomeView.vue
+++ b/apps/demo-app/src/views/HomeView.vue
@@ -125,7 +125,7 @@ const tableData = [
 </script>
 
 <template>
-  <OnyxPageLayout>
+  <OnyxPageLayout :class="['page', `onyx-density-${activeDensityOption}`]">
     <template #sidebar>
       <div class="sidebar">
         <OnyxRadioGroup
@@ -151,140 +151,138 @@ const tableData = [
       </div>
     </template>
 
-    <div class="page" :class="[`onyx-density-${activeDensityOption}`]">
-      <section class="page__intro">
-        <OnyxHeadline is="h1">Component usages</OnyxHeadline>
-        <p>Each onyx component should be used at least once in this page.</p>
-      </section>
+    <section class="page__intro">
+      <OnyxHeadline is="h1">Component usages</OnyxHeadline>
+      <p>Each onyx component should be used at least once in this page.</p>
+    </section>
 
-      <div class="page__examples">
-        <OnyxAvatar v-if="show('OnyxAvatar')" label="John Doe" />
+    <div class="page__examples">
+      <OnyxAvatar v-if="show('OnyxAvatar')" label="John Doe" />
 
-        <OnyxBadge v-if="show('OnyxBadge')">Badge</OnyxBadge>
-        <OnyxButton v-if="show('OnyxButton')" label="Button" :skeleton="useSkeleton" />
+      <OnyxBadge v-if="show('OnyxBadge')">Badge</OnyxBadge>
+      <OnyxButton v-if="show('OnyxButton')" label="Button" :skeleton="useSkeleton" />
 
-        <template v-if="show('OnyxCheckboxGroup')">
-          <OnyxCheckboxGroup
-            v-model="checkboxState"
-            headline="Checkbox Group"
-            :options="minimalSelectOptions"
-            :skeleton="skeletonNumber"
-          />
-          <div v-if="!useSkeleton" class="onyx-text--small state-info">
-            OnyxCheckboxGroup state: {{ checkboxState }}
-          </div>
-        </template>
-
-        <OnyxEmpty v-if="show('OnyxEmpty')">No data available</OnyxEmpty>
-
-        <OnyxHeadline is="h1" v-if="show('OnyxHeadline')">Headline</OnyxHeadline>
-
-        <OnyxIcon v-if="show('OnyxIcon')" :icon="emojiHappy2" />
-
-        <OnyxIconButton
-          v-if="show('OnyxIconButton')"
-          label="Happy Emoji"
-          :icon="emojiHappy2"
-          :skeleton="useSkeleton"
+      <template v-if="show('OnyxCheckboxGroup')">
+        <OnyxCheckboxGroup
+          v-model="checkboxState"
+          headline="Checkbox Group"
+          :options="minimalSelectOptions"
+          :skeleton="skeletonNumber"
         />
+        <div v-if="!useSkeleton" class="onyx-text--small state-info">
+          OnyxCheckboxGroup state: {{ checkboxState }}
+        </div>
+      </template>
 
-        <OnyxInput
-          v-if="show('OnyxInput')"
-          label="Input"
-          :skeleton="useSkeleton"
-          label-tooltip="More information tooltip"
+      <OnyxEmpty v-if="show('OnyxEmpty')">No data available</OnyxEmpty>
+
+      <OnyxHeadline is="h1" v-if="show('OnyxHeadline')">Headline</OnyxHeadline>
+
+      <OnyxIcon v-if="show('OnyxIcon')" :icon="emojiHappy2" />
+
+      <OnyxIconButton
+        v-if="show('OnyxIconButton')"
+        label="Happy Emoji"
+        :icon="emojiHappy2"
+        :skeleton="useSkeleton"
+      />
+
+      <OnyxInput
+        v-if="show('OnyxInput')"
+        label="Input"
+        :skeleton="useSkeleton"
+        label-tooltip="More information tooltip"
+      />
+
+      <OnyxLink v-if="show('OnyxLink')" href="#" :skeleton="useSkeleton">Link</OnyxLink>
+
+      <SelectDemo
+        v-if="show('OnyxSelect')"
+        :select-options="selectOptions"
+        :use-skeleton="useSkeleton"
+      />
+
+      <OnyxLoadingIndicator v-if="show('OnyxLoadingIndicator')" />
+
+      <template v-if="show('OnyxRadioGroup')">
+        <OnyxRadioGroup
+          v-model="radioState"
+          headline="Radio group"
+          :options="minimalSelectOptions"
+          :skeleton="skeletonNumber"
         />
+        <div v-if="!useSkeleton" class="onyx-text--small state-info">
+          OnyxRadioGroup state: {{ radioState ?? "–" }}
+        </div>
+      </template>
 
-        <OnyxLink v-if="show('OnyxLink')" href="#" :skeleton="useSkeleton">Link</OnyxLink>
+      <OnyxSkeleton v-if="show('OnyxSkeleton')" class="skeleton" />
 
-        <SelectDemo
-          v-if="show('OnyxSelect')"
-          :select-options="selectOptions"
-          :use-skeleton="useSkeleton"
-        />
+      <OnyxStepper
+        v-if="show('OnyxStepper')"
+        v-model="stepperValue"
+        label="Stepper"
+        placeholder="0"
+        :skeleton="useSkeleton"
+      />
 
-        <OnyxLoadingIndicator v-if="show('OnyxLoadingIndicator')" />
+      <OnyxSwitch
+        v-if="show('OnyxSwitch')"
+        v-model="switchState"
+        :label="'Switch is ' + (switchState ? 'on' : 'off')"
+        :skeleton="useSkeleton"
+      />
 
-        <template v-if="show('OnyxRadioGroup')">
-          <OnyxRadioGroup
-            v-model="radioState"
-            headline="Radio group"
-            :options="minimalSelectOptions"
-            :skeleton="skeletonNumber"
-          />
-          <div v-if="!useSkeleton" class="onyx-text--small state-info">
-            OnyxRadioGroup state: {{ radioState ?? "–" }}
-          </div>
-        </template>
-
-        <OnyxSkeleton v-if="show('OnyxSkeleton')" class="skeleton" />
-
-        <OnyxStepper
-          v-if="show('OnyxStepper')"
-          v-model="stepperValue"
-          label="Stepper"
-          placeholder="0"
-          :skeleton="useSkeleton"
-        />
-
-        <OnyxSwitch
-          v-if="show('OnyxSwitch')"
-          v-model="switchState"
-          :label="'Switch is ' + (switchState ? 'on' : 'off')"
-          :skeleton="useSkeleton"
-        />
-
-        <template v-if="show('OnyxTable')">
-          <OnyxTable with-page-scrolling>
-            <template #head>
-              <tr>
-                <th v-for="col in tableColumns" :key="col">{{ col }}</th>
-              </tr>
-            </template>
-            <tr v-for="{ fruit, price, inventory } in tableData" :key="fruit">
-              <td>{{ fruit }}</td>
-              <td>{{ price }}</td>
-              <td>{{ inventory }}</td>
+      <template v-if="show('OnyxTable')">
+        <OnyxTable with-page-scrolling>
+          <template #head>
+            <tr>
+              <th v-for="col in tableColumns" :key="col">{{ col }}</th>
             </tr>
-          </OnyxTable>
+          </template>
+          <tr v-for="{ fruit, price, inventory } in tableData" :key="fruit">
+            <td>{{ fruit }}</td>
+            <td>{{ price }}</td>
+            <td>{{ inventory }}</td>
+          </tr>
+        </OnyxTable>
 
-          <OnyxTable>
-            <template #head>
-              <tr>
-                <th>Empty</th>
-                <th>Table</th>
-                <th>Example</th>
-              </tr>
-            </template>
+        <OnyxTable>
+          <template #head>
+            <tr>
+              <th>Empty</th>
+              <th>Table</th>
+              <th>Example</th>
+            </tr>
+          </template>
 
-            <!-- this demonstrates that the empty state works even when v-for is used -->
-            <tr v-for="(_row, index) in []" :key="index"></tr>
-          </OnyxTable>
-        </template>
+          <!-- this demonstrates that the empty state works even when v-for is used -->
+          <tr v-for="(_row, index) in []" :key="index"></tr>
+        </OnyxTable>
+      </template>
 
-        <OnyxTag v-if="show('OnyxTag')" label="Example tag" :icon="emojiHappy2" />
+      <OnyxTag v-if="show('OnyxTag')" label="Example tag" :icon="emojiHappy2" />
 
-        <OnyxTextarea
-          v-if="show('OnyxTextarea')"
-          label="Example textarea"
-          label-tooltip="More information tooltip"
-          :skeleton="useSkeleton"
-        />
+      <OnyxTextarea
+        v-if="show('OnyxTextarea')"
+        label="Example textarea"
+        label-tooltip="More information tooltip"
+        :skeleton="useSkeleton"
+      />
 
-        <OnyxTimer v-if="show('OnyxTimer')" label="Timer" :end-time="timerEndDate" />
+      <OnyxTimer v-if="show('OnyxTimer')" label="Timer" :end-time="timerEndDate" />
 
-        <OnyxButton
-          v-if="show('OnyxToast')"
-          label="Show toast"
-          @click="toast.show({ headline: 'Example toast', color: 'success' })"
-        />
+      <OnyxButton
+        v-if="show('OnyxToast')"
+        label="Show toast"
+        @click="toast.show({ headline: 'Example toast', color: 'success' })"
+      />
 
-        <OnyxTooltip v-if="show('OnyxTooltip')" text="Example tooltip text">
-          Hover me to show tooltip
-        </OnyxTooltip>
+      <OnyxTooltip v-if="show('OnyxTooltip')" text="Example tooltip text">
+        Hover me to show tooltip
+      </OnyxTooltip>
 
-        <!-- Add new components alphabetically. -->
-      </div>
+      <!-- Add new components alphabetically. -->
     </div>
   </OnyxPageLayout>
 </template>
@@ -299,9 +297,12 @@ const tableData = [
   height: calc(100%);
   width: 16rem;
 }
-.page {
-  padding: var(--onyx-spacing-xl);
 
+:deep(.page) {
+  padding: var(--onyx-spacing-xl);
+}
+
+.page {
   &__intro {
     margin-bottom: var(--onyx-spacing-lg);
   }
@@ -312,10 +313,12 @@ const tableData = [
     align-items: flex-start;
   }
 }
+
 .skeleton {
   height: 2rem;
   width: 8rem;
 }
+
 .state-info {
   color: var(--onyx-color-text-icons-neutral-soft);
 }

--- a/apps/docs/src/development/index.md
+++ b/apps/docs/src/development/index.md
@@ -96,9 +96,7 @@ import { OnyxAppLayout, OnyxPageLayout, OnyxNavBar } from "sit-onyx";
       <OnyxNavBar app-name="My app" />
     </template>
 
-    <OnyxPageLayout>
-      <div class="onyx-grid-container">Your page content here...</div>
-    </OnyxPageLayout>
+    <OnyxPageLayout class="onyx-grid-container"> Your page content here... </OnyxPageLayout>
   </OnyxAppLayout>
 </template>
 ```

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
@@ -289,12 +289,11 @@ Object.entries(ONYX_BREAKPOINTS).forEach(([breakpoint, width]) => {
           </template>
         </OnyxNavBar>
 
-        <OnyxPageLayout class="onyx-grid-container onyx-grid">
-          <div
-            class="onyx-grid-span-16"
-            style={{ backgroundColor: "var(--onyx-color-base-info-200)" }}
-          >
-            Page content...
+        <OnyxPageLayout>
+          <div class="onyx-grid-container">
+            <div style={{ backgroundColor: "var(--onyx-color-base-info-200)" }}>
+              Page content...
+            </div>
           </div>
         </OnyxPageLayout>
       </OnyxAppLayout>,

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
@@ -289,14 +289,12 @@ Object.entries(ONYX_BREAKPOINTS).forEach(([breakpoint, width]) => {
           </template>
         </OnyxNavBar>
 
-        <OnyxPageLayout>
-          <div class="onyx-grid-container onyx-grid">
-            <div
-              class="onyx-grid-span-16"
-              style={{ backgroundColor: "var(--onyx-color-base-info-200)" }}
-            >
-              Page content...
-            </div>
+        <OnyxPageLayout class="onyx-grid-container onyx-grid">
+          <div
+            class="onyx-grid-span-16"
+            style={{ backgroundColor: "var(--onyx-color-base-info-200)" }}
+          >
+            Page content...
           </div>
         </OnyxPageLayout>
       </OnyxAppLayout>,

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
@@ -273,7 +273,7 @@ Object.entries(ONYX_BREAKPOINTS).forEach(([breakpoint, width]) => {
     await page.setViewportSize({ width, height: 400 });
 
     await page.addStyleTag({
-      content: "body { margin: 0; }",
+      content: "body { margin: 0; background-color: var(--onyx-color-base-background-tinted); }",
     });
 
     await mount(
@@ -289,12 +289,8 @@ Object.entries(ONYX_BREAKPOINTS).forEach(([breakpoint, width]) => {
           </template>
         </OnyxNavBar>
 
-        <OnyxPageLayout>
-          <div class="onyx-grid-container">
-            <div style={{ backgroundColor: "var(--onyx-color-base-info-200)" }}>
-              Page content...
-            </div>
-          </div>
+        <OnyxPageLayout class="onyx-grid-container">
+          <div style={{ backgroundColor: "var(--onyx-color-base-info-200)" }}>Page content...</div>
         </OnyxPageLayout>
       </OnyxAppLayout>,
     );

--- a/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.ct.tsx
@@ -4,9 +4,6 @@ import OnyxPageLayout from "./OnyxPageLayout.vue";
 const demoSidebar = `<div style="min-width: 10rem;"></div>`;
 const demoDefault = `<div style="height: 100%; width: 100%;"></div>`;
 const demoFooter = `<div style="min-height: 4rem;"></div>`;
-const defaultConfig = {
-  slots: { default: demoDefault },
-};
 
 test.beforeEach(async ({ page }) => {
   await page.addStyleTag({
@@ -24,7 +21,7 @@ test.beforeEach(async ({ page }) => {
 test("should render standard page", async ({ mount, makeAxeBuilder }) => {
   // ARRANGE
   const component = await mount(OnyxPageLayout, {
-    ...defaultConfig,
+    slots: { default: demoDefault },
   });
 
   // ASSERT

--- a/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.ct.tsx
@@ -4,19 +4,22 @@ import OnyxPageLayout from "./OnyxPageLayout.vue";
 const demoSidebar = `<div style="min-width: 10rem;"></div>`;
 const demoDefault = `<div style="height: 100%; width: 100%;"></div>`;
 const demoFooter = `<div style="min-height: 4rem;"></div>`;
-const defaultProps = {
-  style: `
-  --background-color-sidebar: peachpuff;
-  --background-color-main: ivory;
-  --background-color-footer: olivedrab;
-  height: 100vh;
-  width: 100vw;
-  `,
-};
 const defaultConfig = {
-  props: defaultProps,
   slots: { default: demoDefault },
 };
+
+test.beforeEach(async ({ page }) => {
+  await page.addStyleTag({
+    content: `
+    body, #root { height: 100vh; width: 100vw; margin: 0; }
+    .onyx-page {
+      --background-color-sidebar: peachpuff;
+      --background-color-main: ivory;
+      --background-color-footer: olivedrab;
+    }
+    `,
+  });
+});
 
 test("should render standard page", async ({ mount, makeAxeBuilder }) => {
   // ARRANGE
@@ -37,7 +40,6 @@ test("should render standard page", async ({ mount, makeAxeBuilder }) => {
 test("should render with sidebar", async ({ mount, makeAxeBuilder }) => {
   // ARRANGE
   const component = await mount(OnyxPageLayout, {
-    props: defaultProps,
     slots: { default: demoDefault, sidebar: demoSidebar },
   });
 
@@ -54,7 +56,6 @@ test("should render with sidebar", async ({ mount, makeAxeBuilder }) => {
 test("should render with footer", async ({ mount, makeAxeBuilder }) => {
   // ARRANGE
   const component = await mount(OnyxPageLayout, {
-    props: defaultProps,
     slots: { default: demoDefault, footer: demoFooter },
   });
 
@@ -71,7 +72,6 @@ test("should render with footer", async ({ mount, makeAxeBuilder }) => {
 test("should render with footer below sidebar", async ({ mount, makeAxeBuilder }) => {
   // ARRANGE
   const component = await mount(OnyxPageLayout, {
-    props: defaultProps,
     slots: { default: demoDefault, sidebar: demoSidebar, footer: demoFooter },
   });
 
@@ -88,7 +88,7 @@ test("should render with footer below sidebar", async ({ mount, makeAxeBuilder }
 test("should render with footer aside sidebar", async ({ mount, makeAxeBuilder }) => {
   // ARRANGE
   const component = await mount(OnyxPageLayout, {
-    props: { ...defaultProps, footerAsideSidebar: true },
+    props: { footerAsideSidebar: true },
     slots: { default: demoDefault, sidebar: demoSidebar, footer: demoFooter },
   });
 

--- a/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.stories.ts
@@ -7,6 +7,8 @@ import OnyxPageLayout from "./OnyxPageLayout.vue";
  * Layout component that structures your page.
  * Includes slots for a sidebar, page content, footer and notifications.
  * Recommended to use on view/page level of an application.
+ *
+ * Note: If you are binding custom classes directly on `OnyxPageLayout` with `<style scoped>`, make sure use `:deep()` as selector because the classes will be bind to the `<main>` element inside the page layout, not the page layout wrapper element.
  */
 const meta: Meta<typeof OnyxPageLayout> = {
   title: "Layout/PageLayout",
@@ -49,7 +51,7 @@ type Story = StoryObj<typeof OnyxPageLayout>;
 /** A standard page with some content. */
 export const Default = {
   args: {
-    default: () => h("div", "This is the page content."),
+    default: () => "This is the page content.",
   },
 } satisfies Story;
 

--- a/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.vue
+++ b/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { computed } from "vue";
+import { useRootAttrs } from "../../utils/attrs";
 import type { OnyxPageLayoutProps } from "./types";
 
 const props = defineProps<OnyxPageLayoutProps>();
@@ -23,15 +24,18 @@ const pageModifier = computed(() => {
   }
   return "onyx-page--footer-full";
 });
+
+defineOptions({ inheritAttrs: false });
+const { rootAttrs, restAttrs } = useRootAttrs();
 </script>
 
 <template>
-  <div class="onyx-page" :class="pageModifier">
+  <div v-bind="restAttrs" :class="['onyx-page', pageModifier]">
     <aside v-if="slots.sidebar && !props.hideSidebar" class="onyx-page__sidebar">
       <slot name="sidebar"></slot>
     </aside>
 
-    <main class="onyx-page__main">
+    <main v-bind="rootAttrs" class="onyx-page__main">
       <slot></slot>
     </main>
 

--- a/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.vue
+++ b/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.vue
@@ -86,6 +86,7 @@ const { rootAttrs, restAttrs } = useRootAttrs();
       overflow: hidden auto;
       position: relative;
       background-color: var(--background-color-main);
+      width: 100%;
     }
     &__footer {
       grid-area: footer;


### PR DESCRIPTION
closes #1650

Bind `style` and `class` attributes for `OnyxPageLayout` to nested `<main>` element instead of page layout component wrapper.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
