### PR TITLE
chore: fix dev script of all packages to use turborepo

### DIFF
--- a/apps/demo-app/package.json
+++ b/apps/demo-app/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0-beta.63",
   "type": "module",
   "scripts": {
-    "dev": "turbo run turbo:dev --filter demo-app",
+    "dev": "turbo run turbo:dev --filter=.",
     "turbo:dev": "vite",
     "build": "vue-tsc && vite build",
     "preview": "vite preview"

--- a/apps/demo-app/package.json
+++ b/apps/demo-app/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0-beta.63",
   "type": "module",
   "scripts": {
-    "dev": "turbo run vite --filter demo-app",
-    "vite": "vite",
+    "dev": "turbo run turbo:dev --filter demo-app",
+    "turbo:dev": "vite",
     "build": "vue-tsc && vite build",
     "preview": "vite preview"
   },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "turbo run turbo:dev --filter docs",
+    "dev": "turbo run turbo:dev --filter=.",
     "turbo:dev": "VITEPRESS_SKIP_GITHUB_FETCH=true vitepress dev src",
     "build": "pnpm run '/type-check|build-only/'",
     "build-only": "vitepress build src",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "VITEPRESS_SKIP_GITHUB_FETCH=true vitepress dev src",
+    "dev": "turbo run turbo:dev --filter docs",
+    "turbo:dev": "VITEPRESS_SKIP_GITHUB_FETCH=true vitepress dev src",
     "build": "pnpm run '/type-check|build-only/'",
     "build-only": "vitepress build src",
     "type-check": "vue-tsc --noEmit",

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "homepage": "https://playground.onyx.schwarz",
   "scripts": {
-    "dev": "turbo run turbo:dev --filter playground",
+    "dev": "turbo run turbo:dev --filter=.",
     "turbo:dev": "vite",
     "preview": "vite preview",
     "build": "pnpm run '/type-check|build-only/'",

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -8,8 +8,8 @@
   "private": true,
   "homepage": "https://playground.onyx.schwarz",
   "scripts": {
-    "dev": "turbo run vite --filter playground",
-    "vite": "vite",
+    "dev": "turbo run turbo:dev --filter playground",
+    "turbo:dev": "vite",
     "preview": "vite preview",
     "build": "pnpm run '/type-check|build-only/'",
     "build-only": "vite build",

--- a/packages/chartjs-plugin/package.json
+++ b/packages/chartjs-plugin/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/SchwarzIT/onyx/issues"
   },
   "scripts": {
-    "dev": "turbo run turbo:dev --filter @sit-onyx/chartjs-plugin",
+    "dev": "turbo run turbo:dev --filter=.",
     "turbo:dev": "storybook dev -p 6006 --no-open",
     "build": "vue-tsc --noEmit",
     "test": "vitest",

--- a/packages/chartjs-plugin/package.json
+++ b/packages/chartjs-plugin/package.json
@@ -23,7 +23,8 @@
     "url": "https://github.com/SchwarzIT/onyx/issues"
   },
   "scripts": {
-    "dev": "storybook dev -p 6006 --no-open",
+    "dev": "turbo run turbo:dev --filter @sit-onyx/chartjs-plugin",
+    "turbo:dev": "storybook dev -p 6006 --no-open",
     "build": "vue-tsc --noEmit",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -26,7 +26,8 @@
     "dist"
   ],
   "scripts": {
-    "dev": "nuxi dev playground",
+    "dev": "turbo run turbo:dev --filter @sit-onyx/nuxt",
+    "turbo:dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "build": "pnpm run dev:prepare && nuxt-module-build build",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "turbo run turbo:dev --filter @sit-onyx/nuxt",
+    "dev": "turbo run turbo:dev --filter=.",
     "turbo:dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -34,8 +34,8 @@
     "url": "https://github.com/SchwarzIT/onyx/issues"
   },
   "scripts": {
-    "td": "turbo watch --filter=sit-onyx dev",
-    "dev": "storybook dev -p 6006 --no-open",
+    "dev": "turbo run turbo:dev --filter sit-onyx",
+    "turbo:dev": "storybook dev -p 6006 --no-open",
     "build": "vite build && vue-tsc -p tsconfig.app.json --composite false",
     "build:storybook": "storybook build",
     "preview": "vite serve storybook-static",

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/SchwarzIT/onyx/issues"
   },
   "scripts": {
-    "dev": "turbo run turbo:dev --filter sit-onyx",
+    "dev": "turbo run turbo:dev --filter=.",
     "turbo:dev": "storybook dev -p 6006 --no-open",
     "build": "vite build && vue-tsc -p tsconfig.app.json --composite false",
     "build:storybook": "storybook build",

--- a/turbo.json
+++ b/turbo.json
@@ -21,12 +21,7 @@
       "dependsOn": ["sit-onyx#build", "build"],
       "outputs": ["playwright-report", "test-results"]
     },
-    "dev": {
-      "dependsOn": ["^build"],
-      "cache": false,
-      "persistent": true
-    },
-    "vite": {
+    "turbo:dev": {
       "dependsOn": ["^build"],
       "cache": false,
       "persistent": true


### PR DESCRIPTION
Relates to #1951 

Currently our dev scripts (e.g. of `sit-onyx`) do not work in a clean repository. The issue is that `sit-onyx` depends on other packages (like icons) to be build first.

I aligned all `dev` scripts for all packages to be run with turborepo so all dependencies are managed/build correctly.
