### PR TITLE
fix(OnyxButton): ripple animation not working

### DIFF
--- a/.changeset/beige-cherries-explain.md
+++ b/.changeset/beige-cherries-explain.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxButton): ripple animation not working

--- a/packages/sit-onyx/src/components/OnyxButton/OnyxButton.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxButton/OnyxButton.ct.tsx
@@ -99,3 +99,20 @@ test("should render button inline aligned with text", async ({ mount }) => {
   // ASSERT
   await expect(component).toHaveScreenshot("inline-aligned.png");
 });
+
+test("should trigger some ripples", async ({ mount, page }) => {
+  await page.addStyleTag({
+    content: `.onyx-ripple__element {
+    animation-duration: 5s;
+  }`,
+  });
+
+  // ARRANGE
+  const component = await mount(<OnyxButton label="Button" />);
+
+  await component.click({ clickCount: 2 });
+  await component.click({ clickCount: 1 });
+
+  // ASSERT
+  await expect(component.locator(".onyx-ripple__element")).toHaveCount(3);
+});

--- a/packages/sit-onyx/src/components/OnyxButton/OnyxButton.vue
+++ b/packages/sit-onyx/src/components/OnyxButton/OnyxButton.vue
@@ -41,7 +41,7 @@ const rippleEvents = computed(() => rippleRef.value?.events ?? {});
     :autofocus="props.autofocus"
     v-on="rippleEvents"
   >
-    <OnyxRipple v-if="!props.disabled && !props.loading" ref="rippleRef" />
+    <OnyxRipple v-if="!disabled && !props.loading" ref="rippleRef" />
     <OnyxIcon v-if="props.icon && !props.loading" class="onyx-button__icon" :icon="props.icon" />
     <OnyxLoadingIndicator v-if="props.loading" class="onyx-button__loading" />
     <span class="onyx-button__label onyx-truncation-ellipsis">{{ props.label }}</span>


### PR DESCRIPTION
closes #1934
Issue caused by #1902 

Fix OnyxButton to show ripple animation again on click.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
