### PR TITLE
chore: fix icon library release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,7 +45,8 @@ jobs:
         run: pnpm run format:check:all
 
       - name: 🛠️ Build packages
-        run: pnpm run build:all
+        # TODO: remove --filter
+        run: pnpm run build:all --filter=!docs
         env:
           # skip fetching statistics for our docs here so we don't exceed GitHub rate limits which may fail in CI
           VITEPRESS_SKIP_GITHUB_FETCH: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,8 +45,7 @@ jobs:
         run: pnpm run format:check:all
 
       - name: 🛠️ Build packages
-        # TODO: remove --filter
-        run: pnpm run build:all --filter=!docs
+        run: pnpm run build:all
         env:
           # skip fetching statistics for our docs here so we don't exceed GitHub rate limits which may fail in CI
           VITEPRESS_SKIP_GITHUB_FETCH: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,23 +39,13 @@ jobs:
         run: pnpm install
 
       - name: 🛠️ Build packages
-        run: pnpm build:all
-        env:
-          # needed for increase rate limit for the GitHub API that is used when building
-          # the VitePress documentation
-          VITEPRESS_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm build:all --filter=!docs
 
       - name: Upload Storybook artifact
         uses: actions/upload-artifact@v4
         with:
           name: storybook-static
           path: packages/sit-onyx/storybook-static
-
-      - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation
-          path: apps/docs/src/.vitepress/dist
 
       - name: Upload playground artifact
         uses: actions/upload-artifact@v4
@@ -90,6 +80,21 @@ jobs:
           npx changeset add --empty
           npx changeset version --snapshot
           npx changeset publish --tag snapshot
+
+      # the docs need to be build AFTER the release because there the changelogs are generated which need to be included in the
+      # documentation build
+      - name: 🛠️ Build docs
+        run: pnpm build:all --filter=docs
+        env:
+          # needed for increase rate limit for the GitHub API that is used when building
+          # the VitePress documentation
+          VITEPRESS_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: apps/docs/src/.vitepress/dist
 
   deploy_storybook:
     name: Deploy Storybook

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -26,7 +26,6 @@
     "generate:changeset": "tsx ./scripts/changeset.ts"
   },
   "devDependencies": {
-    "@changesets/pre": "^2.0.1",
     "@changesets/write": "~0.3.2",
     "tsx": "^4.19.0"
   }

--- a/packages/icons/scripts/changeset.spec.ts
+++ b/packages/icons/scripts/changeset.spec.ts
@@ -1,7 +1,5 @@
-import * as changesetPre from "@changesets/pre";
 import writeChangeset from "@changesets/write";
 import { exec } from "node:child_process";
-import { writeFile } from "node:fs/promises";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { generateChangeset } from "./changeset";
 
@@ -103,34 +101,6 @@ describe("changeset.ts", () => {
         summary: expect.any(String),
       },
       expect.any(String), // file path,
-    );
-  });
-
-  test("should add changeset to pre.json if repo is in pre-release mode", async () => {
-    // ARRANGE
-    const writeChangesetSpy = vi.mocked(writeChangeset).mockResolvedValue("changeset-id-42");
-    const readPreSpy = vi
-      .spyOn(changesetPre, "readPreState")
-      .mockResolvedValue({ changesets: ["a", "z"], initialVersions: {}, mode: "pre", tag: "" });
-    const writeFileMock = vi.mocked(writeFile);
-
-    vi.spyOn(process, "cwd").mockReturnValue("/test/cwd/packages/icons");
-
-    mockExec(["A newIcon1.svg", "M modifiedIcon1.svg"]);
-
-    // ACT
-    await generateChangeset();
-
-    // ASSERT
-    expect(writeChangesetSpy).toHaveBeenCalled();
-    expect(readPreSpy).toHaveBeenCalled();
-    expect(writeFileMock).toHaveBeenCalledWith(
-      "/test/cwd/.changeset/pre.json",
-      JSON.stringify(
-        { changesets: ["a", "changeset-id-42", "z"], initialVersions: {}, mode: "pre", tag: "" },
-        null,
-        2,
-      ) + "\n",
     );
   });
 

--- a/packages/icons/scripts/changeset.ts
+++ b/packages/icons/scripts/changeset.ts
@@ -1,10 +1,8 @@
 /**
  * Script to generate changeset based on the changed .svg files
  */
-import { readPreState } from "@changesets/pre";
 import writeChangeset from "@changesets/write";
 import { exec as nodeExec } from "node:child_process";
-import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { exit } from "node:process";
 import { name as packageName } from "../package.json";
@@ -30,7 +28,7 @@ export async function generateChangeset() {
     (icon) => icon.status === "deleted" || icon.status === "renamed",
   );
 
-  const changesetId = await writeChangeset(
+  await writeChangeset(
     {
       releases: [
         {
@@ -42,18 +40,6 @@ export async function generateChangeset() {
     },
     changesetCwd,
   );
-
-  // if changeset is in pre-release mode, we need to add the generated changeset to the pre.json file so it is picked up correctly
-  const preState = await readPreState(changesetCwd);
-  if (preState) {
-    preState.changesets.push(changesetId);
-    preState.changesets.sort();
-
-    await writeFile(
-      path.join(changesetCwd, ".changeset", "pre.json"),
-      JSON.stringify(preState, null, 2) + "\n",
-    );
-  }
 
   console.log("Wrote changeset");
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,9 +272,6 @@ importers:
 
   packages/icons:
     devDependencies:
-      '@changesets/pre':
-        specifier: ^2.0.1
-        version: 2.0.1
       '@changesets/write':
         specifier: ~0.3.2
         version: 0.3.2


### PR DESCRIPTION
closes #1814

Fixes the issue that our icon library is not released when automated PRs for Figma imports are done.
Also fixes the issue that the documentation did not contain the latest changelogs when a release is done because it was build before the changelogs were generated.
