### PR TITLE
chore: ignore `@vue/repl` in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,10 @@ updates:
       - dependency-name: "@types/node"
         update-types: [version-update:semver-major]
 
+      # TODO: remove when https://github.com/vuejs/repl/issues/269 is fixed
+      - dependency-name: "@vue/repl"
+        update-types: [version-update:semver-minor]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Follow up for #1681

Ignore updates for `@vue/repl` until the bug is fixed. We need it to be pinned to `4.2.1` for now.
