### PR TITLE
feat(OnyxMenuItem): add property target

### DIFF
--- a/.changeset/pink-weeks-tan.md
+++ b/.changeset/pink-weeks-tan.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxMenuItem): add property `target`

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.stories.ts
@@ -36,6 +36,7 @@ export const WithLink = {
   args: {
     ...Default.args,
     href: "https://onyx.schwarz",
+    target: "_blank",
   },
 } satisfies Story;
 

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { createMenuItems } from "@sit-onyx/headless";
+import { computed } from "vue";
 import { injectI18n } from "../../../../i18n";
 import OnyxListItem from "../../../OnyxListItem/OnyxListItem.vue";
 import OnyxVisuallyHidden from "../../../OnyxVisuallyHidden/OnyxVisuallyHidden.vue";
@@ -14,6 +15,13 @@ const { t } = injectI18n();
 const {
   elements: { listItem, menuItem },
 } = createMenuItems();
+
+const headlessProps = computed(() =>
+  menuItem({
+    active: props.active,
+    disabled: props.disabled,
+  }),
+);
 </script>
 
 <template>
@@ -31,11 +39,7 @@ const {
       :href="props.href"
       :target="props.target"
       :rel="props.target === '_blank' ? 'noreferrer' : undefined"
-      v-bind="
-        menuItem({
-          active: props.active,
-        })
-      "
+      v-bind="headlessProps"
     >
       <slot></slot>
     </a>
@@ -45,12 +49,7 @@ const {
       class="onyx-menu-item__trigger"
       type="button"
       :disabled="props.disabled"
-      v-bind="
-        menuItem({
-          active: props.active,
-          disabled: props.disabled,
-        })
-      "
+      v-bind="headlessProps"
     >
       <slot></slot>
 

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
 import { createMenuItems } from "@sit-onyx/headless";
+import { injectI18n } from "../../../../i18n";
 import OnyxListItem from "../../../OnyxListItem/OnyxListItem.vue";
+import OnyxVisuallyHidden from "../../../OnyxVisuallyHidden/OnyxVisuallyHidden.vue";
 import { type OnyxMenuItemProps } from "./types";
 
-const props = defineProps<OnyxMenuItemProps>();
+const props = withDefaults(defineProps<OnyxMenuItemProps>(), {
+  target: "_self",
+});
+
+const { t } = injectI18n();
 
 const {
   elements: { listItem, menuItem },
@@ -19,20 +25,39 @@ const {
     class="onyx-menu-item"
     v-bind="listItem"
   >
-    <component
-      :is="props.href ? 'a' : 'button'"
+    <a
+      v-if="props.href"
       class="onyx-menu-item__trigger"
-      :disabled="!props.href && props.disabled"
       :href="props.href"
+      :target="props.target"
+      :rel="props.target === '_blank' ? 'noreferrer' : undefined"
       v-bind="
         menuItem({
           active: props.active,
-          disabled: !props.href && props.disabled,
         })
       "
     >
       <slot></slot>
-    </component>
+    </a>
+
+    <button
+      v-else
+      class="onyx-menu-item__trigger"
+      type="button"
+      :disabled="props.disabled"
+      v-bind="
+        menuItem({
+          active: props.active,
+          disabled: props.disabled,
+        })
+      "
+    >
+      <slot></slot>
+
+      <OnyxVisuallyHidden v-if="props.target === '_blank'">
+        {{ t("link.opensExternally") }}
+      </OnyxVisuallyHidden>
+    </button>
   </OnyxListItem>
 </template>
 

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/types.ts
@@ -1,6 +1,7 @@
 import type { OnyxColor } from "../../../../types";
+import type { OnyxLinkProps } from "../../../OnyxLink/types";
 
-export type OnyxMenuItemProps = {
+export type OnyxMenuItemProps = Pick<OnyxLinkProps, "target"> & {
   /**
    * URL that the menu item points to.
    * If the property is set the menuitem will act as an anchor, otherwise it will act as an button.


### PR DESCRIPTION
relates to #1935

Support `target` property when OnyxMenuItem is used as link so it can be opened in a new tab.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
