### PR TITLE
docs: fix flaky VitePress builds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,7 +48,7 @@ jobs:
         run: pnpm run build:all
         env:
           # skip fetching statistics for our docs here so we don't exceed GitHub rate limits which may fail in CI
-          VITEPRESS_SKIP_GITHUB_FETCH: true
+          VITEPRESS_SKIP_REMOTE_FETCH: true
 
       - name: 🚨 Run unit tests
         run: pnpm run test:all

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "turbo run turbo:dev --filter=.",
-    "turbo:dev": "VITEPRESS_SKIP_GITHUB_FETCH=true vitepress dev src",
+    "turbo:dev": "VITEPRESS_SKIP_REMOTE_FETCH=true vitepress dev src",
     "build": "pnpm run '/type-check|build-only/'",
     "build-only": "vitepress build src",
     "type-check": "vue-tsc --noEmit",

--- a/apps/docs/src/.vitepress/browser-loader.data.mock.ts
+++ b/apps/docs/src/.vitepress/browser-loader.data.mock.ts
@@ -22,6 +22,4 @@ export const data: Data = {
       },
     },
   ],
-  coverage: 96.86,
-  browserRules: "default",
 };

--- a/apps/docs/src/.vitepress/browser-loader.data.ts
+++ b/apps/docs/src/.vitepress/browser-loader.data.ts
@@ -13,8 +13,6 @@ export type Browser = {
 
 export interface Data {
   browsers: Browser[];
-  coverage: number;
-  browserRules: string;
 }
 
 declare const data: Data;
@@ -28,6 +26,10 @@ export { data };
  */
 export default defineLoader({
   async load(): Promise<Data> {
+    if (process.env.VITEPRESS_SKIP_REMOTE_FETCH) {
+      return { browsers: [] };
+    }
+
     return new Promise((resolve, reject) => {
       let browserRules = "";
 
@@ -35,7 +37,7 @@ export default defineLoader({
         const data = fs.readFileSync(browserslistRcPath, "utf8");
         const lines = data.split("\n").filter((l) => !!l && !l.startsWith("#"));
         browserRules = lines.join("").trim();
-      } catch (_) {
+      } catch {
         reject("could not read .browserslistrc");
       }
 
@@ -53,8 +55,8 @@ export default defineLoader({
 
       try {
         fetchBrowserslistData();
-      } catch {
-        reject("error loading browserslist API data");
+      } catch (e) {
+        reject(e);
       }
     });
   },

--- a/apps/docs/src/github-api.ts
+++ b/apps/docs/src/github-api.ts
@@ -8,7 +8,7 @@
 export const executeGitHubRequest = async (apiRoute: string) => {
   // we only want to fetch the data from GitHub / npmjs API on build, not when running locally
   // to improve the startup time and prevent rate limits
-  const skipGitHubFetch = process.env.VITEPRESS_SKIP_GITHUB_FETCH === "false";
+  const skipGitHubFetch = process.env.VITEPRESS_SKIP_REMOTE_FETCH === "false";
   if (skipGitHubFetch) {
     return;
   }


### PR DESCRIPTION
Fix flaky VitePress builds (esspecially in CI) by skipping all remote fetches in PR check pipelines.