### PR TITLE
chore(CI): always run full test matrix, even when there are failing tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   playwright:
     strategy:
+      fail-fast: false
       matrix:
         # to optimize the speed of the screenshot generation, we are using Playwright sharding
         # to split up the tests in smaller chunks and run them in parallel
@@ -117,6 +118,9 @@ jobs:
       - name: Merge into HTML Report
         run: find . -type d -name blob-report | xargs -n1 -I {} sh -c 'npx playwright merge-reports --reporter html {} && mv playwright-report {}/../playwright-report'
 
+      # The html report can be manually downloaded and after extraction a static file server can be used to show the results.
+      # A file server is necessary, otherwise not all features are supported.
+      # E.g. use `python3 -m http.server` or `npx serve` to quick and easily start one.
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
- We set [fail-fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) to `false`, so that all shards run the tests to completion.
This way, we will have a full report at the end of the test run.
- Added comment explaining how to use the test-report