### PR TITLE
chore: add script for showing playwright report

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:ci:all": "pnpm run lint:all --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",
     "publint:all": "pnpm -r --parallel --aggregate-output exec publint",
     "prepare": "simple-git-hooks",
+    "gh:show-report": "./scripts/show-last-test-report.sh",
     "preinstall": "npx only-allow pnpm"
   },
   "devDependencies": {

--- a/scripts/show-last-test-report.sh
+++ b/scripts/show-last-test-report.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+# check if gh cli is installed
+if ! command -v gh &>/dev/null; then
+    echo "gh CLI is not installed. Please install it first: https://github.com/cli/cli#installation"
+    exit 1
+fi
+
+# Create temporary directory
+TMP_DIR=$(mktemp -d)
+
+# Create shell trap to clean up temporary directory
+function cleanup {
+    rm -r ${TMP_DIR}
+}
+trap cleanup EXIT
+
+# query the id of the last failed run for the current branch
+GH_LAST_RUN_ID=$(gh run list -s failure -b $(git branch --show-current) --json "createdAt,databaseId" --jq "sort_by(.createdAt) | last.databaseId")
+
+# download report
+gh run download $GH_LAST_RUN_ID -D $TMP_DIR -p "html-report--attempt-1"
+
+# show report
+(cd $TMP_DIR/html-report--attempt-1/packages/sit-onyx && pnpm dlx playwright show-report)


### PR DESCRIPTION
This PR adds a neat little scrip `gh:show-report`, which uses the [GitHub CLI](https://cli.github.com/) and playwright to download and show the latest failed test report of the current branch.
GitHub CLI needs to be installed manually.