### PR TITLE
chore: fix codeowners for icons

### DIFF
--- a/.github/workflows/import-figma-icons.yml
+++ b/.github/workflows/import-figma-icons.yml
@@ -43,7 +43,6 @@ jobs:
           title: "feat: update Figma icons"
           body: This is an auto-generated pull request. All Figma icons have been updated.
           branch-suffix: short-commit-hash # needed to not override other pull requests created via workflows
-          team-reviewers: "@SchwarzIT/onyx-ux"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: ${{ github.ref_name }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,5 @@
 # Global code owners (developers)
 * @SchwarzIT/onyx-dev
+
+# UX code owners
+/packages/icons/src/assets/ @SchwarzIT/onyx-ux

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,4 @@
 
 # UX code owners
 /packages/icons/src/assets/ @SchwarzIT/onyx-ux
+/packages/icons/src/metadata.json @SchwarzIT/onyx-ux


### PR DESCRIPTION
Relates to #939

The automated requested UX reviewers for the icons did not work, see [this workflow run](https://github.com/SchwarzIT/onyx/actions/runs/10521665935). I added UX as codeowners instead so they are automatically requested for changes