### PR TITLE
refactor(OnyxInput): use CSS implementation for clear and success icon

### DIFF
--- a/.changeset/spotty-dancers-jog.md
+++ b/.changeset/spotty-dancers-jog.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxInput): support clear and success icon

--- a/packages/sit-onyx/src/components/OnyxInput/OnyxInput.vue
+++ b/packages/sit-onyx/src/components/OnyxInput/OnyxInput.vue
@@ -1,11 +1,12 @@
 <script lang="ts" setup>
 import checkSmall from "@sit-onyx/icons/check-small.svg?raw";
 import xSmall from "@sit-onyx/icons/x-small.svg?raw";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useDensity } from "../../composables/density";
 import { getFormMessages, useCustomValidity } from "../../composables/useCustomValidity";
 import { useErrorClass } from "../../composables/useErrorClass";
 import { SKELETON_INJECTED_SYMBOL, useSkeletonContext } from "../../composables/useSkeletonState";
+import { injectI18n } from "../../i18n";
 import { FORM_INJECTED_SYMBOL, useFormContext } from "../OnyxForm/OnyxForm.core";
 import OnyxFormElement from "../OnyxFormElement/OnyxFormElement.vue";
 import OnyxIcon from "../OnyxIcon/OnyxIcon.vue";
@@ -14,7 +15,6 @@ import OnyxSkeleton from "../OnyxSkeleton/OnyxSkeleton.vue";
 import type { OnyxInputProps } from "./types";
 
 const props = withDefaults(defineProps<OnyxInputProps>(), {
-  modelValue: "",
   type: "text",
   required: false,
   autocapitalize: "sentences",
@@ -38,6 +38,7 @@ const emit = defineEmits<{
   validityChange: [validity: ValidityState];
 }>();
 
+const { t } = injectI18n();
 const { vCustomValidity, errorMessages } = useCustomValidity({ props, emit });
 const successMessages = computed(() => getFormMessages(props.success));
 const messages = computed(() => getFormMessages(props.message));
@@ -47,7 +48,7 @@ const { densityClass } = useDensity(props);
 /**
  * Current value (with getter and setter) that can be used as "v-model" for the native input.
  */
-const value = defineModel<string>();
+const value = defineModel<string>({ default: "" });
 
 const patternSource = computed(() => {
   if (props.pattern instanceof RegExp) return props.pattern.source;
@@ -57,7 +58,6 @@ const patternSource = computed(() => {
 const { disabled, showError } = useFormContext(props);
 const skeleton = useSkeletonContext(props);
 const errorClass = useErrorClass(showError);
-const isFocused = ref(false);
 </script>
 
 <template>
@@ -95,28 +95,22 @@ const isFocused = ref(false);
             :maxlength="props.maxlength"
             :aria-label="props.hideLabel ? props.label : undefined"
             :title="props.hideLabel ? props.label : undefined"
-            @focus="isFocused = true"
-            @blur="isFocused = false"
           />
+
           <button
-            v-if="
-              !hideClearIcon &&
-              isFocused &&
-              !readonly &&
-              value !== '' &&
-              value !== undefined &&
-              value !== null
-            "
+            v-if="!props.hideClearIcon && value !== ''"
             type="button"
-            class="onyx-input__icon"
-            aria-label="Icon"
-            @mousedown.prevent
-            @click="() => emit('update:modelValue', '')"
+            class="onyx-input__clear"
+            :aria-label="t('input.clear')"
+            :title="t('input.clear')"
+            @click="() => (value = '')"
           >
-            <OnyxIcon class="onyx-clear-icon" :icon="xSmall" color="neutral" />
+            <OnyxIcon :icon="xSmall" />
           </button>
+
           <OnyxIcon
-            v-if="!isFocused && !hideSuccessIcon && successMessages"
+            v-if="!props.hideSuccessIcon && successMessages"
+            class="onyx-input__check-icon"
             :icon="checkSmall"
             color="success"
           />
@@ -148,10 +142,12 @@ const isFocused = ref(false);
       $vertical-padding: var(--onyx-input-padding-vertical)
     );
   }
+
   ::-webkit-search-cancel-button {
     display: none;
   }
-  &__icon {
+
+  &__clear {
     height: 100%;
     margin: 0;
     padding: 0;
@@ -160,12 +156,26 @@ const isFocused = ref(false);
     align-items: center;
     background-color: transparent;
     border: none;
+    cursor: pointer;
+    color: var(--onyx-color-text-icons-neutral-intense);
+
+    &:hover,
+    &:focus-visible {
+      color: var(--onyx-color-text-icons-primary-intense);
+    }
+
+    &:focus-visible {
+      outline: var(--onyx-outline-width) solid var(--onyx-color-component-focus-primary);
+      border-radius: var(--onyx-radius-sm);
+    }
   }
-}
-.onyx-clear-icon {
-  cursor: pointer;
-  &:hover {
-    fill: var(--onyx-color-text-icons-primary-intense);
+
+  // hide clear icon when input is not focussed
+  &:not(&:has(&__wrapper:focus-within)),
+  &:has(&__native:read-only) {
+    .onyx-input__clear {
+      display: none;
+    }
   }
 }
 </style>

--- a/packages/sit-onyx/src/components/OnyxSelectInput/OnyxSelectInput.vue
+++ b/packages/sit-onyx/src/components/OnyxSelectInput/OnyxSelectInput.vue
@@ -51,7 +51,6 @@ const messages = computed(() => getFormMessages(props.message));
 const { disabled, showError } = useFormContext(props);
 const skeleton = useSkeletonContext(props);
 const errorClass = useErrorClass(showError);
-const isFocused = ref(false);
 
 /**
  * Number of selected options.
@@ -173,8 +172,6 @@ const blockTyping = (event: KeyboardEvent) => {
             :autofocus="props.autofocus"
             autocomplete="off"
             @keydown="blockTyping"
-            @focus="isFocused = true"
-            @blur="isFocused = false"
           />
 
           <!-- TODO: figure out how the tooltip width can be sized to the select-input
@@ -202,8 +199,10 @@ const blockTyping = (event: KeyboardEvent) => {
           >
             <OnyxIcon :icon="chevronDownUp" />
           </button>
+
           <OnyxIcon
-            v-if="!hideSuccessIcon && successMessages && !props.showFocus && !isFocused"
+            v-if="!props.hideSuccessIcon && successMessages"
+            class="onyx-select-input__check-icon"
             :icon="checkSmall"
             color="success"
           />

--- a/packages/sit-onyx/src/i18n/locales/de-DE.json
+++ b/packages/sit-onyx/src/i18n/locales/de-DE.json
@@ -123,5 +123,8 @@
       "label": "Seiten-Auswahl",
       "listLabel": "Verfügbare Seiten"
     }
+  },
+  "input": {
+    "clear": "Eingabe löschen"
   }
 }

--- a/packages/sit-onyx/src/i18n/locales/en-US.json
+++ b/packages/sit-onyx/src/i18n/locales/en-US.json
@@ -132,5 +132,8 @@
       "label": "Page selection",
       "listLabel": "Available pages"
     }
+  },
+  "input": {
+    "clear": "Clear input"
   }
 }

--- a/packages/sit-onyx/src/styles/mixins/input.scss
+++ b/packages/sit-onyx/src/styles/mixins/input.scss
@@ -84,6 +84,14 @@
         background-color: var(--onyx-color-base-warning-100);
       }
     }
+
+    // hide success check icon when input is focussed
+    &:focus-within,
+    &:has(#{$base-selector}__native--show-focus) {
+      #{$base-selector}__check-icon {
+        display: none;
+      }
+    }
   }
 
   &__loading {


### PR DESCRIPTION
PR feedback for #2143.

Changes:

- CSS implementation for show/hide clear and success icon when focused
- translate label for clear button
- make clear icon also accessible via keyboard + add focus styles

@ChristianBusshoff Please take a look :)