### PR TITLE
feat: implement caching for vitepress fetch requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,9 +46,6 @@ jobs:
 
       - name: 🛠️ Build packages
         run: pnpm run build:all
-        env:
-          # skip fetching statistics for our docs here so we don't exceed GitHub rate limits which may fail in CI
-          VITEPRESS_SKIP_REMOTE_FETCH: true
 
       - name: 🚨 Run unit tests
         run: pnpm run test:all

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "turbo run turbo:dev --filter=.",
-    "turbo:dev": "VITEPRESS_SKIP_REMOTE_FETCH=true vitepress dev src",
+    "turbo:dev": "vitepress dev src",
     "build": "pnpm run '/type-check|build-only/'",
     "build-only": "vitepress build src",
     "type-check": "vue-tsc --noEmit",

--- a/apps/docs/src/cached.ts
+++ b/apps/docs/src/cached.ts
@@ -1,0 +1,73 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { resolve } from "path";
+
+const CACHE_DIR = resolve(import.meta.dirname, "..", "node_modules", ".cache", "onyx-docs-fetch");
+
+type CachedWrapper<T> =
+  | { timestamp: number; body: T }
+  | { timestamp?: undefined; body?: undefined };
+
+/**
+ * Converts a given string or stringifyable object to a file system compatible string.
+ */
+const makeFileSystemFriendly = (input: string | { toString: () => string }) =>
+  input.toString().replace(/\W/gi, "_");
+
+const buildPathForUrl = (url: URL) => {
+  const fsFriendly = makeFileSystemFriendly(url);
+  return resolve(CACHE_DIR, `${fsFriendly}.json`);
+};
+
+const writeCache = async <T>(url: URL, body: T) => {
+  const cacheDir = resolve(import.meta.dirname, ".fetch-cache");
+
+  // we use recursive, so that we dont have to handle the `directory already exists` case
+  await mkdir(cacheDir, { recursive: true });
+  const cacheFile = buildPathForUrl(url);
+  await writeFile(
+    cacheFile,
+    JSON.stringify({ timestamp: Date.now(), body } satisfies CachedWrapper<T>),
+  );
+  // eslint-disable-next-line no-console
+  console.info(`Updated cache for request ${url}.`);
+};
+
+const readCache = async <T>(url: URL, validAfter: Date): Promise<T | undefined> => {
+  // we use recursive, so that we dont have to handle the `directory already exists` case
+  await mkdir(CACHE_DIR, { recursive: true });
+  const cacheFile = buildPathForUrl(url);
+
+  const { timestamp, body }: CachedWrapper<T> = await readFile(cacheFile, "utf-8")
+    .then(JSON.parse)
+    .catch(() => ({}));
+
+  if (timestamp && new Date(timestamp) > validAfter) {
+    // eslint-disable-next-line no-console
+    console.info(`Used cache for request ${url}.`);
+    return body;
+  }
+};
+
+/**
+ * Caches an async operation to the filesystem.
+ * Default cache duration is 24 hours.
+ */
+export const cached = async <T>(
+  url: URL,
+  fetch: () => Promise<T>,
+  duration = 24 * 60 * 60 * 1000,
+): Promise<T> => {
+  const result = await readCache<T>(url, new Date(Date.now() - duration));
+  if (result) {
+    return result;
+  }
+
+  const body = await fetch();
+  // eslint-disable-next-line no-console
+  console.info(`Fetched ${url}.`);
+
+  // we don't need to wait for the cache to be written
+  writeCache(url, body);
+
+  return body;
+};

--- a/apps/docs/src/github-api.ts
+++ b/apps/docs/src/github-api.ts
@@ -1,3 +1,5 @@
+import { cached } from "./cached";
+
 /**
  * Executes a GET request to the given GitHub API route.
  *
@@ -6,28 +8,27 @@
  * @returns JSON response body.
  */
 export const executeGitHubRequest = async (apiRoute: string) => {
-  // we only want to fetch the data from GitHub / npmjs API on build, not when running locally
-  // to improve the startup time and prevent rate limits
-  const skipGitHubFetch = process.env.VITEPRESS_SKIP_REMOTE_FETCH === "false";
-  if (skipGitHubFetch) {
-    return;
-  }
-
   // GitHub token can be used to have a higher rate limit (useful if used in CI)
   // see: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-primary-rate-limits
   const accessToken = process.env.VITEPRESS_GITHUB_ACCESS_TOKEN;
 
-  const response = await fetch(`https://api.github.com/${apiRoute}`, {
-    headers: {
-      "X-GitHub-Api-Version": "2022-11-28",
-      Authorization: accessToken ? `Bearer ${accessToken}` : "",
-    },
-  });
-  const body = await response.json();
+  const url = new URL(`https://api.github.com/${apiRoute}`);
 
-  if (response.status < 200 || response.status >= 300) {
-    throw new Error(`GitHub request failed. Response body: ${JSON.stringify(body)}`);
-  }
+  const fetchGithub = async () => {
+    const response = await fetch(url, {
+      headers: {
+        "X-GitHub-Api-Version": "2022-11-28",
+        Authorization: accessToken ? `Bearer ${accessToken}` : "",
+      },
+    });
+    const body = await response.json();
 
-  return body;
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`GitHub request failed. Response body: ${JSON.stringify(body)}`);
+    }
+
+    return body;
+  };
+
+  return cached(url, fetchGithub);
 };


### PR DESCRIPTION
Cache vitepress requests in the node_modules folder for 24 hours.