### PR TITLE
feat(OnyxMoreList): implement more indicator

### DIFF
--- a/.changeset/tame-wolves-push.md
+++ b/.changeset/tame-wolves-push.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": major
+---
+
+feat(OnyxMoreList): support more indicator

--- a/.changeset/tame-wolves-push.md
+++ b/.changeset/tame-wolves-push.md
@@ -8,3 +8,4 @@ Also changed the underlying logic to calculate the component visibility which is
 
 - OnyxMoreList: removed `disabled` property
 - useMoreList: removed `disabled` and `componentRefs` option, added required `listRef` and `moreIndicatorRef` option
+- OnyxNavButton: prevent warning for missing injection key

--- a/.changeset/tame-wolves-push.md
+++ b/.changeset/tame-wolves-push.md
@@ -7,5 +7,6 @@ feat(OnyxMoreList): support more indicator
 Also changed the underlying logic to calculate the component visibility which is now based on component widths instead of using IntersectionObservers.
 
 - OnyxMoreList: removed `disabled` property
+- OnyxMoreList: removed `is` property. Make sure to use the new `default` and `more` slots and bind the attributes passed to the slots using `v-bind`.
 - useMoreList: removed `disabled` and `componentRefs` option, added required `listRef` and `moreIndicatorRef` option
 - OnyxNavButton: prevent warning for missing injection key

--- a/.changeset/tame-wolves-push.md
+++ b/.changeset/tame-wolves-push.md
@@ -3,3 +3,8 @@
 ---
 
 feat(OnyxMoreList): support more indicator
+
+Also changed the underlying logic to calculate the component visibility which is now based on component widths instead of using IntersectionObservers.
+
+- OnyxMoreList: removed `disabled` property
+- useMoreList: removed `disabled` and `componentRefs` option, added required `listRef` and `moreIndicatorRef` option

