### PR TITLE
fix(enhanceEventArgTypes): log actions/events without "on" prefix

### DIFF
--- a/.changeset/sharp-rules-sing.md
+++ b/.changeset/sharp-rules-sing.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/storybook-utils": patch
+---
+
+fix(enhanceEventArgTypes): log actions/events without "on" prefix

--- a/packages/storybook-utils/src/actions.spec.ts
+++ b/packages/storybook-utils/src/actions.spec.ts
@@ -1,0 +1,29 @@
+import type { StoryContextForEnhancers } from "storybook/internal/types";
+import { expect, test } from "vitest";
+import { enhanceEventArgTypes } from "./actions";
+
+test("should enhance event arg types", () => {
+  const argTypes = {
+    someProp: {
+      name: "someProp",
+      table: { category: "props" },
+    },
+    click: {
+      name: "click",
+      table: { category: "events" },
+    },
+  } satisfies StoryContextForEnhancers["argTypes"];
+
+  const result = enhanceEventArgTypes({
+    argTypes,
+  } as unknown as StoryContextForEnhancers);
+
+  expect(result).toStrictEqual({
+    ...argTypes,
+    onClick: {
+      name: "onClick",
+      table: { disable: true },
+      action: "click",
+    },
+  });
+});

--- a/packages/storybook-utils/src/actions.ts
+++ b/packages/storybook-utils/src/actions.ts
@@ -16,8 +16,8 @@ export const enhanceEventArgTypes: ArgTypesEnhancer = ({ argTypes }) => {
       }
       argTypes[eventName] = {
         name: eventName,
-        table: { disable: true },
-        action: eventName,
+        table: { disable: true }, // do not add a second table entry for event name prefixed with "on"
+        action: name,
       };
     });
   return argTypes;


### PR DESCRIPTION
Relates to #1725

In #1725 we implemented auto actions for all component events. However, the actions/Events are logged with an "on" prefix, e.g. "onClick" instead of "click" although the "real" component event name is just "click" as it is defined with `defineEmits()`

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
