### PR TITLE
chore:  fix "Cannot find module" error in IDE when using vite specific import features

### DIFF
--- a/packages/sit-onyx/tsconfig.node.json
+++ b/packages/sit-onyx/tsconfig.node.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node20/tsconfig.json",
   "include": [
+    "env.d.ts",
     "vite.config.*",
     "vitest.config.*",
     "playwright.config.*",

--- a/packages/sit-onyx/tsconfig.playwright.json
+++ b/packages/sit-onyx/tsconfig.playwright.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.app.json",
-  "include": ["src/**/*"],
+  "include": ["env.d.ts", "src/**/*"],
   "exclude": [],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
In the local dev environment vite import features like queries (`import "xxx?raw"`) where marked with a typescript error:
> "Cannot find module 'xxx?raw' or its corresponding type declarations.ts(2307)"

This is now fixed by adding the `env.d.ts` declaration file to the includes of the `tsconfig.json` files used for local development.
Closes #1896 