### PR TITLE
chore: fix `withOnyxVModelDecorator` storybook decorator never matching

### DIFF
--- a/packages/sit-onyx/.storybook/vModel.ts
+++ b/packages/sit-onyx/.storybook/vModel.ts
@@ -1,15 +1,16 @@
 import { withVModelDecorator } from "@sit-onyx/storybook-utils";
+import type { StrictInputType } from "storybook/internal/types";
+
+const isManaged = (argType: StrictInputType) =>
+  argType.table?.defaultValue?.summary === "MANAGED_SYMBOL";
 
 /**
  * Custom `withVModelDecorator` filter function, because we want don't want to override values that are managed.
  */
 export const withOnyxVModelDecorator = withVModelDecorator({
-  filter: ({ table, name }, _, array) => {
+  filter: ({ table, name }, _, argTypes) => {
     if (table?.category !== "events" || !name.startsWith("update:")) return false;
     const propName = name.replace(/^update:/, "");
-    return !array.some(
-      (argType) =>
-        argType.name === propName && argType.table?.defaultValue?.summary === "MANAGED_SYMBOL",
-    );
+    return !argTypes.some((argType) => argType.name === propName && isManaged(argType));
   },
 });

--- a/packages/sit-onyx/.storybook/vModel.ts
+++ b/packages/sit-onyx/.storybook/vModel.ts
@@ -7,9 +7,9 @@ export const withOnyxVModelDecorator = withVModelDecorator({
   filter: ({ table, name }, _, array) => {
     if (table?.category !== "events" || !name.startsWith("update:")) return false;
     const propName = name.replace(/^update:/, "");
-    return array.every(
+    return !array.some(
       (argType) =>
-        argType.name !== propName && argType.table?.defaultValue?.summary !== "MANAGED_SYMBOL",
+        argType.name === propName && argType.table?.defaultValue?.summary === "MANAGED_SYMBOL",
     );
   },
 });


### PR DESCRIPTION
The filter logic of the `withOnyxVModelDecorator` was incorrect and never matched. This is fixed now by checking for the specific prop and checking its default value.