### PR TITLE
fix caching 

### DIFF
--- a/.github/templates/node-setup/action.yml
+++ b/.github/templates/node-setup/action.yml
@@ -30,13 +30,22 @@ runs:
         node-version-file: .node-version
         cache: pnpm
 
+    - name: 📆 Get Date
+      id: get-date
+      run: |
+        echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: 🫙 Cache
       uses: actions/cache@v4
       with:
         path: |
           **/.turbo
           **/.cache
-        key: ${{ runner.os }}-caches
+        key: build-caches-${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/.turbo', '**/.cache') }}
+        restore-keys: |
+          build-caches-${{ runner.os }}-${{ steps.get-date.outputs.date }}-
+          build-caches-${{ runner.os }}-
 
     - name: 📦 Install dependencies
       run: pnpm install


### PR DESCRIPTION
Looking at https://github.com/SchwarzIT/onyx/actions/runs/12179300264/job/33971147249 I noticed, that our cache command does not update:

> Post Run /./.github/templates/node-setup
> Post job cleanup.
> Post job cleanup.
> Cache hit occurred on the primary key Linux-caches, not saving cache.
> Post job cleanup.
> Cache hit occurred on the primary key node-cache-Linux-x64-pnpm-74339e7969f992363e9689a5a87f7851e81d1b5d2de2ff1763e6aad33ac19da7, not saving cache.
> Post job cleanup.
> Pruning is unnecessary.

This was caused by using a static caching key, buw now we include date and file hashes.