--- a/packages/sit-onyx/.storybook/main.ts
+++ b/packages/sit-onyx/.storybook/main.ts
@@ -32,7 +32,11 @@ const config: StorybookConfig = {
   viteFinal: (config) => {
     return mergeConfig(config, {
       optimizeDeps: {
-        exclude: ["node_module/.cache/sb-vite", "node_module/.cache/storybook"],
+        exclude: [
+          "node_module/.cache/sb-vite",
+          "node_module/.cache/storybook",
+          "node_module/.cache",
+        ],
       },
     } satisfies typeof config);
   },

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.stories.ts
@@ -25,7 +25,7 @@ export const Default = {
     is: "div",
     injectionKey: NAV_BAR_MORE_LIST_INJECTION_KEY,
     default: () =>
-      Array.from({ length: 12 }, (_, index) => h(OnyxNavButton, { label: `Element ${index + 1}` })),
+      Array.from({ length: 16 }, (_, index) => h(OnyxNavButton, { label: `Element ${index + 1}` })),
     more: ({ hiddenElements }) =>
       h(
         "div",

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.stories.ts
@@ -25,7 +25,14 @@ export const Default = {
     is: "div",
     injectionKey: NAV_BAR_MORE_LIST_INJECTION_KEY,
     default: () =>
-      Array.from({ length: 24 }, (_, index) => h(OnyxNavButton, { label: `Element ${index + 1}` })),
-    more: ({ hiddenElements }) => h("div", `+${hiddenElements} more`),
+      Array.from({ length: 12 }, (_, index) => h(OnyxNavButton, { label: `Element ${index + 1}` })),
+    more: ({ hiddenElements }) =>
+      h(
+        "div",
+        {
+          style: `font-family: var(--onyx-font-family); color: var(--onyx-color-text-icons-neutral-soft)`,
+        },
+        `+${hiddenElements} more`,
+      ),
   },
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.stories.ts
@@ -6,7 +6,7 @@ import OnyxMoreList from "./OnyxMoreList.vue";
 
 /**
  * Support component for rendering a horizontal list of components with a "+ more" indicator.
- * If using custom or not natively supported components, make sure to implement the `useMoreChild()` composable in all child components.
+ * If using custom or not natively supported components, make sure to implement the `useMoreListChild()` composable in all child components.
  */
 const meta: Meta<typeof OnyxMoreList> = {
   title: "Support/MoreList",

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.stories.ts
@@ -22,15 +22,21 @@ type Story = StoryObj<typeof OnyxMoreList>;
 
 export const Default = {
   args: {
-    is: "div",
     injectionKey: NAV_BAR_MORE_LIST_INJECTION_KEY,
-    default: () =>
-      Array.from({ length: 16 }, (_, index) => h(OnyxNavButton, { label: `Element ${index + 1}` })),
-    more: ({ hiddenElements }) =>
+    default: ({ attributes }) =>
       h(
-        "div",
+        "ul",
+        { style: "padding: 0", role: "menu", ...attributes },
+        Array.from({ length: 16 }, (_, index) =>
+          h(OnyxNavButton, { label: `Element ${index + 1}` }),
+        ),
+      ),
+    more: ({ hiddenElements, attributes }) =>
+      h(
+        "span",
         {
           style: `font-family: var(--onyx-font-family); color: var(--onyx-color-text-icons-neutral-soft)`,
+          ...attributes,
         },
         `+${hiddenElements} more`,
       ),

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -35,7 +35,7 @@ provide(props.injectionKey, more);
 
 watch([more.visibleElements, more.hiddenElements], ([visibleElements, hiddenElements]) => {
   emit("visibilityChange", {
-    visibleElements: visibleElements?.length ?? 0,
+    visibleElements: visibleElements.length,
     hiddenElements: hiddenElements.length,
   });
 });
@@ -56,7 +56,7 @@ watch([more.visibleElements, more.hiddenElements], ([visibleElements, hiddenElem
       <slot
         name="more"
         :hidden-elements="more.hiddenElements.value.length"
-        :visible-elements="more.visibleElements.value?.length ?? 0"
+        :visible-elements="more.visibleElements.value.length"
       ></slot>
     </component>
   </component>
@@ -81,10 +81,6 @@ watch([more.visibleElements, more.hiddenElements], ([visibleElements, hiddenElem
     &__indicator {
       min-width: max-content;
       max-width: 100%;
-
-      > * {
-        visibility: visible !important;
-      }
     }
   }
 }

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -1,10 +1,6 @@
 <script lang="ts" setup>
-import { provide, reactive, ref, watch } from "vue";
-import {
-  useMoreList,
-  type HTMLOrInstanceRef,
-  type UseMoreListOptions,
-} from "../../composables/useMoreList";
+import { provide, ref, watch } from "vue";
+import { useMoreList, type HTMLOrInstanceRef } from "../../composables/useMoreList";
 import type { MoreListSlotBindings, OnyxMoreListProps } from "./types";
 
 const props = defineProps<OnyxMoreListProps>();
@@ -30,12 +26,11 @@ defineSlots<{
 const parentRef = ref<HTMLOrInstanceRef>();
 const listRef = ref<HTMLOrInstanceRef>();
 const moreIndicatorRef = ref<HTMLOrInstanceRef>();
-const components = reactive(new Map() satisfies UseMoreListOptions["components"]);
 
-const more = useMoreList({ parentRef, listRef, components, moreIndicatorRef });
+const more = useMoreList({ parentRef, listRef, moreIndicatorRef });
 
 // eslint-disable-next-line vue/no-setup-props-reactivity-loss -- provide does not support reactive symbols, this reactivity loss is mentioned in the property docs
-provide(props.injectionKey, { components, ...more });
+provide(props.injectionKey, more);
 
 watch([more.visibleElements, more.hiddenElements], ([visibleElements, hiddenElements]) => {
   emit("visibilityChange", {
@@ -79,7 +74,7 @@ watch([more.visibleElements, more.hiddenElements], ([visibleElements, hiddenElem
       display: inherit;
       align-items: inherit;
       gap: inherit;
-      overflow-x: hidden;
+      overflow-x: clip;
     }
 
     &__indicator {

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -15,7 +15,7 @@ const emit = defineEmits<{
 
 defineSlots<{
   /**
-   * List of components to render. Each child must implement the `useMoreChild()` composable.
+   * List of components to render. Each child must implement the `useMoreListChild()` composable.
    */
   default(): unknown;
   /**

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -17,11 +17,11 @@ defineSlots<{
   /**
    * List of components to render. Each child must implement the `useMoreListChild()` composable.
    */
-  default(): unknown;
+  default(props: { attributes: object }): unknown;
   /**
    * Slot to display at the end if not all default slot elements fit in the available width.
    */
-  more(props: MoreListSlotBindings): unknown;
+  more(props: MoreListSlotBindings & { attributes: object }): unknown;
 }>();
 
 const parentRef = ref<VueTemplateRefElement>();
@@ -42,24 +42,25 @@ watch(
 </script>
 
 <template>
-  <component :is="props.is" ref="parentRef" class="onyx-more-list">
-    <component :is="props.is" ref="listRef" class="onyx-more-list__elements">
-      <slot></slot>
-    </component>
+  <div ref="parentRef" class="onyx-more-list">
+    <slot
+      :attributes="{
+        ref: (el?: VueTemplateRefElement) => (listRef = el),
+        class: 'onyx-more-list__elements',
+      }"
+    ></slot>
 
-    <component
-      :is="props.is"
+    <slot
       v-if="more.hiddenElements.value.length > 0"
-      ref="moreIndicatorRef"
-      class="onyx-more-list__indicator"
-    >
-      <slot
-        name="more"
-        :hidden-elements="more.hiddenElements.value.length"
-        :visible-elements="more.visibleElements.value.length"
-      ></slot>
-    </component>
-  </component>
+      name="more"
+      :attributes="{
+        ref: (el?: VueTemplateRefElement) => (moreIndicatorRef = el),
+        class: 'onyx-more-list__indicator',
+      }"
+      :hidden-elements="more.hiddenElements.value.length"
+      :visible-elements="more.visibleElements.value.length"
+    ></slot>
+  </div>
 </template>
 
 <style lang="scss">

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -45,26 +45,49 @@ watch([more.visibleElements, more.hiddenElements], ([visibleElements, hiddenElem
 </script>
 
 <template>
-  <component :is="props.is" ref="parentRef" class="onyx-more">
-    <slot></slot>
-    <slot
+  <component :is="props.is" class="onyx-more-list">
+    <component :is="props.is" ref="parentRef" class="onyx-more-list__elements">
+      <slot></slot>
+    </component>
+
+    <component
+      :is="props.is"
       v-if="more.hiddenElements.value.length > 0"
-      name="more"
-      :hidden-elements="more.hiddenElements.value.length"
-      :visible-elements="more.visibleElements.value.length"
-    ></slot>
+      class="onyx-more-list__indicator"
+    >
+      <slot
+        name="more"
+        :hidden-elements="more.hiddenElements.value.length"
+        :visible-elements="more.visibleElements.value.length"
+      ></slot>
+    </component>
   </component>
 </template>
 
 <style lang="scss">
 @use "../../styles/mixins/layers.scss";
 
-.onyx-more {
+.onyx-more-list {
   @include layers.component() {
     display: flex;
     align-items: center;
     gap: var(--onyx-spacing-4xs);
-    overflow-x: clip;
+
+    &__elements {
+      display: inherit;
+      align-items: inherit;
+      gap: inherit;
+      overflow-x: hidden;
+    }
+
+    &__indicator {
+      min-width: max-content;
+      max-width: 100%;
+
+      > * {
+        visibility: visible !important;
+      }
+    }
   }
 }
 </style>

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -38,7 +38,7 @@ provide(props.injectionKey, {
 
 watch([more.visibleElements, more.hiddenElements], ([visibleElements, hiddenElements]) => {
   emit("visibilityChange", {
-    visibleElements: visibleElements.length,
+    visibleElements: visibleElements?.length ?? 0,
     hiddenElements: hiddenElements.length,
   });
 });
@@ -58,7 +58,7 @@ watch([more.visibleElements, more.hiddenElements], ([visibleElements, hiddenElem
       <slot
         name="more"
         :hidden-elements="more.hiddenElements.value.length"
-        :visible-elements="more.visibleElements.value.length"
+        :visible-elements="more.visibleElements.value?.length ?? 0"
       ></slot>
     </component>
   </component>

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { provide, ref, watch } from "vue";
 import { useMoreList } from "../../composables/useMoreList";
-import type { HTMLOrInstanceRef } from "../../composables/useResizeObserver";
+import type { VueTemplateRefElement } from "../../composables/useResizeObserver";
 import type { MoreListSlotBindings, OnyxMoreListProps } from "./types";
 
 const props = defineProps<OnyxMoreListProps>();
@@ -24,9 +24,9 @@ defineSlots<{
   more(props: MoreListSlotBindings): unknown;
 }>();
 
-const parentRef = ref<HTMLOrInstanceRef>();
-const listRef = ref<HTMLOrInstanceRef>();
-const moreIndicatorRef = ref<HTMLOrInstanceRef>();
+const parentRef = ref<VueTemplateRefElement>();
+const listRef = ref<VueTemplateRefElement>();
+const moreIndicatorRef = ref<VueTemplateRefElement>();
 
 const more = useMoreList({ parentRef, listRef, moreIndicatorRef });
 

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -33,12 +33,12 @@ const more = useMoreList({ parentRef, listRef, moreIndicatorRef });
 // eslint-disable-next-line vue/no-setup-props-reactivity-loss -- provide does not support reactive symbols, this reactivity loss is mentioned in the property docs
 provide(props.injectionKey, more);
 
-watch([more.visibleElements, more.hiddenElements], ([visibleElements, hiddenElements]) => {
-  emit("visibilityChange", {
-    visibleElements: visibleElements.length,
-    hiddenElements: hiddenElements.length,
-  });
-});
+watch(
+  [() => more.visibleElements.value.length, () => more.hiddenElements.value.length],
+  ([visibleElements, hiddenElements]) => {
+    emit("visibilityChange", { visibleElements, hiddenElements });
+  },
+);
 </script>
 
 <template>

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { provide, reactive, ref, toRef, watch, type Ref } from "vue";
 import { useMoreList, type HTMLOrInstanceRef } from "../../composables/useMoreList";
+import { useResizeObserver } from "../../composables/useResizeObserver";
 import type { MoreListSlotBindings, OnyxMoreListProps } from "./types";
 
 const props = defineProps<OnyxMoreListProps>();
@@ -28,12 +29,14 @@ const componentRefs = reactive(new Map<string, Ref<HTMLOrInstanceRef>>());
 const disabled = toRef(props, "disabled");
 
 const more = useMoreList({ parentRef, componentRefs, disabled });
+const { width } = useResizeObserver();
 
 // eslint-disable-next-line vue/no-setup-props-reactivity-loss -- provide does not support reactive symbols, this reactivity loss is mentioned in the property docs
 provide(props.injectionKey, {
   components: componentRefs,
   visibleElements: more.visibleElements,
   disabled,
+  width,
 });
 
 watch([more.visibleElements, more.hiddenElements], ([visibleElements, hiddenElements]) => {

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { provide, ref, watch } from "vue";
-import { useMoreList, type HTMLOrInstanceRef } from "../../composables/useMoreList";
+import { useMoreList } from "../../composables/useMoreList";
+import type { HTMLOrInstanceRef } from "../../composables/useResizeObserver";
 import type { MoreListSlotBindings, OnyxMoreListProps } from "./types";
 
 const props = defineProps<OnyxMoreListProps>();

--- a/packages/sit-onyx/src/components/OnyxMoreList/TestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/TestWrapper.ct.vue
@@ -20,28 +20,30 @@ const COMPONENT_WIDTH = "8rem";
 
 <template>
   <OnyxMoreList
-    is="ul"
     class="list"
-    role="menu"
     :injection-key="NAV_BAR_MORE_LIST_INJECTION_KEY"
     :style="{
       width: props.count ? `calc(${props.count} * ${COMPONENT_WIDTH})` : undefined,
     }"
     @visibility-change="emit('visibilityChange', $event)"
   >
-    <OnyxNavButton
-      v-for="i in 24"
-      :key="i"
-      :label="`Element ${i}`"
-      :style="{ minWidth: COMPONENT_WIDTH }"
-    />
+    <template #default="{ attributes }">
+      <ul v-bind="attributes" role="menu">
+        <OnyxNavButton
+          v-for="i in 24"
+          :key="i"
+          :label="`Element ${i}`"
+          :style="{ minWidth: COMPONENT_WIDTH }"
+        />
+      </ul>
+    </template>
   </OnyxMoreList>
 </template>
 
 <!-- eslint-disable-next-line vue-scoped-css/enforce-style-type -->
 <style scoped>
-.list {
+:deep(.onyx-more-list__elements),
+:deep(.onyx-more-list__indicator) {
   padding: 0;
-  gap: 0;
 }
 </style>

--- a/packages/sit-onyx/src/components/OnyxMoreList/types.ts
+++ b/packages/sit-onyx/src/components/OnyxMoreList/types.ts
@@ -10,11 +10,6 @@ export type OnyxMoreListProps = {
    * Will not be reactive so it must not be changed.
    */
   injectionKey: MoreListInjectionKey;
-  /**
-   * Whether the intersection observer should be disabled (e.g. when more feature is currently not needed due to mobile layout).
-   * Can increase performance.
-   */
-  disabled?: boolean;
 };
 
 export type MoreListSlotBindings = {

--- a/packages/sit-onyx/src/components/OnyxMoreList/types.ts
+++ b/packages/sit-onyx/src/components/OnyxMoreList/types.ts
@@ -2,10 +2,6 @@ import type { MoreListInjectionKey } from "../../composables/useMoreList";
 
 export type OnyxMoreListProps = {
   /**
-   * Component to render (e.g. `<ul>` or `<div>`).
-   */
-  is: string;
-  /**
    * Injection key to use. Must match the one used in the child components.
    * Will not be reactive so it must not be changed.
    */

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavButton/OnyxNavButton.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavButton/OnyxNavButton.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import chevronRightSmall from "@sit-onyx/icons/chevron-right-small.svg?raw";
-import { computed, inject, toRef } from "vue";
+import { computed, inject, ref, toRef } from "vue";
 import { MANAGED_SYMBOL, useManagedState } from "../../../../composables/useManagedState";
 import { useMoreListChild } from "../../../../composables/useMoreList";
 import OnyxExternalLinkIcon from "../../../OnyxExternalLinkIcon/OnyxExternalLinkIcon.vue";
@@ -37,7 +37,7 @@ const slots = defineSlots<{
   children?(): unknown;
 }>();
 
-const isMobile = inject(MOBILE_NAV_BAR_INJECTION_KEY);
+const isMobile = inject(MOBILE_NAV_BAR_INJECTION_KEY, () => ref(false), true);
 const hasChildren = computed(() => !!slots.children);
 const { componentRef, isVisible } = useMoreListChild(NAV_BAR_MORE_LIST_INJECTION_KEY);
 

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavButton/OnyxNavButton.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavButton/OnyxNavButton.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import chevronRightSmall from "@sit-onyx/icons/chevron-right-small.svg?raw";
-import { computed, inject, ref, toRef } from "vue";
+import { computed, inject, toRef } from "vue";
 import { MANAGED_SYMBOL, useManagedState } from "../../../../composables/useManagedState";
 import { useMoreListChild } from "../../../../composables/useMoreList";
 import OnyxExternalLinkIcon from "../../../OnyxExternalLinkIcon/OnyxExternalLinkIcon.vue";
@@ -37,7 +37,10 @@ const slots = defineSlots<{
   children?(): unknown;
 }>();
 
-const isMobile = inject(MOBILE_NAV_BAR_INJECTION_KEY, () => ref(false), true);
+const isMobile = inject(
+  MOBILE_NAV_BAR_INJECTION_KEY,
+  computed(() => false),
+);
 const hasChildren = computed(() => !!slots.children);
 const { componentRef, isVisible } = useMoreListChild(NAV_BAR_MORE_LIST_INJECTION_KEY);
 

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavButton/OnyxNavButton.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavButton/OnyxNavButton.vue
@@ -58,6 +58,7 @@ const handleParentClick = (event: MouseEvent) => {
 
 <template>
   <NavButtonLayout
+    v-show="isMobile || isVisible"
     ref="componentRef"
     v-bind="props"
     v-model:mobile-children-open="mobileChildrenOpen"
@@ -65,7 +66,6 @@ const handleParentClick = (event: MouseEvent) => {
     :class="{
       'onyx-nav-button--mobile': isMobile,
       'onyx-nav-button--active': props.active,
-      'onyx-nav-button--hidden': !isMobile && !isVisible,
     }"
     :is-mobile="isMobile ?? false"
   >
@@ -109,10 +109,6 @@ $border-radius: var(--onyx-radius-sm);
     position: relative;
     $gap: var(--onyx-spacing-2xs);
     list-style: none;
-
-    &--hidden {
-      visibility: hidden;
-    }
 
     &__trigger {
       display: inline-flex;

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavSeparator/OnyxNavSeparator.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavSeparator/OnyxNavSeparator.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { inject } from "vue";
+import { computed, inject } from "vue";
 import { MOBILE_NAV_BAR_INJECTION_KEY } from "../../../OnyxNavBar/types";
 import type { OnyxNavSeparatorProps } from "./types";
 
@@ -7,7 +7,10 @@ const props = withDefaults(defineProps<OnyxNavSeparatorProps>(), {
   orientation: "vertical",
 });
 
-const isMobile = inject(MOBILE_NAV_BAR_INJECTION_KEY);
+const isMobile = inject(
+  MOBILE_NAV_BAR_INJECTION_KEY,
+  computed(() => false),
+);
 </script>
 
 <template>

--- a/packages/sit-onyx/src/composables/useMoreList.ts
+++ b/packages/sit-onyx/src/composables/useMoreList.ts
@@ -13,7 +13,7 @@ import {
 import {
   getTemplateRefElement,
   useResizeObserver,
-  type HTMLOrInstanceRef,
+  type VueTemplateRefElement,
 } from "./useResizeObserver";
 
 /**
@@ -25,15 +25,15 @@ export type UseMoreListOptions = {
   /**
    * Vue template ref for the parent element containing the more indicator as well as the list of components.
    */
-  parentRef: Ref<HTMLOrInstanceRef>;
+  parentRef: Ref<VueTemplateRefElement>;
   /**
    * Vue template ref for the element containing the list of components.
    */
-  listRef: Ref<HTMLOrInstanceRef>;
+  listRef: Ref<VueTemplateRefElement>;
   /**
    * Vue template ref for the more indicator element that might be shown if not all elements are visible.
    */
-  moreIndicatorRef: Ref<HTMLOrInstanceRef>;
+  moreIndicatorRef: Ref<VueTemplateRefElement>;
 };
 
 /**
@@ -174,7 +174,7 @@ export const useMoreList = (options: UseMoreListOptions) => {
 /**
  * Gets the CSS column-gap property for the given element or 0 if invalid or unset.
  */
-const getColumnGap = (ref: HTMLOrInstanceRef) => {
+const getColumnGap = (ref: VueTemplateRefElement) => {
   const element = getTemplateRefElement(ref);
   if (!element) return 0;
   // we use "|| 0" here to fallback to zero for NaN values when no/invalid gap exist
@@ -198,7 +198,7 @@ const getColumnGap = (ref: HTMLOrInstanceRef) => {
  */
 export const useMoreListChild = (injectionKey: MoreListInjectionKey) => {
   const id = useId();
-  const componentRef = ref<HTMLOrInstanceRef>();
+  const componentRef = ref<VueTemplateRefElement>();
   const moreContext = inject(injectionKey);
   const { width } = useResizeObserver(componentRef);
 

--- a/packages/sit-onyx/src/composables/useMoreList.ts
+++ b/packages/sit-onyx/src/composables/useMoreList.ts
@@ -1,16 +1,17 @@
-import { debounce } from "@sit-onyx/headless";
 import {
   computed,
   inject,
-  nextTick,
   onBeforeUnmount,
+  onMounted,
   ref,
   unref,
   useId,
   watch,
+  watchEffect,
   type InjectionKey,
   type Ref,
 } from "vue";
+import { useResizeObserver } from "./useResizeObserver";
 
 /**
  * Template ref of either a native HTML element or a custom Vue component.
@@ -20,141 +21,92 @@ export type HTMLOrInstanceRef = Element | { $el: Element } | null | undefined;
 /**
  * Injection key for providing "more" data to child components of a list to e.g. render a "+3 more" indicator.
  */
-export type MoreListInjectionKey = InjectionKey<{
-  /**
-   * Map of components in the list. Key = unique ID, value = component template ref
-   */
-  components: Map<string, Ref<HTMLOrInstanceRef>>;
-  /**
-   * List of component IDs that are currently fully visible.
-   * If undefined, the visibility has not yet been initialized.
-   */
-  visibleElements: Ref<string[] | undefined>;
-  /**
-   * Whether the intersection observer should be disabled (e.g. when more feature is currently not needed due to mobile layout).
-   */
-  disabled: Ref<boolean>;
-  /**
-   * Current width of the viewport. Can be used to react on user resizes.
-   */
-  width: Ref<number>;
-}>;
+export type MoreListInjectionKey = InjectionKey<
+  ReturnType<typeof useMoreList> & {
+    /**
+     * Map of components in the list. Key = unique ID, value = component template ref
+     */
+    components: UseMoreListOptions["components"];
+  }
+>;
 
 export type UseMoreListOptions = {
   /**
-   * Vue template ref for the parent element containing the list of components.
+   * Vue template ref for the parent element containing the more indicator as well as the list of components.
    */
   parentRef: Ref<HTMLOrInstanceRef>;
   /**
+   * Vue template ref for the element containing the list of components.
+   */
+  listRef: Ref<HTMLOrInstanceRef>;
+  moreIndicatorRef: Ref<HTMLOrInstanceRef>;
+  /**
    * Refs for the individual components in the list.
    */
-  componentRefs: Map<string, Ref<HTMLOrInstanceRef>>;
-  /**
-   * Whether the intersection observer should be disabled (e.g. when more feature is currently not needed due to mobile layout).
-   */
-  disabled?: Ref<boolean>;
+  components: Map<string, { width: Ref<number> }>;
 };
 
-/**
- * Composable for managing a list of components where e.g. a "+3" more indicator should be shown if not all components
- * fit into the available width.
- *
- * @example
- *
- * ```vue
- * <script lang="ts" setup>
- * import { ref, type ComponentInstance } from "vue";
- * import { useMore } from "../../composables/useMore";
- * import OnyxNavButton from "../OnyxNavBar/modules/OnyxNavButton/OnyxNavButton.vue";
- *
- * const parentRef = ref<HTMLElement>();
- * const componentRefs = ref<ComponentInstance<typeof OnyxNavButton>[]>([]);
- *
- * const { visibleElements, hiddenElements } = useMore({ parentRef, componentRefs });
- * </script>
- *
- * <template>
- *   <div ref="parentRef" class="onyx-more">
- *     <OnyxNavButton v-for="i in 16" ref="componentRefs" :key="i" :label="`Nav button ${i}`" />
- *   </div>
- * </template>
- *
- * <style lang="scss">
- * @use "../../styles/mixins/layers.scss";
- *
- * .onyx-more {
- *   @include layers.component() {
- *     display: flex;
- *     align-items: center;
- *     overflow-x: clip;
- *   }
- * }
- * </style>
- * ```
- */
 export const useMoreList = (options: UseMoreListOptions) => {
-  const visibleElements = ref<string[]>();
+  const visibleElements = ref<string[]>([]);
+  const hiddenElements = ref<string[]>([]);
 
-  const hiddenElements = computed(() => {
-    return Array.from(options.componentRefs.keys()).filter(
-      (key) => !visibleElements.value?.includes(key),
-    );
-  });
+  const { width: parentWidth } = useResizeObserver(
+    computed(() => getTemplateRefElement(options.parentRef.value)),
+  );
 
-  const observer = ref<IntersectionObserver>();
-  onBeforeUnmount(() => observer.value?.disconnect());
+  const { width: indicatorWidth } = useResizeObserver(
+    computed(() => getTemplateRefElement(options.moreIndicatorRef.value)),
+  );
 
+  const widthMap = ref(new Map<string, number>());
+
+  // sync widthMap to components but keep component width if it changes to zero (e.g. because the element is hidden)
+  // so we can continue calculating if hidden elements would fit into the available width if resized
   watch(
-    [options.parentRef, options.componentRefs, options.disabled],
-    () => {
-      observer.value?.disconnect(); // reset observer before all changes
-
-      const root = getTemplateRefElement(options.parentRef.value);
-      if (!root || options.disabled?.value) {
-        visibleElements.value = undefined;
-        return;
-      }
-
-      observer.value = new IntersectionObserver(
-        (changeEntries) => {
-          // changeEntries contains all changed component visibilities (not all available components)
-          // if component is shown, intersectionRatio is 1, otherwise its completely or partially hidden
-          const shownIds: string[] = [];
-          const hiddenIds: string[] = [];
-
-          changeEntries.forEach((entry) => {
-            const elementId = Array.from(options.componentRefs).find(([_, element]) => {
-              return getTemplateRefElement(unref(element)) === entry.target;
-            })?.[0];
-            if (!elementId) return;
-
-            const isFullyVisible = entry.intersectionRatio === 1;
-
-            if (isFullyVisible) shownIds.push(elementId);
-            else hiddenIds.push(elementId);
-          });
-
-          if (!visibleElements.value?.length) {
-            visibleElements.value = shownIds;
-          } else {
-            visibleElements.value = visibleElements.value
-              // remove now hidden elements
-              .filter((id) => !hiddenIds.includes(id))
-              // add newly visible elements
-              .concat(shownIds);
-          }
-        },
-        { root, threshold: 1 },
-      );
-
-      options.componentRefs.forEach((ref) => {
-        const element = getTemplateRefElement(unref(ref));
-        if (!element) return;
-        observer.value?.observe(element);
+    options.components,
+    (newValue) => {
+      newValue.forEach((value, key) => {
+        const newWidth = unref(value.width);
+        if (widthMap.value.has(key) && newWidth === 0) return;
+        widthMap.value.set(key, newWidth);
       });
     },
-    { immediate: true },
+    { deep: true, immediate: true },
   );
+
+  onMounted(() => {
+    watchEffect(() => {
+      const parentGap = getColumnGap(options.parentRef.value);
+      const listGap = getColumnGap(options.listRef.value);
+      let availableWidth = parentWidth.value;
+      if (indicatorWidth.value > 0) {
+        availableWidth -= indicatorWidth.value + parentGap;
+      }
+      if (availableWidth <= 0) return;
+
+      const { visible, hidden } = Array.from(widthMap.value.entries()).reduce(
+        (acc, [id, componentWidth], index) => {
+          availableWidth -= componentWidth + (index > 0 ? listGap : 0);
+
+          if (
+            availableWidth >= 0 ||
+            // check if last element would fit if more indicator is gone
+            (index === widthMap.value.size - 1 && availableWidth + indicatorWidth.value >= 0)
+          ) {
+            acc.visible.push(id);
+          } else {
+            acc.hidden.push(id);
+          }
+
+          return acc;
+        },
+        { visible: [] as string[], hidden: [] as string[] },
+      );
+
+      visibleElements.value = visible;
+      hiddenElements.value = hidden;
+    });
+  });
 
   return {
     /**
@@ -177,86 +129,25 @@ const getTemplateRefElement = (ref: HTMLOrInstanceRef) => {
 };
 
 /**
- * Composable that must be implemented in all list children when using `useMore` to correctly observe the visibility of the elements.
- *
- * @example
- *
- * ```vue
- * <script lang="ts" setup
- * const { componentRef, isVisible } = useMoreChild();
- * </script>
- *
- * <template
- *  <div ref="componentRef" :class="{ hidden: !isVisible }"> Your content... </div>
- * </template>
- *
- * <style>
- * .hidden {
- *  visibility: hidden;
- * }
- * </style>
- * ```
+ * Gets the CSS column-gap property for the given element or 0 if invalid or unset.
  */
+const getColumnGap = (ref: HTMLOrInstanceRef) => {
+  const element = getTemplateRefElement(ref);
+  if (!element) return 0;
+  // we use "|| 0" here to fallback to zero for NaN values when no/invalid gap exist
+  return Number.parseFloat(getComputedStyle(element).columnGap) || 0;
+};
+
 export const useMoreListChild = (injectionKey: MoreListInjectionKey) => {
   const id = useId();
   const componentRef = ref<HTMLOrInstanceRef>();
+  const { width } = useResizeObserver(computed(() => getTemplateRefElement(componentRef.value)));
   const moreContext = inject(injectionKey);
 
-  moreContext?.components?.set(id, componentRef);
+  moreContext?.components?.set(id, { width });
   onBeforeUnmount(() => moreContext?.components?.delete(id));
 
-  const isVisible = ref(true);
-
-  // we debounce the width here and watch this instead for better performance and less
-  // visual flickering since we are force rendering and then hiding elements over and over again
-  // while resizing to check visibility
-  const debouncedWidth = ref(0);
-  const updateDebouncedWidth = debounce((width: number) => (debouncedWidth.value = width), 25);
-  watch(
-    () => moreContext?.width.value,
-    (newWidth) => updateDebouncedWidth(newWidth ?? 0),
-    { immediate: true },
-  );
-
-  const updateVisible = () => {
-    isVisible.value =
-      moreContext?.disabled.value || (moreContext?.visibleElements.value?.includes(id) ?? true);
-  };
-
-  // this watcher updates the visibility whenever the visible elements defined by the intersection observer
-  // change = screen is resized smaller
-  watch(
-    () => moreContext?.visibleElements.value,
-    () => updateVisible(),
-    { deep: true },
-  );
-
-  // force render of the tab when screen is resized bigger so new visibility can checked
-  //  again by the intersection observer
-  watch([debouncedWidth], async ([newWidth], [oldWidth]) => {
-    const wasVisible = isVisible.value;
-    const element = getTemplateRefElement(componentRef.value);
-    if (wasVisible || newWidth < oldWidth || !element) return;
-
-    isVisible.value = true;
-
-    await nextTick();
-
-    // this intersection observer is used/needed to actually wait until the component has been rendered
-    // so we can check/update the new visibility afterwards
-    await new Promise((resolve) => {
-      const intersectionObserver = new IntersectionObserver(
-        (entries) => {
-          const fullyVisible = entries.at(0)?.intersectionRatio === 1;
-          resolve(fullyVisible);
-        },
-        { root: element.parentElement, threshold: 0 },
-      );
-      intersectionObserver.observe(element);
-    });
-
-    updateVisible();
-  });
+  const isVisible = computed(() => !moreContext?.hiddenElements.value.includes(id));
 
   return {
     /**

--- a/packages/sit-onyx/src/composables/useMoreList.ts
+++ b/packages/sit-onyx/src/composables/useMoreList.ts
@@ -10,12 +10,11 @@ import {
   type InjectionKey,
   type Ref,
 } from "vue";
-import { useResizeObserver } from "./useResizeObserver";
-
-/**
- * Template ref of either a native HTML element or a custom Vue component.
- */
-export type HTMLOrInstanceRef = Element | { $el: Element } | null | undefined;
+import {
+  getTemplateRefElement,
+  useResizeObserver,
+  type HTMLOrInstanceRef,
+} from "./useResizeObserver";
 
 /**
  * Injection key for providing "more" data to child components of a list to e.g. render a "+3 more" indicator.
@@ -41,13 +40,8 @@ export const useMoreList = (options: UseMoreListOptions) => {
   const visibleElements = ref<string[]>([]);
   const hiddenElements = ref<string[]>([]);
 
-  const { width: parentWidth } = useResizeObserver(
-    computed(() => getTemplateRefElement(options.parentRef.value)),
-  );
-
-  const { width: moreIndicatorWidth } = useResizeObserver(
-    computed(() => getTemplateRefElement(options.moreIndicatorRef.value)),
-  );
+  const { width: parentWidth } = useResizeObserver(options.parentRef);
+  const { width: moreIndicatorWidth } = useResizeObserver(options.moreIndicatorRef);
 
   // type casting is needed to prevent TypeScript from unwrapping the type which will lead to "width" being a single number instead of Ref<number>
   const componentMap = ref(new Map()) as Ref<Map<string, { width: Ref<number> }>>;
@@ -126,13 +120,6 @@ export const useMoreList = (options: UseMoreListOptions) => {
 };
 
 /**
- * Gets the native HTML element of a template ref.
- */
-const getTemplateRefElement = (ref: HTMLOrInstanceRef) => {
-  return ref instanceof Element ? ref : ref?.$el;
-};
-
-/**
  * Gets the CSS column-gap property for the given element or 0 if invalid or unset.
  */
 const getColumnGap = (ref: HTMLOrInstanceRef) => {
@@ -146,7 +133,7 @@ export const useMoreListChild = (injectionKey: MoreListInjectionKey) => {
   const id = useId();
   const componentRef = ref<HTMLOrInstanceRef>();
   const moreContext = inject(injectionKey);
-  const { width } = useResizeObserver(computed(() => getTemplateRefElement(componentRef.value)));
+  const { width } = useResizeObserver(componentRef);
 
   moreContext?.componentMap.value.set(id, { width });
   onBeforeUnmount(() => moreContext?.componentMap.value.delete(id));

--- a/packages/sit-onyx/src/composables/useMoreList.ts
+++ b/packages/sit-onyx/src/composables/useMoreList.ts
@@ -36,6 +36,58 @@ export type UseMoreListOptions = {
   moreIndicatorRef: Ref<HTMLOrInstanceRef>;
 };
 
+/**
+ * Composable for managing a list of components where e.g. a "+3" more indicator should be shown if not all components
+ * fit into the available width.
+ *
+ * @example
+ *
+ * ```vue
+ * <script lang="ts" setup>
+ * import { provide, ref, watch } from "vue";
+ * import { useMoreList, NAV_BAR_MORE_LIST_INJECTION_KEY } from "sit-onyx";
+ *
+ * const parentRef = ref<HTMLElement>();
+ * const listRef = ref<HTMLElement>();
+ * const moreIndicatorRef = ref<HTMLElement>();
+ *
+ * const more = useMoreList({ parentRef, listRef, moreIndicatorRef });
+ * provide(NAV_BAR_MORE_LIST_INJECTION_KEY, more);
+ * </script>
+ *
+ * <template>
+ *   <div ref="parentRef" class="more-list">
+ *     <div ref="listRef" class="more-list__elements">
+ *        <OnyxNavButton v-for="i in 16" ref="componentRefs" :key="i" :label="`Nav button ${i}`" />
+ *     </div>
+ *
+ *     <div ref="moreIndicatorRef" class="more-list__indicator">
+ *        +{{ more.hiddenElements.value.length }} more
+ *     </div>
+ *   </div>
+ * </template>
+ *
+ * <style lang="scss">
+ * .more-list {
+ *   display: flex;
+ *   align-items: center;
+ *   gap: var(--onyx-spacing-4xs);
+ *
+ *   &__elements {
+ *     display: inherit;
+ *     align-items: inherit;
+ *     gap: inherit;
+ *     overflow-x: clip;
+ *    }
+ *
+ *   &__indicator {
+ *     min-width: max-content;
+ *     max-width: 100%;
+ *   }
+ * }
+ * </style>
+ * ```
+ */
 export const useMoreList = (options: UseMoreListOptions) => {
   const visibleElements = ref<string[]>([]);
   const hiddenElements = ref<string[]>([]);
@@ -129,6 +181,21 @@ const getColumnGap = (ref: HTMLOrInstanceRef) => {
   return Number.parseFloat(getComputedStyle(element).columnGap) || 0;
 };
 
+/**
+ * Composable that must be implemented in all list children when using `useMoreList` to correctly observe the visibility of the elements.
+ *
+ * @example
+ *
+ * ```vue
+ * <script lang="ts" setup
+ * const { componentRef, isVisible } = useMoreListChild();
+ * </script>
+ *
+ * <template
+ *  <div v-show="isVisible" ref="componentRef"> Your content... </div>
+ * </template>
+ * ```
+ */
 export const useMoreListChild = (injectionKey: MoreListInjectionKey) => {
   const id = useId();
   const componentRef = ref<HTMLOrInstanceRef>();
@@ -147,8 +214,7 @@ export const useMoreListChild = (injectionKey: MoreListInjectionKey) => {
     componentRef,
     /**
      * Whether the component is currently visible.
-     * Should hide itself visually (e.g. using "visibility: hidden").
-     * Do not use v-if, v-show or "display: none" since the more feature does not work then when resizing
+     * Should hide itself visually (e.g. using `v-show="isVisible"`).
      */
     isVisible,
   };

--- a/packages/sit-onyx/src/composables/useMoreList.ts
+++ b/packages/sit-onyx/src/composables/useMoreList.ts
@@ -205,7 +205,7 @@ export const useMoreListChild = (injectionKey: MoreListInjectionKey) => {
   moreContext?.componentMap.value.set(id, { width });
   onBeforeUnmount(() => moreContext?.componentMap.value.delete(id));
 
-  const isVisible = computed(() => moreContext?.visibleElements.value.includes(id));
+  const isVisible = computed(() => moreContext?.visibleElements.value.includes(id) ?? true);
 
   return {
     /**

--- a/packages/sit-onyx/src/composables/useMoreList.ts
+++ b/packages/sit-onyx/src/composables/useMoreList.ts
@@ -182,7 +182,7 @@ const getColumnGap = (ref: VueTemplateRefElement) => {
 export const useMoreListChild = (injectionKey: MoreListInjectionKey) => {
   const id = useId();
   const componentRef = ref<VueTemplateRefElement>();
-  const moreContext = inject(injectionKey);
+  const moreContext = inject(injectionKey, undefined);
   const { width } = useResizeObserver(componentRef);
 
   watch(

--- a/packages/sit-onyx/src/composables/useMoreList.ts
+++ b/packages/sit-onyx/src/composables/useMoreList.ts
@@ -6,7 +6,6 @@ import {
   ref,
   unref,
   useId,
-  watch,
   watchEffect,
   type InjectionKey,
   type Ref,
@@ -21,14 +20,7 @@ export type HTMLOrInstanceRef = Element | { $el: Element } | null | undefined;
 /**
  * Injection key for providing "more" data to child components of a list to e.g. render a "+3 more" indicator.
  */
-export type MoreListInjectionKey = InjectionKey<
-  ReturnType<typeof useMoreList> & {
-    /**
-     * Map of components in the list. Key = unique ID, value = component template ref
-     */
-    components: UseMoreListOptions["components"];
-  }
->;
+export type MoreListInjectionKey = InjectionKey<ReturnType<typeof useMoreList>>;
 
 export type UseMoreListOptions = {
   /**
@@ -39,11 +31,10 @@ export type UseMoreListOptions = {
    * Vue template ref for the element containing the list of components.
    */
   listRef: Ref<HTMLOrInstanceRef>;
-  moreIndicatorRef: Ref<HTMLOrInstanceRef>;
   /**
-   * Refs for the individual components in the list.
+   * Vue template ref for the more indicator element that might be shown if not all elements are visible.
    */
-  components: Map<string, { width: Ref<number> }>;
+  moreIndicatorRef: Ref<HTMLOrInstanceRef>;
 };
 
 export const useMoreList = (options: UseMoreListOptions) => {
@@ -54,44 +45,51 @@ export const useMoreList = (options: UseMoreListOptions) => {
     computed(() => getTemplateRefElement(options.parentRef.value)),
   );
 
-  const { width: indicatorWidth } = useResizeObserver(
+  const { width: moreIndicatorWidth } = useResizeObserver(
     computed(() => getTemplateRefElement(options.moreIndicatorRef.value)),
   );
 
-  const widthMap = ref(new Map<string, number>());
+  // type casting is needed to prevent TypeScript from unwrapping the type which will lead to "width" being a single number instead of Ref<number>
+  const componentMap = ref(new Map()) as Ref<Map<string, { width: Ref<number> }>>;
+
+  /**
+   * Map of all component widths. Key = component ID, value = component width.
+   * If component is hidden, this map will still include the previous width.
+   */
+  const memorizedComponentWidthMap = ref(new Map<string, number>());
 
   // sync widthMap to components but keep component width if it changes to zero (e.g. because the element is hidden)
   // so we can continue calculating if hidden elements would fit into the available width if resized
-  watch(
-    options.components,
-    (newValue) => {
-      newValue.forEach((value, key) => {
-        const newWidth = unref(value.width);
-        if (widthMap.value.has(key) && newWidth === 0) return;
-        widthMap.value.set(key, newWidth);
-      });
-    },
-    { deep: true, immediate: true },
-  );
+  watchEffect(() => {
+    componentMap.value.forEach((value, key) => {
+      const newWidth = unref(value.width);
+      if (memorizedComponentWidthMap.value.has(key) && newWidth === 0) return;
+      memorizedComponentWidthMap.value.set(key, newWidth);
+    });
+  });
 
   onMounted(() => {
     watchEffect(() => {
+      let availableWidth = parentWidth.value;
+      if (availableWidth <= 0) return; // parent width is not initialized yet
+
       const parentGap = getColumnGap(options.parentRef.value);
       const listGap = getColumnGap(options.listRef.value);
-      let availableWidth = parentWidth.value;
-      if (indicatorWidth.value > 0) {
-        availableWidth -= indicatorWidth.value + parentGap;
-      }
-      if (availableWidth <= 0) return;
 
-      const { visible, hidden } = Array.from(widthMap.value.entries()).reduce(
+      if (moreIndicatorWidth.value > 0) {
+        availableWidth -= moreIndicatorWidth.value + parentGap;
+      }
+
+      // calculate which components currently fully fit into the available parent width
+      const { visible, hidden } = Array.from(memorizedComponentWidthMap.value.entries()).reduce(
         (acc, [id, componentWidth], index) => {
           availableWidth -= componentWidth + (index > 0 ? listGap : 0);
 
           if (
             availableWidth >= 0 ||
-            // check if last element would fit if more indicator is gone
-            (index === widthMap.value.size - 1 && availableWidth + indicatorWidth.value >= 0)
+            // check if last element fits if more indicator would be hidden
+            (index === memorizedComponentWidthMap.value.size - 1 &&
+              availableWidth + moreIndicatorWidth.value >= 0)
           ) {
             acc.visible.push(id);
           } else {
@@ -111,13 +109,19 @@ export const useMoreList = (options: UseMoreListOptions) => {
   return {
     /**
      * IDs of currently completely visible components in the list.
-     * If undefined, the visibility has not yet been initialized.
      */
     visibleElements,
     /**
      * IDs of currently fully or partially hidden components in the list.
      */
     hiddenElements,
+    /**
+     * Map of widths for all components in the list. Key = component ID.
+     * Components in the list must inject this map and add a ref for their width to it.
+     *
+     * @see `useMoreListChild()`
+     */
+    componentMap,
   };
 };
 
@@ -141,13 +145,13 @@ const getColumnGap = (ref: HTMLOrInstanceRef) => {
 export const useMoreListChild = (injectionKey: MoreListInjectionKey) => {
   const id = useId();
   const componentRef = ref<HTMLOrInstanceRef>();
-  const { width } = useResizeObserver(computed(() => getTemplateRefElement(componentRef.value)));
   const moreContext = inject(injectionKey);
+  const { width } = useResizeObserver(computed(() => getTemplateRefElement(componentRef.value)));
 
-  moreContext?.components?.set(id, { width });
-  onBeforeUnmount(() => moreContext?.components?.delete(id));
+  moreContext?.componentMap.value.set(id, { width });
+  onBeforeUnmount(() => moreContext?.componentMap.value.delete(id));
 
-  const isVisible = computed(() => !moreContext?.hiddenElements.value.includes(id));
+  const isVisible = computed(() => moreContext?.visibleElements.value.includes(id));
 
   return {
     /**

--- a/packages/sit-onyx/src/composables/useMoreList.ts
+++ b/packages/sit-onyx/src/composables/useMoreList.ts
@@ -115,27 +115,23 @@ export const useMoreList = (options: UseMoreListOptions) => {
       }
 
       // calculate which components currently fully fit into the available parent width
-      const { visible, hidden } = Array.from(componentMap.entries()).reduce(
-        (acc, [id, componentWidth], index) => {
-          availableWidth -= componentWidth + (index > 0 ? listGap : 0);
+      // we don't need to worry about changing the refs multiple times here since Vue batches changes
+      visibleElements.value = [];
+      hiddenElements.value = [];
 
-          if (
-            availableWidth >= 0 ||
-            // check if last element fits if more indicator would be hidden
-            (index === componentMap.size - 1 && availableWidth + moreIndicatorWidth.value >= 0)
-          ) {
-            acc.visible.push(id);
-          } else {
-            acc.hidden.push(id);
-          }
+      Array.from(componentMap.entries()).forEach(([id, componentWidth], index) => {
+        availableWidth -= componentWidth + (index > 0 ? listGap : 0);
 
-          return acc;
-        },
-        { visible: [] as string[], hidden: [] as string[] },
-      );
-
-      visibleElements.value = visible;
-      hiddenElements.value = hidden;
+        if (
+          availableWidth >= 0 ||
+          // check if last element fits if more indicator would be hidden
+          (index === componentMap.size - 1 && availableWidth + moreIndicatorWidth.value >= 0)
+        ) {
+          visibleElements.value.push(id);
+        } else {
+          hiddenElements.value.push(id);
+        }
+      });
     });
   });
 

--- a/packages/sit-onyx/src/composables/useResizeObserver.spec.ts
+++ b/packages/sit-onyx/src/composables/useResizeObserver.spec.ts
@@ -6,7 +6,7 @@ vi.mock("vue", async (importOriginal) => {
   return {
     ...(await importOriginal()),
     // this will only affect "foo" outside of the original module
-    onBeforeMount: (callback) => callback(),
+    onMounted: (callback) => callback(),
     onBeforeUnmount: vi.fn(),
   } satisfies typeof import("vue");
 });

--- a/packages/sit-onyx/src/composables/useResizeObserver.ts
+++ b/packages/sit-onyx/src/composables/useResizeObserver.ts
@@ -13,7 +13,7 @@ export const useResizeObserver = (
   /**
    * Target to observe. If undefined, the documentElement will be observed.
    */
-  target?: Ref<HTMLElement | undefined>,
+  target?: Ref<Element | undefined>,
   options?: UseResizeObserverOptions,
 ) => {
   const box = options?.box ?? "content-box";
@@ -42,6 +42,11 @@ export const useResizeObserver = (
         (newTarget, oldTarget) => {
           if (oldTarget) observer?.unobserve(oldTarget);
           if (newTarget) observer?.observe(newTarget, { box });
+          else {
+            // target was removed (e.g. with v-if so we need to reset the size manually)
+            width.value = 0;
+            height.value = 0;
+          }
         },
         { immediate: true },
       );

--- a/packages/sit-onyx/src/composables/useResizeObserver.ts
+++ b/packages/sit-onyx/src/composables/useResizeObserver.ts
@@ -12,13 +12,13 @@ export type UseResizeObserverOptions = {
 /**
  * Template ref of either a native HTML element or a custom Vue component.
  */
-export type HTMLOrInstanceRef = Element | { $el: Element } | null | undefined;
+export type VueTemplateRefElement = Element | { $el: Element } | null | undefined;
 
 export const useResizeObserver = (
   /**
    * Target to observe. If undefined, the documentElement will be observed.
    */
-  target?: Ref<HTMLOrInstanceRef>,
+  target?: Ref<VueTemplateRefElement>,
   options?: UseResizeObserverOptions,
 ) => {
   const box = options?.box ?? "content-box";
@@ -72,6 +72,6 @@ export const useResizeObserver = (
 /**
  * Gets the native HTML element of a template ref.
  */
-export const getTemplateRefElement = (ref: HTMLOrInstanceRef) => {
+export const getTemplateRefElement = (ref: VueTemplateRefElement) => {
   return ref instanceof Element ? ref : ref?.$el;
 };

--- a/packages/sit-onyx/src/composables/useResizeObserver.ts
+++ b/packages/sit-onyx/src/composables/useResizeObserver.ts
@@ -1,4 +1,4 @@
-import { onBeforeMount, onBeforeUnmount, ref, watch, type Ref } from "vue";
+import { onBeforeUnmount, onMounted, ref, watch, type Ref } from "vue";
 
 export type UseResizeObserverOptions = {
   /**
@@ -37,8 +37,8 @@ export const useResizeObserver = (
     height.value = boxSize.reduce((acc, { blockSize }) => acc + blockSize, 0);
   };
 
-  // ensure ResizeObserver is only called before/on mount to support server side rendering
-  onBeforeMount(() => {
+  // ensure ResizeObserver is only called on mount to support server side rendering
+  onMounted(() => {
     const observer = new ResizeObserver(callback);
 
     if (!target) {

--- a/packages/sit-onyx/src/composables/useResizeObserver.ts
+++ b/packages/sit-onyx/src/composables/useResizeObserver.ts
@@ -10,7 +10,10 @@ export type UseResizeObserverOptions = {
 };
 
 export const useResizeObserver = (
-  target: Ref<HTMLElement | undefined>,
+  /**
+   * Target to observe. If undefined, the documentElement will be observed.
+   */
+  target?: Ref<HTMLElement | undefined>,
   options?: UseResizeObserverOptions,
 ) => {
   const box = options?.box ?? "content-box";
@@ -33,14 +36,18 @@ export const useResizeObserver = (
   onBeforeMount(() => {
     const observer = new ResizeObserver(callback);
 
-    watch(
-      target,
-      (newTarget, oldTarget) => {
-        if (oldTarget) observer?.unobserve(oldTarget);
-        if (newTarget) observer?.observe(newTarget, { box });
-      },
-      { immediate: true },
-    );
+    if (target) {
+      watch(
+        target,
+        (newTarget, oldTarget) => {
+          if (oldTarget) observer?.unobserve(oldTarget);
+          if (newTarget) observer?.observe(newTarget, { box });
+        },
+        { immediate: true },
+      );
+    } else {
+      observer.observe(document.documentElement, { box });
+    }
 
     onBeforeUnmount(() => observer.disconnect());
   });


### PR DESCRIPTION
Relates to #986

Implement more indicator for OnyxMoreList. For local testing, run Storybook and open:
http://localhost:6006/?path=/story/support-morelist--default

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [ ] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
