### PR TITLE
test: fix "window.matchMedia is not a function" error in unit tests

### DIFF
--- a/.changeset/yellow-cameras-turn.md
+++ b/.changeset/yellow-cameras-turn.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+test: fix "window.matchMedia is not a function" error in unit tests

--- a/packages/headless/src/utils/vitest.ts
+++ b/packages/headless/src/utils/vitest.ts
@@ -1,6 +1,6 @@
-import { vi, type Awaitable } from "vitest";
+import { vi } from "vitest";
 
-type Callback = () => Awaitable<void>;
+type Callback = () => void | (() => Promise<void>);
 
 /**
  * Mocks the following vue lifecycle functions:

--- a/packages/sit-onyx/src/composables/useResizeObserver.spec.ts
+++ b/packages/sit-onyx/src/composables/useResizeObserver.spec.ts
@@ -7,6 +7,7 @@ vi.mock("vue", async (importOriginal) => {
     ...(await importOriginal()),
     // this will only affect "foo" outside of the original module
     onBeforeMount: (callback) => callback(),
+    onBeforeUnmount: vi.fn(),
   } satisfies typeof import("vue");
 });
 

--- a/packages/sit-onyx/src/composables/useRipple.spec.ts
+++ b/packages/sit-onyx/src/composables/useRipple.spec.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import { computed, ref } from "vue";
 import { useRipple, type RippleConfig } from "./useRipple";
 
-describe("useRipple", () => {
-  vi.stubGlobal(
-    "matchMedia",
-    vi.fn(() => ({ matches: true })),
-  );
+vi.mock("vue", async (original) => ({
+  ...((await original()) as typeof import("vue")),
+  onBeforeMount: vi.fn((callback) => callback()),
+}));
 
+describe("useRipple", () => {
   const rect = {
     x: 0,
     y: 0,

--- a/packages/sit-onyx/src/composables/useRipple.ts
+++ b/packages/sit-onyx/src/composables/useRipple.ts
@@ -68,7 +68,8 @@ export const useRipple = (config: Ref<RippleConfig>) => {
   // so we need to make sure to only call it in "onBeforeMount"
   onBeforeMount(() => {
     // detect if NO pointer device exists, so we use touch events
-    if (window.matchMedia("pointer: none").matches) {
+    // we check if "window.matchMedia" exists first because it may not be available in e.g. unit tests
+    if (window.matchMedia && window.matchMedia("pointer: none").matches) {
       events.value = {
         touchstart: startRipple,
         touchend: hideRipples,

--- a/packages/sit-onyx/src/composables/useRipple.ts
+++ b/packages/sit-onyx/src/composables/useRipple.ts
@@ -68,8 +68,8 @@ export const useRipple = (config: Ref<RippleConfig>) => {
   // so we need to make sure to only call it in "onBeforeMount"
   onBeforeMount(() => {
     // detect if NO pointer device exists, so we use touch events
-    // we check if "window.matchMedia" exists first because it may not be available in e.g. unit tests
-    if (window.matchMedia && window.matchMedia("pointer: none").matches) {
+    // we check if "window.matchMedia" exists first (with the ? operator) because it may not be available in e.g. unit tests
+    if (window.matchMedia?.("pointer: none").matches) {
       events.value = {
         touchstart: startRipple,
         touchend: hideRipples,


### PR DESCRIPTION
Relates to #363

- fix "window.matchMedia is not a function" when using the `OnyxButton` in unit tests so projcets don't have to mock the function all the time
- remove 2 onyx internal unit test warnings

![image](https://github.com/user-attachments/assets/08817aa3-5855-4c14-aff3-2a75290f1c64)


## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
