### PR TITLE
fix(OnyxInput): prevent keyboard focus on clear icon

### DIFF
--- a/.changeset/breezy-cups-turn.md
+++ b/.changeset/breezy-cups-turn.md
@@ -1,0 +1,7 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxInput): prevent keyboard focus on clear icon
+
+The clear icon is no longer focusable via keyboard to not interrupt the users tab order when multiple form elements are used.

--- a/packages/sit-onyx/src/components/OnyxInput/OnyxInput.vue
+++ b/packages/sit-onyx/src/components/OnyxInput/OnyxInput.vue
@@ -103,6 +103,7 @@ const errorClass = useErrorClass(showError);
             class="onyx-input__clear"
             :aria-label="t('input.clear')"
             :title="t('input.clear')"
+            tabindex="-1"
             @click="() => (value = '')"
           >
             <OnyxIcon :icon="xSmall" />
@@ -161,14 +162,8 @@ const errorClass = useErrorClass(showError);
     cursor: pointer;
     color: var(--onyx-color-text-icons-neutral-intense);
 
-    &:hover,
-    &:focus-visible {
+    &:hover {
       color: var(--onyx-color-text-icons-primary-intense);
-    }
-
-    &:focus-visible {
-      outline: var(--onyx-outline-width) solid var(--onyx-color-component-focus-primary);
-      border-radius: var(--onyx-radius-sm);
     }
   }
 


### PR DESCRIPTION
Relates to #2143 

As discussed with Jannick, the clear icon is no longer focusable via keyboard to not interrupt the users tab order when multiple form elements are used.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
