### PR TITLE
fix(vitepress-theme): correctly import fonts

### DIFF
--- a/.changeset/tricky-carrots-run.md
+++ b/.changeset/tricky-carrots-run.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/vitepress-theme": patch
+---
+
+fix(vitepress-theme): correctly import fonts

--- a/packages/vitepress-theme/package.json
+++ b/packages/vitepress-theme/package.json
@@ -27,10 +27,12 @@
     "build": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@fontsource-variable/source-code-pro": ">= 5",
-    "@fontsource-variable/source-sans-3": ">= 5",
     "sass": ">= 1",
     "sit-onyx": "workspace:^",
     "vitepress": ">= 1.0.0"
+  },
+  "dependencies": {
+    "@fontsource-variable/source-code-pro": "^5.0.20",
+    "@fontsource-variable/source-sans-3": "^5.0.22"
   }
 }

--- a/packages/vitepress-theme/src/index.scss
+++ b/packages/vitepress-theme/src/index.scss
@@ -1,3 +1,5 @@
+@use "@fontsource-variable/source-code-pro";
+@use "@fontsource-variable/source-sans-3";
 @use "sit-onyx/src/styles/index.scss";
 @use "mixins.scss";
 

--- a/packages/vitepress-theme/src/index.ts
+++ b/packages/vitepress-theme/src/index.ts
@@ -1,8 +1,6 @@
 import type { Theme } from "vitepress";
 import DefaultTheme from "vitepress/theme";
 
-import "@fontsource-variable/source-code-pro";
-import "@fontsource-variable/source-sans-3";
 import "./index.scss";
 
 const theme: Theme = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,11 +326,11 @@ importers:
   packages/vitepress-theme:
     dependencies:
       '@fontsource-variable/source-code-pro':
-        specifier: '>= 5'
-        version: 5.0.19
+        specifier: ^5.0.20
+        version: 5.0.20
       '@fontsource-variable/source-sans-3':
-        specifier: '>= 5'
-        version: 5.0.21
+        specifier: ^5.0.22
+        version: 5.0.22
       sass:
         specifier: '>= 1'
         version: 1.77.8
@@ -1741,14 +1741,8 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@fontsource-variable/source-code-pro@5.0.19':
-    resolution: {integrity: sha512-mmeEykZsLRuFsklfamKVwahnWNpdAzpvGcOPPiFUydSnrd/9aEXy/HzOSYCOOTCP667L4nio9rB7wO3KVO5J/w==}
-
   '@fontsource-variable/source-code-pro@5.0.20':
     resolution: {integrity: sha512-ib79xMlEi9TJbeV7p0PoqCKVgFRuisQgYOluIa27cWChpBjTBQqK2A5Trs9zTmjuS3toz5S3H4f5s9v9fMfE3w==}
-
-  '@fontsource-variable/source-sans-3@5.0.21':
-    resolution: {integrity: sha512-HG2YLa3xs6+wrQrJoiborhX3q5spamGR1xe2QFkEbhD1QEKQ6goXKa+wccybDUrCBrKVOOeNqZQr5DkW0bqb1g==}
 
   '@fontsource-variable/source-sans-3@5.0.22':
     resolution: {integrity: sha512-KF/7gND9nMPy5bdX014TQ8ETt/BdTc/I7KpK2QtiliG+u04/n3TAmWDCiE8kUA7V4X9xp2D3TUvDJntOijRDpA==}
@@ -8438,11 +8432,7 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@fontsource-variable/source-code-pro@5.0.19': {}
-
   '@fontsource-variable/source-code-pro@5.0.20': {}
-
-  '@fontsource-variable/source-sans-3@5.0.21': {}
 
   '@fontsource-variable/source-sans-3@5.0.22': {}
 


### PR DESCRIPTION
Relates to #1709 

Looks like we are importing the fotns incorrectly in our vitepress theme because they are not recognized/applied when using the theme, see screenshot below. I also moved the font dependencies from peerDependencies to "regular" dependencies.
![image](https://github.com/user-attachments/assets/0c72017b-5c28-4a9b-8c5b-d7c0a1c96a2d)


## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
