### PR TITLE
style(eslint): apply stricter general rules to all packages

### DIFF
--- a/apps/demo-app/src/components/SelectDemo.vue
+++ b/apps/demo-app/src/components/SelectDemo.vue
@@ -73,8 +73,8 @@ const filteredOptions = computed<SelectOption[]>(() =>
         v-model="multiselectState"
         label="Example multiselect"
         list-label="Example listbox list"
-        :multiple="true"
-        :with-check-all="true"
+        multiple
+        with-check-all
         :options="selectOptions"
         :skeleton="useSkeleton"
       />

--- a/apps/demo-app/src/components/form-demo/FormDemo.vue
+++ b/apps/demo-app/src/components/form-demo/FormDemo.vue
@@ -33,7 +33,7 @@ export type FormData = Partial<{
   radioGroup: OnyxRadioGroupProps["modelValue"];
 }>;
 
-const formState = defineModel<FormData>();
+const formState = defineModel<FormData>({ required: true });
 
 const selectOptions = [
   { value: "apple", label: "Apple" },
@@ -63,12 +63,7 @@ const radioOptions: RadioButtonOption[] = [
 </script>
 
 <template>
-  <form
-    v-if="formState"
-    class="demo onyx-grid"
-    @submit.prevent="handleSubmit"
-    @reset="formState = {}"
-  >
+  <form class="demo onyx-grid" @submit.prevent="handleSubmit" @reset="formState = {}">
     <OnyxHeadline is="h3" class="onyx-grid-span-20"
       >This form is currently <span class="demo__invalid">in</span>valid.</OnyxHeadline
     >

--- a/apps/demo-app/src/components/layout-demo/BusyIndicatorDemo.vue
+++ b/apps/demo-app/src/components/layout-demo/BusyIndicatorDemo.vue
@@ -1,6 +1,13 @@
 <script lang="ts" setup>
 import { OnyxHeadline } from "sit-onyx";
 import { FooterDemo } from ".";
+
+defineSlots<{
+  /**
+   * Overlay content.
+   */
+  default?(): unknown;
+}>();
 </script>
 
 <template>

--- a/apps/demo-app/src/components/layout-demo/FlyoutDemo.vue
+++ b/apps/demo-app/src/components/layout-demo/FlyoutDemo.vue
@@ -6,6 +6,13 @@ const showFlyout = defineModel<boolean>();
 
 defineProps<{ small?: boolean }>();
 
+defineSlots<{
+  /**
+   * Flyout content.
+   */
+  default?(): unknown;
+}>();
+
 const selectState = ref();
 </script>
 

--- a/apps/demo-app/src/components/layout-demo/LayoutSettings.vue
+++ b/apps/demo-app/src/components/layout-demo/LayoutSettings.vue
@@ -34,7 +34,6 @@ const props = withDefaults(
     show?: SettingsSection[];
   }>(),
   {
-    horizontal: false,
     show: () => ["content", "sidebar", "footer", "overlay"],
   },
 );

--- a/apps/demo-app/src/components/layout-demo/MobileBottomFlyInDemo.vue
+++ b/apps/demo-app/src/components/layout-demo/MobileBottomFlyInDemo.vue
@@ -1,8 +1,16 @@
 <script lang="ts" setup>
 import { OnyxHeadline } from "sit-onyx";
 import { FooterDemo } from ".";
+
 defineProps<{
   showFooter?: boolean;
+}>();
+
+defineSlots<{
+  /**
+   * Fly-in content.
+   */
+  default?(): unknown;
 }>();
 </script>
 

--- a/apps/demo-app/src/components/layout-demo/MobileNavFlyoutDemo.vue
+++ b/apps/demo-app/src/components/layout-demo/MobileNavFlyoutDemo.vue
@@ -1,5 +1,12 @@
 <script lang="ts" setup>
 import { OnyxHeadline } from "sit-onyx";
+
+defineSlots<{
+  /**
+   * Flyout content.
+   */
+  default?(): unknown;
+}>();
 </script>
 
 <template>

--- a/apps/demo-app/src/components/layout-demo/NavBarDemo.vue
+++ b/apps/demo-app/src/components/layout-demo/NavBarDemo.vue
@@ -3,6 +3,13 @@ import { OnyxButton, OnyxIconButton } from "sit-onyx";
 import { useRouter } from "vue-router";
 import onyxLogo from "../../assets/onyx-logo.svg?raw";
 
+defineSlots<{
+  /**
+   * Nav bar content.
+   */
+  default?(): unknown;
+}>();
+
 const isLeftAligned = defineModel<boolean>();
 
 const router = useRouter();

--- a/apps/demo-app/src/components/layout-demo/PageDemo.vue
+++ b/apps/demo-app/src/components/layout-demo/PageDemo.vue
@@ -4,7 +4,7 @@ import { computed } from "vue";
 import type { SettingsSections } from ".";
 import { FloatingButtonDemo, FlyoutDemo, LayoutSettings, StickyDemo, TooltipDemo } from ".";
 
-const settings = defineModel<SettingsSections>();
+const settings = defineModel<SettingsSections>({ required: true });
 const isSidebarOpen = defineModel<boolean>("isSidebarOpen");
 
 const muchContent = Array.from({ length: 100 }, (_, index) => `Lorem ipsum dolor ${index}`);
@@ -22,7 +22,7 @@ const showSidebarOpenButton = computed<boolean>(() => {
 </script>
 
 <template>
-  <div v-if="settings" class="page">
+  <div class="page">
     <OnyxHeadline is="h1">Scrollable page content</OnyxHeadline>
 
     <LayoutSettings v-model="settings" horizontal />

--- a/apps/demo-app/src/components/layout-demo/SidebarDemo.vue
+++ b/apps/demo-app/src/components/layout-demo/SidebarDemo.vue
@@ -4,6 +4,13 @@ import { OnyxButton, OnyxHeadline } from "sit-onyx";
 
 const isOpen = defineModel<boolean>();
 defineProps<{ isClosable?: boolean }>();
+
+defineSlots<{
+  /**
+   * Sidebar content.
+   */
+  default?(): unknown;
+}>();
 </script>
 
 <template>

--- a/apps/demo-app/src/components/layout-demo/TempOverlayDemo.vue
+++ b/apps/demo-app/src/components/layout-demo/TempOverlayDemo.vue
@@ -4,6 +4,13 @@ import { OnyxButton, OnyxHeadline } from "sit-onyx";
 
 const isOpen = defineModel<boolean>();
 defineProps<{ transparent?: boolean }>();
+
+defineSlots<{
+  /**
+   * Overlay content.
+   */
+  default?(): unknown;
+}>();
 </script>
 
 <template>

--- a/apps/demo-app/src/views/DataGridView.vue
+++ b/apps/demo-app/src/views/DataGridView.vue
@@ -32,6 +32,7 @@ const features = computed(() => {
     </div>
   </OnyxPageLayout>
 </template>
+
 <style lang="scss" scoped>
 .data-grid-settings {
   margin: 1rem 0;

--- a/apps/demo-app/src/views/LayoutDemoView.vue
+++ b/apps/demo-app/src/views/LayoutDemoView.vue
@@ -67,7 +67,7 @@ watch(
           <LayoutSettings v-model="settings" :show="['content']" />
         </FlyoutDemo>
         |
-        <TooltipDemo :force-tooltip="settings.content.forceTooltip" style="display: inline-block" />
+        <TooltipDemo class="tooltip" :force-tooltip="settings.content.forceTooltip" />
       </NavBarDemo>
     </template>
 
@@ -155,3 +155,9 @@ watch(
     </template>
   </OnyxAppLayout>
 </template>
+
+<style lang="scss" scoped>
+.tooltip {
+  display: inline-block;
+}
+</style>

--- a/apps/docs/src/.vitepress/components/ColorPaletteValue.vue
+++ b/apps/docs/src/.vitepress/components/ColorPaletteValue.vue
@@ -23,7 +23,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <button class="step" @click="emit('select')">
+  <button type="button" class="step" @click="emit('select')">
     <div class="step__color" :class="{ 'step__color--with-border': props.showBorder }">
       <span v-if="props.name" class="step__name">{{ props.name }}</span>
       <OnyxIcon class="step__icon" :icon="copyIcon" />

--- a/apps/docs/src/.vitepress/components/DesignVariable.vue
+++ b/apps/docs/src/.vitepress/components/DesignVariable.vue
@@ -27,6 +27,7 @@ const emit = defineEmits<{
       'variable--copyable': props.allowCopy,
     }"
     :disabled="!props.allowCopy"
+    type="button"
     @click="emit('copy')"
     @keyup.enter="emit('copy')"
   >

--- a/apps/docs/src/.vitepress/components/DesignVariableBadge.vue
+++ b/apps/docs/src/.vitepress/components/DesignVariableBadge.vue
@@ -10,7 +10,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <button @click="emit('click')">
+  <button type="button" @click="emit('click')">
     <Badge
       class="badge"
       :class="{ 'badge--active': props.active }"

--- a/apps/docs/src/.vitepress/components/DesignVariableCard.vue
+++ b/apps/docs/src/.vitepress/components/DesignVariableCard.vue
@@ -12,6 +12,17 @@ const props = defineProps<{
   hideValue?: boolean;
 }>();
 
+defineSlots<{
+  /**
+   * Display preview of the given variable.
+   */
+  default(props: { name: string }): unknown;
+  /**
+   * Optional slot to override variable name content.
+   */
+  name?(): unknown;
+}>();
+
 const wrapperRef = ref<HTMLElement>();
 const isCopied = ref(false);
 

--- a/apps/docs/src/.vitepress/components/OnyxColorThemeDefinitions.vue
+++ b/apps/docs/src/.vitepress/components/OnyxColorThemeDefinitions.vue
@@ -39,6 +39,7 @@ const infoColors = Array.from({ length: 9 }, (_, index) => {
       <button
         class="theme__button"
         :class="{ 'theme__button--active': !isDark }"
+        type="button"
         @click="isDark = false"
       >
         Light mode
@@ -46,6 +47,7 @@ const infoColors = Array.from({ length: 9 }, (_, index) => {
       <button
         class="theme__button"
         :class="{ 'theme__button--active': isDark }"
+        type="button"
         @click="isDark = true"
       >
         Dark mode

--- a/apps/docs/src/.vitepress/components/OnyxHomePage.vue
+++ b/apps/docs/src/.vitepress/components/OnyxHomePage.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { computed } from "vue";
 import OnyxHeadline from "~components/OnyxHeadline/OnyxHeadline.vue";
 import packageJson from "../../../../../packages/sit-onyx/package.json";
 import type { HomePageData } from "../../index.data";
@@ -9,13 +10,15 @@ const props = defineProps<{
   data: HomePageData;
 }>();
 
-const kpiTimestamp = Intl.DateTimeFormat("en-US", {
+const timestampFormatter = Intl.DateTimeFormat("en-US", {
   day: "2-digit",
   month: "short",
   year: "numeric",
   hour: "2-digit",
   minute: "2-digit",
-}).format(new Date(props.data.timestamp));
+});
+
+const kpiTimestamp = computed(() => timestampFormatter.format(new Date(props.data.timestamp)));
 
 const storybookHost = "https://storybook.onyx.schwarz" as const;
 </script>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,6 +67,36 @@ const generalVueTsConfig = {
     ],
     "no-console": "error",
     "no-debugger": "error",
+    "vue/no-console": "error",
+    "vue/html-button-has-type": "error",
+    "vue/valid-define-options": "error",
+    "vue/no-setup-props-reactivity-loss": "error",
+    "vue/no-restricted-syntax": "error",
+    "vue/prefer-true-attribute-shorthand": "error",
+    "vue/no-loss-of-precision": "error",
+    "vue/no-irregular-whitespace": "error",
+    "vue/require-explicit-slots": "error",
+    "vue/no-useless-v-bind": "error",
+    "vue/no-useless-mustaches": "error",
+    "vue/no-root-v-if": "error",
+    "vue/no-static-inline-styles": "error",
+    "vue/no-unused-refs": "error",
+    "vue/no-required-prop-with-default": "error",
+    "vue/no-ref-object-reactivity-loss": "error",
+    "vue/no-duplicate-attr-inheritance": "error",
+    "vue/no-boolean-default": "error",
+    "vue/block-tag-newline": "error",
+    "vue/block-order": "error",
+    "vue/padding-line-between-blocks": "error",
+    "vue/block-lang": [
+      "error",
+      {
+        script: {
+          lang: "ts",
+        },
+      },
+    ],
+    "vue/camelcase": "error",
   },
 };
 
@@ -95,6 +125,9 @@ const vitestConfig = {
   name: "onyx-vitest",
   files: ["**/*.spec.{js,jsx,ts,tsx}"],
   extends: [pluginVitest.configs.recommended],
+  rules: {
+    "vue/no-ref-object-reactivity-loss": "off",
+  },
 };
 
 /**
@@ -129,40 +162,7 @@ const sitOnyxConfig = {
   rules: {
     "sitOnyx/import-playwright-a11y": "error",
     "sitOnyx/no-shadow-native": "error",
-    "vue/html-button-has-type": "error",
     "vue/require-prop-comment": "error",
-    "vue/valid-define-options": "error",
-    "vue/no-setup-props-reactivity-loss": "error",
-    "vue/no-restricted-syntax": "error",
-    "vue/prefer-true-attribute-shorthand": "error",
-    "vue/no-loss-of-precision": "error",
-    "vue/no-irregular-whitespace": "error",
-    "vue/no-console": "error",
-    "vue/require-explicit-slots": "error",
-    "vue/no-useless-v-bind": "error",
-    "vue/no-useless-mustaches": "error",
-    "vue/no-root-v-if": "error",
-    "vue/no-static-inline-styles": "error",
-    "vue/no-unused-refs": "error",
-    "vue/no-required-prop-with-default": "error",
-    "vue/no-ref-object-reactivity-loss": "error",
-    "vue/no-duplicate-attr-inheritance": "error",
-    "vue/no-boolean-default": "error",
-    "vue/block-tag-newline": "error",
-    "vue/block-order": "error",
-    "vue/padding-line-between-blocks": "error",
-    "vue/block-lang": [
-      "error",
-      {
-        script: {
-          lang: "ts",
-        },
-      },
-    ],
-    "vue/camelcase": "error",
-    // unfortunately there is a bug with using nested property declaration: https://github.com/future-architect/eslint-plugin-vue-scoped-css/issues/371
-    // but parsing errors should be caught by the compiler anyways
-    "vue-scoped-css/no-parsing-error": "off",
     // disallow scoped or module CSS for components
     // see https://onyx.schwarz/principles/technical-vision.html#css
     "vue-scoped-css/enforce-style-type": ["error", { allows: ["plain"] }],

--- a/packages/headless/src/composables/comboBox/SelectOnlyCombobox.vue
+++ b/packages/headless/src/composables/comboBox/SelectOnlyCombobox.vue
@@ -57,11 +57,11 @@ defineExpose({ comboBox });
       @keydown.arrow-down="isExpanded = true"
     />
 
-    <button v-bind="button">
+    <button v-bind="button" type="button">
       <template v-if="isExpanded">⬆️</template>
       <template v-else>⬇️</template>
     </button>
-    <ul v-bind="listbox" :class="{ hidden: !isExpanded }" style="width: 400px">
+    <ul class="listbox" v-bind="listbox" :class="{ hidden: !isExpanded }">
       <li
         v-for="e in options"
         :key="e"
@@ -83,5 +83,8 @@ defineExpose({ comboBox });
 }
 [aria-selected="true"] {
   background-color: red;
+}
+.listbox {
+  width: 400px;
 }
 </style>

--- a/packages/headless/src/composables/comboBox/createComboBox.ts
+++ b/packages/headless/src/composables/comboBox/createComboBox.ts
@@ -209,13 +209,13 @@ export const createComboBox = createBuilder(
       return handleNavigation(event);
     };
 
-    const autocompleteInput =
-      autocomplete.value !== "none"
-        ? {
-            "aria-autocomplete": autocomplete.value,
-            type: "text",
-          }
-        : null;
+    const autocompleteInput = computed(() => {
+      if (autocomplete.value === "none") return null;
+      return {
+        "aria-autocomplete": autocomplete.value,
+        type: "text",
+      };
+    });
 
     const {
       elements: { option, group, listbox },
@@ -264,7 +264,7 @@ export const createComboBox = createBuilder(
             activeOption.value != undefined ? getOptionId(activeOption.value) : undefined,
           onInput: handleInput,
           onKeydown: handleKeydown,
-          ...autocompleteInput,
+          ...autocompleteInput.value,
         })),
         /**
          * An optional button to control the visibility of the popup.

--- a/packages/headless/src/composables/menuButton/TestMenuButton.vue
+++ b/packages/headless/src/composables/menuButton/TestMenuButton.vue
@@ -18,7 +18,7 @@ const {
 
 <template>
   <div v-bind="root">
-    <button v-bind="button">Toggle nav menu</button>
+    <button v-bind="button" type="button">Toggle nav menu</button>
     <ul v-show="isExpanded" v-bind="menu">
       <li v-for="item in items" v-bind="listItem" :key="item.value">
         <a v-bind="menuItem({ active: activeItem === item.value })" href="#">{{ item.label }}</a>

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/sorting.spec.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/sorting.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/no-ref-object-reactivity-loss */
 import { expect, test, vi } from "vitest";
 import * as vue from "vue";
 import { ref, toRef } from "vue";

--- a/packages/sit-onyx/src/components/OnyxRadioButton/OnyxRadioButton.vue
+++ b/packages/sit-onyx/src/components/OnyxRadioButton/OnyxRadioButton.vue
@@ -147,24 +147,12 @@ const skeleton = useSkeletonContext(props);
       appearance: none;
       margin: var(--onyx-radio-button-selector-margin);
       cursor: inherit;
-
-      outline: {
-        style: solid;
-        width: var(--onyx-radio-button-selector-outline-width);
-        color: var(--onyx-radio-button-selector-outline-color);
-        offset: 0;
-      }
-
       transition: outline var(--onyx-duration-sm);
-
-      border: {
-        style: solid;
-        width: var(--onyx-1px-in-rem);
-        color: var(--onyx-radio-button-selector-border-color);
-        radius: var(--onyx-radius-full);
-      }
-
+      border: var(--onyx-1px-in-rem) solid var(--onyx-radio-button-selector-border-color);
+      border-radius: var(--onyx-radius-full);
       background-color: var(--onyx-radio-button-selector-background-color);
+      outline: var(--onyx-radio-button-selector-outline-width) solid
+        var(--onyx-radio-button-selector-outline-color);
 
       display: inline-grid;
       place-items: center;

--- a/packages/sit-onyx/src/components/examples/GridPlayground/GridBadge/GridBadge.vue
+++ b/packages/sit-onyx/src/components/examples/GridPlayground/GridBadge/GridBadge.vue
@@ -24,6 +24,7 @@ const props = defineProps<{
     <span>{{ props.label }}</span>
   </div>
 </template>
+
 <style lang="scss" scoped>
 .grid-badge {
   font-family: var(--onyx-font-family-mono);


### PR DESCRIPTION
We have some stricter general eslint rules that we are currently only applying to `sit-onyx` but not to other packages like custom Vue components in our docs.

We want to have a high code quality across all packages so I moved those general rules to be applied to the whole monorepo.
