### PR TITLE
fix: Fix uncaught TypeError for components with symbol props

### DIFF
--- a/.changeset/tender-foxes-burn.md
+++ b/.changeset/tender-foxes-burn.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix: Fix uncaught TypeError for components with symbol props

--- a/packages/sit-onyx/src/composables/useManagedState.ts
+++ b/packages/sit-onyx/src/composables/useManagedState.ts
@@ -2,7 +2,7 @@ import { type Ref, computed, ref } from "vue";
 import { asymComputed } from "./asymmetricComputed";
 
 export type ManagedProp<T> = ManagedSymbolType | T;
-export type ManagedSymbolType = typeof MANAGED_SYMBOL;
+export type ManagedSymbolType = symbol; // we can't use `typeof MANAGED_SYMBOL` as vue is unable to infer its type: https://github.com/SchwarzIT/onyx/issues/1980
 export const MANAGED_SYMBOL = Symbol("MANAGED_SYMBOL");
 
 /**


### PR DESCRIPTION
Closes #1980

**Background:**
1. Vue Prop Runtime Validation Vue validates prop types at runtime (e.g., `typeof prop === "boolean"`). If a prop doesn't pass the validation, an error is logged (only in DEV mode): `Invalid prop: type check failed for prop "${name}". Expected ${expectedTypes}.`

1. Vue Prop Type inference Vue supports different ways to define the types of props, which are used for the runtime validation. We define the props using [type-based declaration](https://vuejs.org/guide/typescript/composition-api.html#typing-component-props). This means that the runtime types are inferred based on the typescript types.

**Cause:**
In our case, Vue's compiler inferred the prop type used for runtime validation as `Boolean`, even though the typescript type is `typeof unique symbol | boolean`. This causes the runtime validation to fail and trying to log an error. Because Vue tries to create an error message using implicit string conversions and symbols cannot be implicitly [converted to a string,](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString#description) the JS runtime throws: `Uncaught (in promise) TypeError: can't convert symbol to string`

**Fix:**
Replaced all prop uses of `typeof <unique symbol>` with just `symbol`, this fixes the type inference and the runtime validation. Follow-up issues for Vue core will be created.