### PR TITLE
chore: ignore major `@types/node` update for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
       - dependency-name: eslint
         update-types: [version-update:semver-major]
 
+      # keep this in sync with .node-version file, if we e.g. use node 20, we do not want to update the types to latest 22
+      - dependency-name: "@types/node"
+        update-types: [version-update:semver-major]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Ignore major versions of `@types/node` for dependabot. We are using LTS node version which is currently 20 so we do not want to update the node types to the latest 22 (see #1648)
