### PR TITLE
fix(createPreview): revert unintentional breaking change

### DIFF
--- a/.changeset/itchy-ants-move.md
+++ b/.changeset/itchy-ants-move.md
@@ -3,3 +3,7 @@
 ---
 
 fix(createPreview): revert unintentional breaking change
+
+We unintentionally introduced a breaking change in version `@sit-onyx/storybook-utils@1.0.0.beta.71` that forced you to pass a required first parameter with brand details when calling `createPreview()`.
+
+This was reverted now. The brand details are optional and can be passed as second parameter to `createPreview`.

--- a/.changeset/itchy-ants-move.md
+++ b/.changeset/itchy-ants-move.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/storybook-utils": major
+---
+
+fix(createPreview): revert unintentional breaking change

--- a/packages/sit-onyx/.storybook/preview.ts
+++ b/packages/sit-onyx/.storybook/preview.ts
@@ -24,11 +24,6 @@ const axeConfig: Spec = { rules: enabledRules };
 
 const basePreview = createPreview(
   {
-    brandImage,
-    brandTitle: "onyx Storybook",
-    brandUrl: "https://onyx.schwarz",
-  },
-  {
     argTypesEnhancers: [enhanceManagedSymbol, enhanceFormInjectedSymbol],
     parameters: {
       docs: {
@@ -47,6 +42,11 @@ const basePreview = createPreview(
       ...onyxThemeGlobalType,
     },
     decorators: [withOnyxTheme, withOnyxVModelDecorator],
+  },
+  {
+    brandImage,
+    brandTitle: "onyx Storybook",
+    brandUrl: "https://onyx.schwarz",
   },
 );
 

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -36,8 +36,8 @@ import { ONYX_BREAKPOINTS, createTheme, type BrandDetails } from "./theme";
  * ```
  */
 export const createPreview = <T extends Preview = Preview>(
-  brandDetails: BrandDetails,
   overrides?: T,
+  brandDetails?: BrandDetails,
 ) => {
   const themes = {
     light: createTheme("light", brandDetails),

--- a/packages/storybook-utils/src/theme.ts
+++ b/packages/storybook-utils/src/theme.ts
@@ -4,7 +4,7 @@ import {
 } from "@sit-onyx/shared/breakpoints";
 import { create, type ThemeVars } from "storybook/internal/theming";
 
-export type BrandDetails = Required<Pick<ThemeVars, "brandTitle" | "brandImage" | "brandUrl">>;
+export type BrandDetails = Pick<ThemeVars, "brandTitle" | "brandImage" | "brandUrl">;
 
 /**
  * Get the computed value for a CSS custom property.


### PR DESCRIPTION
We unintentionally introduced a breaking change in version `@sit-onyx/storybook-utils@1.0.0.beta.71` that forced the user to pass a required first parameter with brand details when calling `createPreview()`.

This was reverted now. The brand details are optional and can be passed as second parameter to `createPreview`.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
