### PR TITLE
fix(@sit-onyx/shared): fix peerDependencies

### DIFF
--- a/.changeset/tasty-baboons-impress.md
+++ b/.changeset/tasty-baboons-impress.md
@@ -3,3 +3,5 @@
 ---
 
 fix(@sit-onyx/shared): fix peerDependencies
+
+This fixed a dependency warning with a too strict version scope for `vue` and `sass-embedded` when a package is installed that depends on `@sit-onyx/shared` as peerDependency (e.g. `sit-onyx`)

--- a/.changeset/tasty-baboons-impress.md
+++ b/.changeset/tasty-baboons-impress.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/shared": patch
+---
+
+fix(@sit-onyx/shared): fix peerDependencies

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@vitejs/plugin-vue": "^5.1.4",
-    "sass-embedded": "catalog:",
-    "vue": "catalog:"
+    "sass-embedded": ">= 1.74.0",
+    "vite": ">= 5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,9 +351,9 @@ importers:
       sass-embedded:
         specifier: 1.80.5
         version: 1.80.5
-      vue:
-        specifier: 3.5.12
-        version: 3.5.12(typescript@5.6.3)
+      vite:
+        specifier: '>= 5'
+        version: 5.4.10(@types/node@22.9.0)(sass-embedded@1.80.5)(sass@1.80.4)(stylus@0.57.0)(terser@5.36.0)
 
   packages/sit-onyx:
     dependencies:


### PR DESCRIPTION
Fix dependency warning with a too strict version scope for `vue` and `sass-embedded` when a package is installed that depends on `@sit-onyx/shared` as peerDependency (e.g. `sit-onyx`).

We must not use `catalog:` for peerDependencies, otherwise it will require the exact dependency version to be installed in the project. This leads to install warnings when e.g.`sass-embedded` version `1.80.5` is required but `1.80.6` is installed


## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
