### PR TITLE
fix(OnyxColorSchemeDialog): fix warning "Set operation on key modelValue failed: target is readonly"

### DIFF
--- a/.changeset/real-boxes-share.md
+++ b/.changeset/real-boxes-share.md
@@ -3,3 +3,5 @@
 ---
 
 fix(OnyxColorSchemeDialog): fix warning "Set operation on key modelValue failed: target is readonly"
+
+The bug caused the color scheme dialog to not emit the correct select color scheme.

--- a/.changeset/real-boxes-share.md
+++ b/.changeset/real-boxes-share.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxColorSchemeDialog): fix warning "Set operation on key modelValue failed: target is readonly"

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxColorSchemeDialog/OnyxColorSchemeDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxColorSchemeDialog/OnyxColorSchemeDialog.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, toRef, watchEffect } from "vue";
+import { computed, ref, watchEffect } from "vue";
 import { injectI18n } from "../../../../i18n";
 import OnyxButton from "../../../OnyxButton/OnyxButton.vue";
 import OnyxDialog from "../../../OnyxDialog/OnyxDialog.vue";
@@ -25,7 +25,7 @@ const emit = defineEmits<{
   close: [];
 }>();
 
-const currentValue = toRef(props, "modelValue");
+const currentValue = ref<ColorSchemeValue>();
 watchEffect(() => (currentValue.value = props.modelValue));
 
 const { t } = injectI18n();


### PR DESCRIPTION
Fix incorrect usage of `toRef` which causes the OnyxColorSchemeDialog and OnyxColorSchemeMenuItem to not work any more / not emit the selected color scheme.

As documented in the Vue docs, toRefs must not be used with props if the ref is modified (which is the case for us) since it would modify the prop directly which is invalid: https://vuejs.org/api/reactivity-utilities.html#toref

![image](https://github.com/user-attachments/assets/abde5fd0-56b6-4b58-ab8b-c5d79c121a2d)


## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
