### PR TITLE
fix(OnyxSelect): remove incorrect usage of aria-busy

### DIFF
--- a/.changeset/empty-dingos-hug.md
+++ b/.changeset/empty-dingos-hug.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxSelect): remove incorrect usage of `aria-busy`

--- a/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
+++ b/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
@@ -313,11 +313,7 @@ const selectInputProps = computed(() => {
       @validity-change="emit('validityChange', $event)"
     />
 
-    <div
-      :class="['onyx-select', densityClass, open ? 'onyx-select--open' : '']"
-      :inert="!open"
-      :aria-busy="props.loading"
-    >
+    <div :class="['onyx-select', densityClass, open ? 'onyx-select--open' : '']" :inert="!open">
       <div v-scroll-end class="onyx-select__wrapper" tabindex="-1">
         <!-- model-value is set here, as it is written be the onAutocomplete callback -->
         <OnyxMiniSearch


### PR DESCRIPTION
closes #1146

According to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy), `aria-busy` must only be used inside a `aria-live` region. Since the `OnyxSelect` has no live region, I removed the incorrect usage of the `aria-busy` attribute.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
