### PR TITLE
fix(CI): fix CI caching, deploy and enable turbo remote cache

### DIFF
--- a/.github/templates/cf-push/action.yml
+++ b/.github/templates/cf-push/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Deploy (${{ inputs.space }})
       shell: bash
-      run: cf push --manifest "./manifest-${{ inputs.space }}.yml" --strategy rolling ${{ inputs.vars }}
+      run: cf push --manifest "./manifest-${{ inputs.space }}.yml" --strategy rolling ${{ inputs.varArgs }}
       working-directory: ${{ inputs.working-directory }}
 
     - name: Logout from Cloud Foundry

--- a/.github/templates/cf-push/action.yml
+++ b/.github/templates/cf-push/action.yml
@@ -20,6 +20,9 @@ inputs:
   working-directory:
     required: true
     description: Directory where the push command is executed in (manifest, Staticfile etc. must be placed inside this folder)
+  varArgs:
+    default: ""
+    description: Variables argument strings used for variable substitution file in manifest. Must be provided in the form of `--var KEY1=VALUE1 --var KEY2=VALUE2`
 
 runs:
   using: "composite"
@@ -39,7 +42,7 @@ runs:
 
     - name: Deploy (${{ inputs.space }})
       shell: bash
-      run: cf push --manifest "./manifest-${{ inputs.space }}.yml" --strategy rolling
+      run: cf push --manifest "./manifest-${{ inputs.space }}.yml" --strategy rolling ${{ inputs.vars }}
       working-directory: ${{ inputs.working-directory }}
 
     - name: Logout from Cloud Foundry

--- a/.github/templates/node-setup/action.yml
+++ b/.github/templates/node-setup/action.yml
@@ -40,9 +40,8 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          **/.turbo
           **/.cache
-        key: build-caches-${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/.turbo', '**/.cache') }}
+        key: build-caches-${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/.cache') }}
         restore-keys: |
           build-caches-${{ runner.os }}-${{ steps.get-date.outputs.date }}-
           build-caches-${{ runner.os }}-

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }}
+
 jobs:
   check:
     name: Check code quality

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,3 +70,4 @@ jobs:
   screenshots:
     name: Component tests
     uses: ./.github/workflows/playwright.yml
+    secrets: inherit

--- a/.github/workflows/deploy-turbo-remote-cache.yml
+++ b/.github/workflows/deploy-turbo-remote-cache.yml
@@ -8,13 +8,11 @@ on:
   workflow_dispatch:
   pull_request:
 
-env:
-  STAGE: prod
-
 jobs:
   deploy:
     name: Deploy to CloudFoundry
     runs-on: ubuntu-latest
+    environment: prod
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-turbo-remote-cache.yml
+++ b/.github/workflows/deploy-turbo-remote-cache.yml
@@ -24,5 +24,5 @@ jobs:
           username: ${{ vars.CF_USERNAME }}
           password: ${{ secrets.CF_PASSWORD }}
           space: prod
-          varArgs: "--var TURBO_TOKEN=${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN}} --var AWS_ACCESS_KEY_ID=${{ secrets.TURBO_REMOTE_CACHE__AWS_ACCESS_KEY_ID}} --var AWS_SECRET_ACCESS_KEY=${{ secrets.TURBO_REMOTE_CACHE__AWS_SECRET_ACCESS_KEY}}"
+          varArgs: "--var TURBO_TOKEN=${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }} --var AWS_ACCESS_KEY_ID=${{ secrets.TURBO_REMOTE_CACHE__AWS_ACCESS_KEY_ID }} --var AWS_SECRET_ACCESS_KEY=${{ secrets.TURBO_REMOTE_CACHE__AWS_SECRET_ACCESS_KEY }}"
           working-directory: apps/turbo-remote-cache/.cloud-foundry

--- a/.github/workflows/deploy-turbo-remote-cache.yml
+++ b/.github/workflows/deploy-turbo-remote-cache.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "apps/turbo-remote-cache/**"
   workflow_dispatch:
+  pull_request:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-turbo-remote-cache.yml
+++ b/.github/workflows/deploy-turbo-remote-cache.yml
@@ -1,0 +1,26 @@
+name: Deploy Turbo Remote Cache
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "apps/turbo-remote-cache/**"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to CloudFoundry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Cloud Foundry
+        uses: ./.github/templates/cf-push
+        with:
+          endpoint: ${{ vars.CF_ENDPOINT }}
+          org: ${{ vars.CF_ORG }}
+          username: ${{ vars.CF_USERNAME }}
+          password: ${{ secrets.CF_PASSWORD }}
+          space: prod
+          varArgs: "--var TURBO_TOKEN=${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN}} --var AWS_ACCESS_KEY_ID=${{ secrets.TURBO_REMOTE_CACHE__AWS_ACCESS_KEY_ID}} --var AWS_SECRET_ACCESS_KEY=${{ secrets.TURBO_REMOTE_CACHE__AWS_SECRET_ACCESS_KEY}}"
+          working-directory: apps/turbo-remote-cache/.cloud-foundry

