### PR TITLE
fix(OnyxNavButton): prop mobileChildrenOpen not working

### DIFF
--- a/.changeset/sixty-frogs-sneeze.md
+++ b/.changeset/sixty-frogs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxNavButton): prop `mobileChildrenOpen` not working

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavButton/NavButtonLayout.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavButton/NavButtonLayout.vue
@@ -2,27 +2,20 @@
 // this layout component is only used internally for the nav button component
 // to easily switch between mobile and desktop layout
 import arrowSmallLeft from "@sit-onyx/icons/arrow-small-left.svg?raw";
-import { toRef } from "vue";
-import { MANAGED_SYMBOL, useManagedState } from "../../../../composables/useManagedState";
 import { injectI18n } from "../../../../i18n";
 import OnyxButton from "../../../OnyxButton/OnyxButton.vue";
 import OnyxFlyoutMenu from "../OnyxFlyoutMenu/OnyxFlyoutMenu.vue";
 import OnyxNavSeparator from "../OnyxNavSeparator/OnyxNavSeparator.vue";
 import type { OnyxNavButtonProps } from "./types";
 
-const props = withDefaults(
-  defineProps<
-    OnyxNavButtonProps & {
-      /**
-       * If the mobile layout should be used.
-       */
-      isMobile: boolean;
-    }
-  >(),
-  {
-    mobileChildrenOpen: MANAGED_SYMBOL,
-  },
-);
+const props = defineProps<
+  OnyxNavButtonProps & {
+    /**
+     * If the mobile layout should be used.
+     */
+    isMobile: boolean;
+  }
+>();
 
 const slots = defineSlots<{
   button?(): unknown;
@@ -34,12 +27,6 @@ const { t } = injectI18n();
 const emit = defineEmits<{
   "update:mobileChildrenOpen": [isOpen: boolean];
 }>();
-
-const { state: mobileChildrenOpen } = useManagedState(
-  toRef(() => props.mobileChildrenOpen),
-  false,
-  (newVal) => emit("update:mobileChildrenOpen", newVal),
-);
 </script>
 
 <template>
@@ -51,7 +38,7 @@ const { state: mobileChildrenOpen } = useManagedState(
         mode="plain"
         color="neutral"
         :icon="arrowSmallLeft"
-        @click="mobileChildrenOpen = false"
+        @click="emit('update:mobileChildrenOpen', false)"
       />
 
       <slot v-if="!mobileChildrenOpen || props.href" name="button"></slot>


### PR DESCRIPTION
closes #1965

Make property `mobileChildrenOpen` work again.

You can test it by changing line 66 in OnyxNavBar.stories.ts like this and then view to mobile nav bar:
![image](https://github.com/user-attachments/assets/cd454d82-899f-4ca9-a001-34acfccb88df)


## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
