### PR TITLE
docs(typography): fix typo in code snippet

### DIFF
--- a/apps/docs/src/development/typography.md
+++ b/apps/docs/src/development/typography.md
@@ -15,15 +15,15 @@ To install and use the recommended onyx font families, install them by running
 ::: code-group
 
 ```sh [pnpm]
-pnpm add -D @fontsource-variable/source-sans-3 @fontsource-variable/source-code-pro
+pnpm add @fontsource-variable/source-sans-3 @fontsource-variable/source-code-pro
 ```
 
 ```sh [npm]
-npm install -D @fontsource-variable/source-sans-3 @fontsource-variable/source-code-pro
+npm install @fontsource-variable/source-sans-3 @fontsource-variable/source-code-pro
 ```
 
-```sh [pnpm]
-yarn install -D @fontsource-variable/source-sans-3 @fontsource-variable/source-code-pro
+```sh [yarn]
+yarn install @fontsource-variable/source-sans-3 @fontsource-variable/source-code-pro
 ```
 
 :::


### PR DESCRIPTION
- fix "yarn" script name to be yarn instead of pnpm
- document to install font families as direct dependencies instead if dev dependencies to match [font source install instructions](https://fontsource.org/fonts/source-sans-pro/install)
