### PR TITLE
docs(OnyxFlyoutMenu): fix Storybook example

### DIFF
--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.stories.ts
@@ -23,7 +23,7 @@ const meta: Meta<typeof OnyxFlyoutMenu> = {
     }),
   ],
   argTypes: {
-    default: { control: { disable: true } },
+    button: { control: { disable: true } },
     options: { control: { disable: true } },
     header: { control: { disable: true } },
     footer: { control: { disable: true } },
@@ -39,7 +39,7 @@ type Story = StoryObj<typeof OnyxFlyoutMenu>;
 export const Default = {
   args: {
     label: "Choose application language",
-    default: ({ trigger }) => [
+    button: ({ trigger }) => [
       h(OnyxButton, { label: "English", mode: "plain", color: "neutral", icon: globe, ...trigger }),
     ],
     options: () => [


### PR DESCRIPTION
<!-- Is your PR related to an issue? Then please link it via the "Relates to #" below. Else, remove it. -->

Relates to #2123

Currently, the Storybook example for the OnyxFlyoutMenu is broken due to #2123
