### PR TITLE
chore: release playwright utils version `1.0.0-beta.1`

### DIFF
--- a/.changeset/real-bears-float.md
+++ b/.changeset/real-bears-float.md
@@ -3,3 +3,5 @@
 ---
 
 release version `1.0.0-beta.0`
+
+There are no changes in this version. We only bumped/fixed the package version to `1.0.0-beta.0` to be aligned with other packages.

--- a/.changeset/real-bears-float.md
+++ b/.changeset/real-bears-float.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/playwright-utils": major
+---
+
+release version `1.0.0-beta.0`

--- a/.changeset/real-bears-float.md
+++ b/.changeset/real-bears-float.md
@@ -2,6 +2,6 @@
 "@sit-onyx/playwright-utils": major
 ---
 
-release version `1.0.0-beta.0`
+release version `1.0.0-beta.1`
 
-There are no changes in this version. We only bumped/fixed the package version to `1.0.0-beta.0` to be aligned with other packages.
+There are no changes in this version. We only bumped/fixed the package version to `1.0.0-beta.1` to be aligned with other packages.


### PR DESCRIPTION
Relates to #1991

release version `1.0.0-beta.1` since #2269 only released `0.1.0-beta.0`
There are no changes in this version. We only bumped/fixed the package version to `1.0.0-beta.1` to be aligned with other packages.