### PR TITLE
chore: disable incremental builds

### DIFF
--- a/packages/sit-onyx/tsconfig.app.json
+++ b/packages/sit-onyx/tsconfig.app.json
@@ -4,8 +4,6 @@
   "exclude": ["src/**/*.ct.*", "src/**/*.spec.*", "src/**/*.stories.ts"],
   "compilerOptions": {
     "composite": true,
-    "incremental": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "rootDir": "./src",
     "outDir": "./dist",
     "baseUrl": "."

--- a/packages/sit-onyx/tsconfig.node.json
+++ b/packages/sit-onyx/tsconfig.node.json
@@ -10,7 +10,6 @@
   ],
   "compilerOptions": {
     "composite": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "types": ["node", "vite/client"],

--- a/packages/sit-onyx/tsconfig.playwright.json
+++ b/packages/sit-onyx/tsconfig.playwright.json
@@ -4,7 +4,6 @@
   "exclude": [],
   "compilerOptions": {
     "composite": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.playwright.tsbuildinfo",
     "types": ["node"]
   }
 }

--- a/packages/sit-onyx/tsconfig.vitest.json
+++ b/packages/sit-onyx/tsconfig.vitest.json
@@ -4,7 +4,6 @@
   "exclude": [],
   "compilerOptions": {
     "composite": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
     "types": ["node", "jsdom"]
   }
 }


### PR DESCRIPTION
Relates to #1668 

The incremental builds cause several errors (see below): Since we are using turbo repo which already caches the build, I don't think incremental builds deliver a real benefit to us.

- missing types when building multiple times: If building `sit-onyx` locally more than once, no types will be generated which causes build errors
- Running `pnpm build:all` or `pnpm build:all --force` in the monorepo fails
