### PR TITLE
fix(schwarz-theme): use correct theme for dark mode

### DIFF
--- a/.changeset/smart-tips-yell.md
+++ b/.changeset/smart-tips-yell.md
@@ -3,3 +3,6 @@
 ---
 
 fix(schwarz-theme): use correct theme for dark mode
+
+The `schwarz` theme in dark mode showed the default onyx colors instead of the ones from the schwarz theme.
+This is fixed now so it shows the correct `schwarz` theme colors in dark and light mode.

--- a/.changeset/smart-tips-yell.md
+++ b/.changeset/smart-tips-yell.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(schwarz-theme): use correct theme for dark mode

--- a/packages/sit-onyx/src/styles/variables/density-compact.css
+++ b/packages/sit-onyx/src/styles/variables/density-compact.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "compact" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:54:21 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:30:04 GMT
  */
 :where(.onyx-density-compact) {
   --onyx-density-2xl: var(--onyx-number-spacing-600);

--- a/packages/sit-onyx/src/styles/variables/density-cozy.css
+++ b/packages/sit-onyx/src/styles/variables/density-cozy.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "cozy" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:54:21 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:30:04 GMT
  */
 :where(.onyx-density-cozy) {
   --onyx-density-2xl: var(--onyx-number-spacing-800);

--- a/packages/sit-onyx/src/styles/variables/density-default.css
+++ b/packages/sit-onyx/src/styles/variables/density-default.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "default" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:54:14 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:55 GMT
  */
 :where(:root),
 :where(.onyx-density-default) {

--- a/packages/sit-onyx/src/styles/variables/spacing.css
+++ b/packages/sit-onyx/src/styles/variables/spacing.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "spacing" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:54:07 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:49 GMT
  */
 :where(:root) {
   --onyx-spacing-2xl: var(--onyx-number-spacing-700);

--- a/packages/sit-onyx/src/styles/variables/themes/digits-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/digits-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "digits-dark" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:54:01 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:41 GMT
  */
 .dark,
 .onyx-theme-digits-dark {

--- a/packages/sit-onyx/src/styles/variables/themes/digits-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/digits-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "digits-light" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:53:54 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:33 GMT
  */
 :where(:root),
 .onyx-theme-digits-light {

--- a/packages/sit-onyx/src/styles/variables/themes/kaufland-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/kaufland-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "kaufland-dark" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:54:01 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:41 GMT
  */
 .dark,
 .onyx-theme-kaufland-dark {

--- a/packages/sit-onyx/src/styles/variables/themes/kaufland-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/kaufland-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "kaufland-light" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:53:54 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:33 GMT
  */
 :where(:root),
 .onyx-theme-kaufland-light {

--- a/packages/sit-onyx/src/styles/variables/themes/lidl-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/lidl-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "lidl-dark" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:54:01 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:41 GMT
  */
 .dark,
 .onyx-theme-lidl-dark {

--- a/packages/sit-onyx/src/styles/variables/themes/lidl-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/lidl-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "lidl-light" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:53:54 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:33 GMT
  */
 :where(:root),
 .onyx-theme-lidl-light {

--- a/packages/sit-onyx/src/styles/variables/themes/onyx-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/onyx-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "onyx-dark" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:53:46 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:26 GMT
  */
 .dark,
 .onyx-theme-default-dark {

--- a/packages/sit-onyx/src/styles/variables/themes/onyx-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/onyx-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "onyx-light" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:53:39 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:18 GMT
  */
 :where(:root),
 .onyx-theme-default {

--- a/packages/sit-onyx/src/styles/variables/themes/schwarz-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/schwarz-dark.css
@@ -1,9 +1,9 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "schwarz-dark" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:54:01 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:41 GMT
  */
-:where(.dark),
+.dark,
 .onyx-theme-schwarz-dark {
   --onyx-color-base-background-blank: var(--onyx-color-steel-1100);
   --onyx-color-base-background-tinted: var(--onyx-color-steel-1200);

--- a/packages/sit-onyx/src/styles/variables/themes/schwarz-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/schwarz-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "schwarz-light" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:53:54 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:33 GMT
  */
 :where(:root),
 .onyx-theme-schwarz-light {

--- a/packages/sit-onyx/src/styles/variables/themes/value.css
+++ b/packages/sit-onyx/src/styles/variables/themes/value.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "value" theme.
- * Imported from Figma API on Wed, 04 Dec 2024 15:53:39 GMT
+ * Imported from Figma API on Thu, 12 Dec 2024 10:29:18 GMT
  */
 :where(:root),
 .onyx-theme-default {


### PR DESCRIPTION
closes #2288

The schwarz-dark theme currently showed the wrong colors (onyx dark mode) because we used `:where(.dark)` as selector instead of `.dark` which was a leftover from a previous change.

I've run the Figma update variable workflow to update the theme correctly.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
