### PR TITLE
fix: enable eslint rule `vue/no-multiple-template-root`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -36,7 +36,6 @@ module.exports = {
         caughtErrorsIgnorePattern: "^_",
       },
     ],
-
     // see https://eslint.vuejs.org/rules/html-self-closing
     "vue/html-self-closing": [
       "error",
@@ -62,5 +61,8 @@ module.exports = {
         },
       },
     ],
+    // while it is technical supported in Vue 3 to have multiple template roots, we want to prevent this
+    // since it can lead to unexpected issues when e.g. applying "class" or "style" attributes on such components
+    "vue/no-multiple-template-root": "error",
   },
 };

--- a/apps/demo-app/src/components/SelectDemo.vue
+++ b/apps/demo-app/src/components/SelectDemo.vue
@@ -53,58 +53,60 @@ const filteredOptions = computed<SelectOption[]>(() =>
 </script>
 
 <template>
-  <div class="select-demo">
-    <OnyxSelect
-      v-model="selectState"
-      label="Example select"
-      list-label="Example listbox list"
-      :options="selectOptions"
-      :skeleton="useSkeleton"
-    />
-    <OnyxSelect
-      v-model="groupedSelectState"
-      label="Example grouped select"
-      list-label="Example listbox list"
-      :options="groupedSelectOptions"
-      :skeleton="useSkeleton"
-    />
-    <OnyxSelect
-      v-model="multiselectState"
-      label="Example multiselect"
-      list-label="Example listbox list"
-      :multiple="true"
-      :with-check-all="true"
-      :options="selectOptions"
-      :skeleton="useSkeleton"
-    />
-    <OnyxSelect
-      v-model="lazyLoadedState"
-      label="Lazy loading with custom input text"
-      list-label="Lazy loaded list"
-      :lazy-loading="{ enabled: true }"
-      :value-label="`Lazy option ${lazyLoadedState}`"
-      :options="lazyLoadedOptions"
-      :skeleton="useSkeleton"
-      @lazy-load="lazyLoadedLength += 5"
-    />
-    <OnyxSelect
-      v-model="filteredState"
-      v-model:search-term="filterSearchTerm"
-      label="Custom filtering, search for text or number"
-      list-label="Filtered list"
-      :value-label="filterValueLabel"
-      :options="filteredOptions"
-      :skeleton="useSkeleton"
-      with-search
-    />
-  </div>
+  <div>
+    <div class="select-demo">
+      <OnyxSelect
+        v-model="selectState"
+        label="Example select"
+        list-label="Example listbox list"
+        :options="selectOptions"
+        :skeleton="useSkeleton"
+      />
+      <OnyxSelect
+        v-model="groupedSelectState"
+        label="Example grouped select"
+        list-label="Example listbox list"
+        :options="groupedSelectOptions"
+        :skeleton="useSkeleton"
+      />
+      <OnyxSelect
+        v-model="multiselectState"
+        label="Example multiselect"
+        list-label="Example listbox list"
+        :multiple="true"
+        :with-check-all="true"
+        :options="selectOptions"
+        :skeleton="useSkeleton"
+      />
+      <OnyxSelect
+        v-model="lazyLoadedState"
+        label="Lazy loading with custom input text"
+        list-label="Lazy loaded list"
+        :lazy-loading="{ enabled: true }"
+        :value-label="`Lazy option ${lazyLoadedState}`"
+        :options="lazyLoadedOptions"
+        :skeleton="useSkeleton"
+        @lazy-load="lazyLoadedLength += 5"
+      />
+      <OnyxSelect
+        v-model="filteredState"
+        v-model:search-term="filterSearchTerm"
+        label="Custom filtering, search for text or number"
+        list-label="Filtered list"
+        :value-label="filterValueLabel"
+        :options="filteredOptions"
+        :skeleton="useSkeleton"
+        with-search
+      />
+    </div>
 
-  <div v-if="!useSkeleton" class="onyx-text--small state-info">
-    <div>OnyxSelect single state: {{ selectState ?? "–" }}</div>
-    <div>OnyxSelect single grouped state: {{ groupedSelectState ?? "–" }}</div>
-    <div>OnyxSelect multiselect state: {{ multiselectState ?? "–" }}</div>
-    <div>OnyxSelect lazy load state: {{ lazyLoadedState ?? "–" }}</div>
-    <div>OnyxSelect filter state: {{ filteredState ?? "–" }}</div>
+    <div v-if="!useSkeleton" class="onyx-text--small state-info">
+      <div>OnyxSelect single state: {{ selectState ?? "–" }}</div>
+      <div>OnyxSelect single grouped state: {{ groupedSelectState ?? "–" }}</div>
+      <div>OnyxSelect multiselect state: {{ multiselectState ?? "–" }}</div>
+      <div>OnyxSelect lazy load state: {{ lazyLoadedState ?? "–" }}</div>
+      <div>OnyxSelect filter state: {{ filteredState ?? "–" }}</div>
+    </div>
   </div>
 </template>
 

--- a/apps/playground/src/template/NewFile.vue
+++ b/apps/playground/src/template/NewFile.vue
@@ -5,5 +5,5 @@ const message = ref("Hello World");
 </script>
 
 <template>
-  {{ message }}
+  <div>{{ message }}</div>
 </template>

--- a/packages/nuxt/test/fixtures/i18n/pages/optional.vue
+++ b/packages/nuxt/test/fixtures/i18n/pages/optional.vue
@@ -1,3 +1,5 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 
-<template>Optional: {{ $t("onyx.optional") }}</template>
+<template>
+  <div>Optional: {{ $t("onyx.optional") }}</div>
+</template>

--- a/packages/nuxt/test/fixtures/i18n/pages/overwrite.vue
+++ b/packages/nuxt/test/fixtures/i18n/pages/overwrite.vue
@@ -1,3 +1,5 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 
-<template>Overwrite: {{ $t("onyx.navigation.goBack") }}</template>
+<template>
+  <div>Overwrite: {{ $t("onyx.navigation.goBack") }}</div>
+</template>

--- a/packages/nuxt/test/fixtures/i18n/pages/test.vue
+++ b/packages/nuxt/test/fixtures/i18n/pages/test.vue
@@ -1,3 +1,5 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 
-<template>Test: {{ $t("test") }}</template>
+<template>
+  <div>Test: {{ $t("test") }}</div>
+</template>

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
@@ -28,20 +28,22 @@ test("Behaviour test", async ({ mount }) => {
     <OnyxNavBar appName="App name" logoUrl={MOCK_PLAYWRIGHT_LOGO_URL}>
       <OnyxNavButton label="Main One">
         <template v-slot:children>
-          <OnyxNavItem>First</OnyxNavItem>
-          <OnyxNavItem>Second</OnyxNavItem>
+          <OnyxNavItem label="First" />
+          <OnyxNavItem label="Second" />
         </template>
       </OnyxNavButton>
       <OnyxNavButton label="Main Two">
         <template v-slot:children>
-          <OnyxNavItem>Third</OnyxNavItem>
-          <OnyxNavItem>Fourth</OnyxNavItem>
+          <OnyxNavItem label="Third" />
+          <OnyxNavItem label="Fourth" />
         </template>
       </OnyxNavButton>
     </OnyxNavBar>,
   );
   const nav = component.getByRole("navigation");
   const buttons = nav.getByRole("menuitem");
+
+  await expect(nav).toBeVisible();
 
   await navigationTesting({ nav, buttons });
 });

