### PR TITLE
fix(lars-monk): enable linting Vue for block spacings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -148,7 +148,17 @@ const sitOnyxConfig = {
     "vue/no-ref-object-reactivity-loss": "error",
     "vue/no-duplicate-attr-inheritance": "error",
     "vue/no-boolean-default": "error",
+    "vue/block-tag-newline": "error",
     "vue/block-order": "error",
+    "vue/padding-line-between-blocks": "error",
+    "vue/block-lang": [
+      "error",
+      {
+        script: {
+          lang: "ts",
+        },
+      },
+    ],
     "vue/camelcase": "error",
     // unfortunately there is a bug with using nested property declaration: https://github.com/future-architect/eslint-plugin-vue-scoped-css/issues/371
     // but parsing errors should be caught by the compiler anyways

--- a/packages/sit-onyx/src/components/OnyxFormElement/TestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxFormElement/TestWrapper.ct.vue
@@ -2,6 +2,7 @@
 <script lang="ts" setup>
 import OnyxFormElement from "./OnyxFormElement.vue";
 </script>
+
 <template>
   <div>
     <OnyxFormElement label="Test">

--- a/packages/sit-onyx/src/components/OnyxSelectInput/OnyxSelectInput.vue
+++ b/packages/sit-onyx/src/components/OnyxSelectInput/OnyxSelectInput.vue
@@ -111,6 +111,7 @@ const blockTyping = (event: KeyboardEvent) => {
   event.preventDefault();
 };
 </script>
+
 <template>
   <div v-if="skeleton" :class="['onyx-select-input-skeleton', densityClass]" v-bind="rootAttrs">
     <OnyxSkeleton v-if="!props.hideLabel" class="onyx-select-input-skeleton__label" />

--- a/packages/sit-onyx/src/components/OnyxStepper/OnyxStepper.vue
+++ b/packages/sit-onyx/src/components/OnyxStepper/OnyxStepper.vue
@@ -114,6 +114,7 @@ const decrementLabel = computed(() =>
   t.value("stepper.decrement", { stepSize: determinedStepSize.value }),
 );
 </script>
+
 <template>
   <div v-if="skeleton" :class="['onyx-stepper-skeleton', densityClass]">
     <OnyxSkeleton v-if="!props.hideLabel" class="onyx-stepper-skeleton__label" />
@@ -180,6 +181,7 @@ const decrementLabel = computed(() =>
     </OnyxFormElement>
   </div>
 </template>
+
 <style lang="scss">
 @use "../../styles/mixins/layers";
 @use "../../styles/mixins/input.scss";

--- a/packages/sit-onyx/src/components/OnyxToast/OnyxToast.vue
+++ b/packages/sit-onyx/src/components/OnyxToast/OnyxToast.vue
@@ -4,6 +4,7 @@ import { useToast } from "./useToast";
 
 const toastProvider = useToast();
 </script>
+
 <!-- eslint-disable vue/no-root-v-if -->
 <template>
   <dialog


### PR DESCRIPTION
Activate some more linting rules related to Vue block spacings white-spaces and newlines.