### PR TITLE
docs(component-showcase): fix z-index issues

### DIFF
--- a/packages/sit-onyx/src/components/examples/ComponentShowcase/ComponentShowcase.vue
+++ b/packages/sit-onyx/src/components/examples/ComponentShowcase/ComponentShowcase.vue
@@ -279,6 +279,8 @@ const teamMembers = [
 
 .parent {
   container-type: inline-size;
+  z-index: var(--onyx-z-index-app-overlay);
+  position: relative;
 }
 
 .showcase {


### PR DESCRIPTION
As found out in the review today, the navbar flyout is behind the headline underline of the general Storybook content in some browsers (e.g. Chrome).

![image](https://github.com/user-attachments/assets/2b4ebbd6-f10c-41ec-9ec8-42de372d4408)