--- a/packages/sit-onyx/src/components/examples/GridPlayground/GridPlayground.vue
+++ b/packages/sit-onyx/src/components/examples/GridPlayground/GridPlayground.vue
@@ -77,72 +77,76 @@ const handleAddModifier = () => {
 </script>
 
 <template>
-  <form class="onyx-grid-playground" @submit.prevent>
-    <fieldset class="onyx-grid-playground__settings">
-      <legend>Grid options</legend>
-      <label><input v-model="isCentered" type="checkbox" />Centered</label>
-      <label><input v-model="is20Xl" type="checkbox" />XL with 20 columns</label>
-      <label><input v-model="isMaxMd" type="checkbox" />Max md width</label>
-      <label><input v-model="isMaxLg" type="checkbox" />Max lg width</label>
-    </fieldset>
-    <fieldset class="onyx-grid-playground__settings">
-      <legend>Selected Grid Element options</legend>
-      <template v-if="selectedElement">
-        <button type="button" @click="deleteElement()">Delete Grid Element</button>
-        <div v-for="(props, i) in selectedElement" :key="i">
-          <label>
-            Breakpoint:
-            <select v-model="props.breakpoint">
-              <option :value="undefined">None</option>
-              <option v-for="bp in Object.keys(BREAKPOINTS)" :key="bp" :value="bp">{{ bp }}</option>
-            </select>
-          </label>
-          <label>
-            Columns:
-            <input
-              id="number"
-              v-model="props.spans"
-              type="number"
-              :max="(props.breakpoint && BREAKPOINTS[props.breakpoint]?.cols) ?? 20"
-            />
-          </label>
-          <button type="button" @click="handleDeleteModifier">Delete modifier</button>
-        </div>
-        <button type="button" @click="handleAddModifier">Add Grid Modifier</button>
-      </template>
-      <template v-else>
-        <span>Click an existing grid element to change its properties</span>
-      </template>
-    </fieldset>
-  </form>
-  <GridElementsIndicator v-if="gridSettings" :settings="gridSettings" />
-  <main
-    ref="gridElement"
-    :class="{
-      'onyx-grid': true,
-      'onyx-grid-container': true,
-      'onyx-grid-center': isCentered,
-      'onyx-grid-xl-20': is20Xl,
-      'onyx-grid-max-md': isMaxMd,
-      'onyx-grid-max-lg': isMaxLg,
-    }"
-  >
-    <GridElement
-      v-for="(element, i) in elements"
-      :key="i"
-      :settings="element"
-      :selected="element === selectedElement"
-      @click="selectedElement = elements[i]"
-    />
-
-    <button
-      type="button"
-      class="onyx-grid-playground__add-new"
-      @click="elements.push([{ spans: 4 }])"
+  <div class="onyx-grid-playground">
+    <form @submit.prevent>
+      <fieldset class="onyx-grid-playground__settings">
+        <legend>Grid options</legend>
+        <label><input v-model="isCentered" type="checkbox" />Centered</label>
+        <label><input v-model="is20Xl" type="checkbox" />XL with 20 columns</label>
+        <label><input v-model="isMaxMd" type="checkbox" />Max md width</label>
+        <label><input v-model="isMaxLg" type="checkbox" />Max lg width</label>
+      </fieldset>
+      <fieldset class="onyx-grid-playground__settings">
+        <legend>Selected Grid Element options</legend>
+        <template v-if="selectedElement">
+          <button type="button" @click="deleteElement()">Delete Grid Element</button>
+          <div v-for="(props, i) in selectedElement" :key="i">
+            <label>
+              Breakpoint:
+              <select v-model="props.breakpoint">
+                <option :value="undefined">None</option>
+                <option v-for="bp in Object.keys(BREAKPOINTS)" :key="bp" :value="bp">
+                  {{ bp }}
+                </option>
+              </select>
+            </label>
+            <label>
+              Columns:
+              <input
+                id="number"
+                v-model="props.spans"
+                type="number"
+                :max="(props.breakpoint && BREAKPOINTS[props.breakpoint]?.cols) ?? 20"
+              />
+            </label>
+            <button type="button" @click="handleDeleteModifier">Delete modifier</button>
+          </div>
+          <button type="button" @click="handleAddModifier">Add Grid Modifier</button>
+        </template>
+        <template v-else>
+          <span>Click an existing grid element to change its properties</span>
+        </template>
+      </fieldset>
+    </form>
+    <GridElementsIndicator v-if="gridSettings" :settings="gridSettings" />
+    <main
+      ref="gridElement"
+      :class="{
+        'onyx-grid': true,
+        'onyx-grid-container': true,
+        'onyx-grid-center': isCentered,
+        'onyx-grid-xl-20': is20Xl,
+        'onyx-grid-max-md': isMaxMd,
+        'onyx-grid-max-lg': isMaxLg,
+      }"
     >
-      +
-    </button>
-  </main>
+      <GridElement
+        v-for="(element, i) in elements"
+        :key="i"
+        :settings="element"
+        :selected="element === selectedElement"
+        @click="selectedElement = elements[i]"
+      />
+
+      <button
+        type="button"
+        class="onyx-grid-playground__add-new"
+        @click="elements.push([{ spans: 4 }])"
+      >
+        +
+      </button>
+    </main>
+  </div>
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
While it is technical supported in Vue 3 to have multiple template roots, we want to prevent this since it can lead to unexpected issues when e.g. applying "class" or "style" attributes on such components
