### PR TITLE
refactor: remove relative onyx imports from docs

### DIFF
--- a/apps/docs/src/.vitepress/components/ColorPaletteValue.vue
+++ b/apps/docs/src/.vitepress/components/ColorPaletteValue.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import copyIcon from "@sit-onyx/icons/copy.svg?raw";
-import OnyxIcon from "~components/OnyxIcon/OnyxIcon.vue";
+import { OnyxIcon } from "sit-onyx";
 
 export type ColorPaletteValueProps = {
   /** Text to show below the value. */

--- a/apps/docs/src/.vitepress/components/ComponentCard.vue
+++ b/apps/docs/src/.vitepress/components/ComponentCard.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import OnyxHeadline from "~components/OnyxHeadline/OnyxHeadline.vue";
+import { OnyxHeadline } from "sit-onyx";
 import type { ComponentStatus } from "./ComponentStatusBadge.vue";
 import ComponentStatusBadge from "./ComponentStatusBadge.vue";
 

--- a/apps/docs/src/.vitepress/components/ComponentRoadmap.vue
+++ b/apps/docs/src/.vitepress/components/ComponentRoadmap.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
+import { OnyxButton, OnyxHeadline } from "sit-onyx";
 import { computed, ref } from "vue";
-import OnyxButton from "~components/OnyxButton/OnyxButton.vue";
-import OnyxHeadline from "~components/OnyxHeadline/OnyxHeadline.vue";
 import type { ComponentCardProps } from "./ComponentCard.vue";
 import ComponentCard from "./ComponentCard.vue";
 import ComponentStatusBadge from "./ComponentStatusBadge.vue";

--- a/apps/docs/src/.vitepress/components/ComponentStatusBadge.vue
+++ b/apps/docs/src/.vitepress/components/ComponentStatusBadge.vue
@@ -2,7 +2,7 @@
 import check from "@sit-onyx/icons/check.svg?raw";
 import history from "@sit-onyx/icons/history.svg?raw";
 import loadingDots from "@sit-onyx/icons/loading-dots.svg?raw";
-import OnyxIcon from "~components/OnyxIcon/OnyxIcon.vue";
+import { OnyxIcon } from "sit-onyx";
 
 export type ComponentStatus = "implemented" | "in-progress" | "planned";
 

--- a/apps/docs/src/.vitepress/components/DensitySelection.vue
+++ b/apps/docs/src/.vitepress/components/DensitySelection.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { DENSITIES, type Density } from "~components/../composables/density";
+import { type Density, DENSITIES } from "sit-onyx";
 import DesignVariableBadge from "./DesignVariableBadge.vue";
 
 const modelValue = defineModel<Density>({ default: "default" });

--- a/apps/docs/src/.vitepress/components/DesignVariable.vue
+++ b/apps/docs/src/.vitepress/components/DesignVariable.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import checkIcon from "@sit-onyx/icons/check-small.svg?raw";
 import copyIcon from "@sit-onyx/icons/copy.svg?raw";
-import OnyxIcon from "~components/OnyxIcon/OnyxIcon.vue";
+import { OnyxIcon } from "sit-onyx";
 
 const props = defineProps<{
   /** Variable name. */

--- a/apps/docs/src/.vitepress/components/DesignVariableHeader.vue
+++ b/apps/docs/src/.vitepress/components/DesignVariableHeader.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
-import OnyxButton from "~components/OnyxButton/OnyxButton.vue";
-import OnyxHeadline from "~components/OnyxHeadline/OnyxHeadline.vue";
+import { OnyxButton, OnyxHeadline } from "sit-onyx";
 
 const props = defineProps<{
   /** Headline to show on the left side of the header. */

--- a/apps/docs/src/.vitepress/components/IconLibraryItem.vue
+++ b/apps/docs/src/.vitepress/components/IconLibraryItem.vue
@@ -1,7 +1,5 @@
 <script lang="ts" setup>
-import OnyxIcon from "~components/OnyxIcon/OnyxIcon.vue";
-import { useToast } from "~components/OnyxToast/useToast";
-import OnyxTooltip from "~components/OnyxTooltip/OnyxTooltip.vue";
+import { OnyxIcon, OnyxTooltip, useToast } from "sit-onyx";
 import type { EnrichedIcon } from "../utils-icons";
 
 const props = defineProps<{

--- a/apps/docs/src/.vitepress/components/OnyxHomePage.vue
+++ b/apps/docs/src/.vitepress/components/OnyxHomePage.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
+import { OnyxHeadline } from "sit-onyx";
 import { computed } from "vue";
-import OnyxHeadline from "~components/OnyxHeadline/OnyxHeadline.vue";
 import packageJson from "../../../../../packages/sit-onyx/package.json";
 import type { HomePageData } from "../../index.data";
 import ComponentRoadmap from "./ComponentRoadmap.vue";

--- a/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
+++ b/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
+import { OnyxHeadline, OnyxInput } from "sit-onyx";
 import { computed, ref } from "vue";
-import OnyxHeadline from "~components/OnyxHeadline/OnyxHeadline.vue";
-import OnyxInput from "~components/OnyxInput/OnyxInput.vue";
 import { getEnrichedIconCategoryList } from "../utils-icons";
 import IconLibraryItem from "./IconLibraryItem.vue";
 

--- a/apps/docs/src/.vitepress/components/OnyxTypography.vue
+++ b/apps/docs/src/.vitepress/components/OnyxTypography.vue
@@ -1,9 +1,6 @@
 <script lang="ts" setup>
+import { OnyxHeadline, OnyxLink, type HeadlineType, type TextSize } from "sit-onyx";
 import { computed, ref } from "vue";
-import OnyxHeadline from "~components/OnyxHeadline/OnyxHeadline.vue";
-import type { HeadlineType } from "~components/OnyxHeadline/types";
-import OnyxLink from "~components/OnyxLink/OnyxLink.vue";
-import type { TextSize } from "../../../../../packages/sit-onyx/src/types/fonts";
 import DesignVariable from "./DesignVariable.vue";
 import DesignVariableCard from "./DesignVariableCard.vue";
 import DesignVariableHeader from "./DesignVariableHeader.vue";

--- a/apps/docs/src/.vitepress/theme/TheLayout.vue
+++ b/apps/docs/src/.vitepress/theme/TheLayout.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
+import { OnyxToast } from "sit-onyx";
 import DefaultTheme from "vitepress/theme";
-import OnyxToast from "~components/OnyxToast/OnyxToast.vue";
 
 const { Layout } = DefaultTheme;
 </script>

--- a/apps/docs/src/.vitepress/theme/index.ts
+++ b/apps/docs/src/.vitepress/theme/index.ts
@@ -1,10 +1,12 @@
 import OnyxTheme from "@sit-onyx/vitepress-theme";
 import type { Theme } from "vitepress";
-import { createOnyx } from "~components/..";
 import TopicOverviewCard from "../components/TopicOverviewCard.vue";
 import TheLayout from "./TheLayout.vue";
 
 // custom styles must be imported after the theme
+import { createOnyx } from "sit-onyx";
+
+import "sit-onyx/style.css";
 import "./theme.scss";
 
 const theme: Theme = {

--- a/apps/docs/src/variables/spacings.md
+++ b/apps/docs/src/variables/spacings.md
@@ -5,7 +5,7 @@ Below you will find all available spacing variables that are supported by onyx.
 <script lang="ts" setup>
 import OnyxSpacingVariables from "../.vitepress/components/OnyxSpacingVariables.vue";
 import DensitySelection from "../.vitepress/components/DensitySelection.vue";
-import type { Density } from "~components/../composables/density";
+import type { Density } from "sit-onyx";
 import { ref } from "vue";
 
 const selectedDensity = ref<Density>("default");

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -3,9 +3,6 @@
   "include": ["env.d.ts", "src/**/*", "tests/**/*", "src/.vitepress/**/*", "vite.config.ts"],
   "compilerOptions": {
     "moduleResolution": "Bundler",
-    "baseUrl": ".",
-    "paths": {
-      "~components/*": ["../../packages/sit-onyx/src/components/*"]
-    }
+    "baseUrl": "."
   }
 }

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -1,18 +1,7 @@
 import { VITE_BASE_CONFIG } from "@sit-onyx/shared/vite.config.base";
-import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config
 export default defineConfig({
   ...VITE_BASE_CONFIG,
-  resolve: {
-    alias: {
-      "~components": getFilePath("../../packages/sit-onyx/src/components"),
-    },
-  },
 });
-
-/** Gets the given path while ensuring cross-platform and correct decoding */
-function getFilePath(path: string) {
-  return fileURLToPath(new URL(path, import.meta.url));
-}


### PR DESCRIPTION
We were currently using direct/relative imports for onyx components used in our VitePress docs. This required custom Vite/tsconfig options and might not be intuitive for new/External contributors taking a look at our codebase.

With our turbo repo setup, we can easily import directly from `sit-onyx` and turbo repo will make sure to build the components first. Like this our docs is just a regular consumer of the `sit-onyx` package, just like our playground and demo app.
