### PR TITLE
docs: correctly skip remote fetches in CI

### DIFF
--- a/apps/docs/src/.vitepress/browser-loader.data.ts
+++ b/apps/docs/src/.vitepress/browser-loader.data.ts
@@ -26,7 +26,7 @@ export { data };
  */
 export default defineLoader({
   async load(): Promise<Data> {
-    if (process.env.VITEPRESS_SKIP_REMOTE_FETCH) {
+    if (process.env.VITEPRESS_SKIP_REMOTE_FETCH === "true") {
       return { browsers: [] };
     }
 

--- a/apps/docs/src/.vitepress/browser-loader.data.ts
+++ b/apps/docs/src/.vitepress/browser-loader.data.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import { fileURLToPath } from "url";
 import { defineLoader } from "vitepress";
+import { shouldSkipRemoteFetches } from "../github-api";
 
 const browserslistRcPath = fileURLToPath(new URL("../../../../.browserslistrc", import.meta.url));
 
@@ -26,7 +27,7 @@ export { data };
  */
 export default defineLoader({
   async load(): Promise<Data> {
-    if (process.env.VITEPRESS_SKIP_REMOTE_FETCH === "true") {
+    if (shouldSkipRemoteFetches()) {
       return { browsers: [] };
     }
 

--- a/apps/docs/src/about/team.data.ts
+++ b/apps/docs/src/about/team.data.ts
@@ -51,7 +51,8 @@ type GithubContributor = {
  * Lists all github contributors
  */
 const getContributors = async (): Promise<GithubContributor[]> => {
-  const body = await executeGitHubRequest(`repos/SchwarzIT/onyx/contributors`);
+  const { body, skipped } = await executeGitHubRequest(`repos/SchwarzIT/onyx/contributors`);
+  if (skipped) return [];
 
   if (typeof body !== "object" && !Array.isArray(body)) {
     throw new Error(

--- a/apps/docs/src/github-api.ts
+++ b/apps/docs/src/github-api.ts
@@ -8,9 +8,8 @@
 export const executeGitHubRequest = async (apiRoute: string) => {
   // we only want to fetch the data from GitHub / npmjs API on build, not when running locally
   // to improve the startup time and prevent rate limits
-  const skipGitHubFetch = process.env.VITEPRESS_SKIP_REMOTE_FETCH === "false";
-  if (skipGitHubFetch) {
-    return;
+  if (process.env.VITEPRESS_SKIP_REMOTE_FETCH === "true") {
+    return { skipped: true };
   }
 
   // GitHub token can be used to have a higher rate limit (useful if used in CI)
@@ -29,5 +28,5 @@ export const executeGitHubRequest = async (apiRoute: string) => {
     throw new Error(`GitHub request failed. Response body: ${JSON.stringify(body)}`);
   }
 
-  return body;
+  return { skipped: false, body };
 };

--- a/apps/docs/src/github-api.ts
+++ b/apps/docs/src/github-api.ts
@@ -8,7 +8,7 @@
 export const executeGitHubRequest = async (apiRoute: string) => {
   // we only want to fetch the data from GitHub / npmjs API on build, not when running locally
   // to improve the startup time and prevent rate limits
-  if (process.env.VITEPRESS_SKIP_REMOTE_FETCH === "true") {
+  if (shouldSkipRemoteFetches()) {
     return { skipped: true };
   }
 
@@ -30,3 +30,8 @@ export const executeGitHubRequest = async (apiRoute: string) => {
 
   return { skipped: false, body };
 };
+
+/**
+ * Where all remote fetches, e.g. to GitHub should be skipped to avoid rate limits or failed CI pipelines.
+ */
+export const shouldSkipRemoteFetches = () => process.env.VITEPRESS_SKIP_REMOTE_FETCH === "true";

--- a/apps/docs/src/index.data.ts
+++ b/apps/docs/src/index.data.ts
@@ -260,7 +260,10 @@ const searchGitHub = async (
   const queryString = encodeURIComponent(`repo:SchwarzIT/onyx ${filterString}`);
 
   // since we only need the total_count, we can decrease the per_page to 1 to improve request speeds
-  const body = await executeGitHubRequest(`search/${endpoint}?q=${queryString}&per_page=1`);
+  const { body, skipped } = await executeGitHubRequest(
+    `search/${endpoint}?q=${queryString}&per_page=1`,
+  );
+  if (skipped) return 0;
 
   if (typeof body !== "object" || typeof body.total_count !== "number") {
     throw new Error(


### PR DESCRIPTION
The `VITEPRESS_SKIP_REMOTE_FETCH` env variable for our docs was implemented incorrectly. When set, not all remote fetches where skipped so some CI pipelines still failed if triggered too often.