### PR TITLE
fix: storybook dark mode to light mode toggle

### DIFF
--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -68,11 +68,9 @@ export const createPreview = <T extends Preview = Preview>(
           if (isDark) {
             document.body.classList.remove("light");
             document.body.classList.add("dark");
-            document.documentElement.style.colorScheme = "dark";
           } else {
             document.body.classList.remove("dark");
             document.body.classList.add("light");
-            document.documentElement.style.colorScheme = "light";
           }
 
           return isDark ? themes.dark : themes.light;


### PR DESCRIPTION
If you load/reload the page in dark mode, switching to light mode is buggy.