--- a/.github/workflows/deploy-turbo-remote-cache.yml
+++ b/.github/workflows/deploy-turbo-remote-cache.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - "apps/turbo-remote-cache/**"
   workflow_dispatch:
-  pull_request:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-turbo-remote-cache.yml
+++ b/.github/workflows/deploy-turbo-remote-cache.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+env:
+  STAGE: prod
+
 jobs:
   deploy:
     name: Deploy to CloudFoundry

--- a/.github/workflows/import-figma-icons.yml
+++ b/.github/workflows/import-figma-icons.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 6 * * *" # run daily at 6 am
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }}
+
 jobs:
   import:
     name: Import Figma icons

--- a/.github/workflows/import-figma.yml
+++ b/.github/workflows/import-figma.yml
@@ -2,6 +2,9 @@ name: Import Figma variables
 on:
   workflow_dispatch:
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }}
+
 jobs:
   import:
     name: Import Figma variables

--- a/.github/workflows/playwright-screenshots.yml
+++ b/.github/workflows/playwright-screenshots.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   screenshots:
     uses: ./.github/workflows/playwright.yml
+    secrets: inherit
     with:
       update-snapshots: true
 

--- a/.github/workflows/playwright-screenshots.yml
+++ b/.github/workflows/playwright-screenshots.yml
@@ -2,6 +2,9 @@ name: Update Playwright screenshots
 on:
   workflow_dispatch:
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }}
+
 jobs:
   screenshots:
     uses: ./.github/workflows/playwright.yml

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,9 +7,6 @@ on:
         default: false
         description: Whether to update snapshots / screenshots
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }}
-
 jobs:
   playwright:
     strategy:
@@ -23,6 +20,8 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
     name: Playwright shard
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,6 +7,9 @@ on:
         default: false
         description: Whether to update snapshots / screenshots
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }}
+
 jobs:
   playwright:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 env:
   # The release + deployment will be done on "prod" stage if on main branch, on "dev" stage otherwise
   STAGE: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
+  TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }}
 
 jobs:
   release:

--- a/apps/turbo-remote-cache/.cloud-foundry/manifest-prod.yml
+++ b/apps/turbo-remote-cache/.cloud-foundry/manifest-prod.yml
@@ -1,7 +1,7 @@
 applications:
   - name: turbo-remote-cache
     instances: 2
-    memory: 128MB
+    memory: 256MB
     disk_quota: 1GB
     docker:
       image: ducktors/turborepo-remote-cache

--- a/apps/turbo-remote-cache/.cloud-foundry/manifest-prod.yml
+++ b/apps/turbo-remote-cache/.cloud-foundry/manifest-prod.yml
@@ -1,7 +1,7 @@
 applications:
   - name: turbo-remote-cache
     instances: 2
-    memory: 265MB
+    memory: 128MB
     disk_quota: 1GB
     docker:
       image: ducktors/turborepo-remote-cache

--- a/apps/turbo-remote-cache/.cloud-foundry/manifest-prod.yml
+++ b/apps/turbo-remote-cache/.cloud-foundry/manifest-prod.yml
@@ -1,0 +1,14 @@
+applications:
+  - name: turbo-remote-cache
+    instances: 2
+    memory: 265MB
+    disk_quota: 1GB
+    docker:
+      image: ducktors/turborepo-remote-cache
+    env:
+      TURBO_TOKEN: ((TURBO_TOKEN))
+      STORAGE_PROVIDER: s3
+      STORAGE_PATH: turbo-remote-cache
+      AWS_ACCESS_KEY_ID: ((AWS_ACCESS_KEY_ID))
+      AWS_SECRET_ACCESS_KEY: ((AWS_SECRET_ACCESS_KEY))
+      S3_ENDPOINT: https://object.storage.eu01.onstackit.cloud

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "remoteCache": {
+    "apiUrl": "https://turbo-remote-cache.apps.01.cf.eu01.stackit.cloud",
+    "teamSlug": "onyx",
+    "enabled": true
+  },
   "globalDependencies": ["pnpm-lock.yaml"],
   "tasks": {
     "build": {


### PR DESCRIPTION
Closes #2321 
- Add deployment pipeline and CF manifest for [turborepo-remote-cache](https://ducktors.github.io/turborepo-remote-cache/)
- Remove GitHub pipeline caching of `.turbo` directories, only vitepress fetchs are cached now
- Configure all CI pipelines to make use of the remote turbo cache
- Add `varArgs` input to our GitHub `cf-push` custom action, which allows passing custom vars to be used in the manifest