### PR TITLE
feat: update CSS variables for backdrop

### DIFF
--- a/.changeset/ten-snakes-live.md
+++ b/.changeset/ten-snakes-live.md
@@ -2,4 +2,5 @@
 "sit-onyx": major
 ---
 
-rename CSS variable `--onyx-color-backdrop` to `--onyx-color-component-opacity-backdrop`
+- renamed CSS variable `--onyx-color-backdrop` to `--onyx-color-component-opacity-backdrop`
+- removed CSS variables `--onyx-number-opacity-medium` and `--onyx-number-opacity-soft`, use `--onyx-color-opacity-medium` and `--onyx-color-opacity-soft` instead

--- a/.changeset/ten-snakes-live.md
+++ b/.changeset/ten-snakes-live.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": major
+---
+
+rename CSS variable `--onyx-color-backdrop` to `--onyx-color-component-opacity-backdrop`

--- a/packages/sit-onyx/src/components/OnyxDialog/OnyxDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxDialog/OnyxDialog.vue
@@ -99,7 +99,7 @@ watch(
     transform: translate(-50%, -50%);
 
     &::backdrop {
-      background-color: var(--onyx-color-backdrop);
+      background-color: var(--onyx-color-component-opacity-backdrop);
     }
 
     &:modal {

--- a/packages/sit-onyx/src/components/OnyxMobileNavButton/OnyxMobileNavButton.vue
+++ b/packages/sit-onyx/src/components/OnyxMobileNavButton/OnyxMobileNavButton.vue
@@ -117,7 +117,7 @@ defineSlots<{
 
     &__backdrop {
       content: "";
-      background-color: var(--onyx-color-backdrop);
+      background-color: var(--onyx-color-component-opacity-backdrop);
       width: 100%;
       height: 100vh;
       display: block;

--- a/packages/sit-onyx/src/styles/root.scss
+++ b/packages/sit-onyx/src/styles/root.scss
@@ -19,7 +19,6 @@
     --onyx-shadow-soft-left: -0.5rem 0 1.5rem 0 rgba(0, 0, 0, 0.1);
     --onyx-shadow-soft-right: 0.5rem 0 1.5rem 0 rgba(0, 0, 0, 0.1);
 
-    --onyx-color-backdrop: rgba(0, 0, 0, 0.15);
     --onyx-outline-width: 0.25rem;
   }
 
@@ -37,8 +36,6 @@
     --onyx-shadow-soft-bottom: none;
     --onyx-shadow-soft-left: none;
     --onyx-shadow-soft-right: none;
-
-    --onyx-color-backdrop: rgba(0, 0, 0, 0.6);
   }
 }
 :where(html.onyx-transition-active *) {

--- a/packages/sit-onyx/src/styles/variables/density-compact.css
+++ b/packages/sit-onyx/src/styles/variables/density-compact.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "compact" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:30:04 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:41 GMT
  */
 :where(.onyx-density-compact) {
   --onyx-density-2xl: var(--onyx-number-spacing-600);

--- a/packages/sit-onyx/src/styles/variables/density-compact.css
+++ b/packages/sit-onyx/src/styles/variables/density-compact.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "compact" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:41 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:50 GMT
  */
 :where(.onyx-density-compact) {
   --onyx-density-2xl: var(--onyx-number-spacing-600);

--- a/packages/sit-onyx/src/styles/variables/density-cozy.css
+++ b/packages/sit-onyx/src/styles/variables/density-cozy.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "cozy" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:41 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:50 GMT
  */
 :where(.onyx-density-cozy) {
   --onyx-density-2xl: var(--onyx-number-spacing-800);

--- a/packages/sit-onyx/src/styles/variables/density-cozy.css
+++ b/packages/sit-onyx/src/styles/variables/density-cozy.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "cozy" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:30:04 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:41 GMT
  */
 :where(.onyx-density-cozy) {
   --onyx-density-2xl: var(--onyx-number-spacing-800);

--- a/packages/sit-onyx/src/styles/variables/density-default.css
+++ b/packages/sit-onyx/src/styles/variables/density-default.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "default" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:31 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:43 GMT
  */
 :where(:root),
 :where(.onyx-density-default) {

--- a/packages/sit-onyx/src/styles/variables/density-default.css
+++ b/packages/sit-onyx/src/styles/variables/density-default.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "default" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:55 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:31 GMT
  */
 :where(:root),
 :where(.onyx-density-default) {

--- a/packages/sit-onyx/src/styles/variables/spacing.css
+++ b/packages/sit-onyx/src/styles/variables/spacing.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "spacing" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:24 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:35 GMT
  */
 :where(:root) {
   --onyx-spacing-2xl: var(--onyx-number-spacing-700);

--- a/packages/sit-onyx/src/styles/variables/spacing.css
+++ b/packages/sit-onyx/src/styles/variables/spacing.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "spacing" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:49 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:24 GMT
  */
 :where(:root) {
   --onyx-spacing-2xl: var(--onyx-number-spacing-700);

--- a/packages/sit-onyx/src/styles/variables/themes/digits-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/digits-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "digits-dark" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:41 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:15 GMT
  */
 .dark,
 .onyx-theme-digits-dark {
@@ -119,7 +119,7 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-700);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-900);
-  --onyx-opacity-backdrop: var(--onyx-number-opacity-medium);
+  --onyx-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/digits-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/digits-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "digits-dark" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:15 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:26 GMT
  */
 .dark,
 .onyx-theme-digits-dark {
@@ -94,6 +94,7 @@
   --onyx-color-component-focus-primary: var(--onyx-color-base-primary-200);
   --onyx-color-component-focus-success: var(--onyx-color-base-success-200);
   --onyx-color-component-focus-warning: var(--onyx-color-base-warning-200);
+  --onyx-color-component-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-color-text-icons-danger-bold: var(--onyx-color-red-400);
   --onyx-color-text-icons-danger-intense: var(--onyx-color-red-500);
   --onyx-color-text-icons-danger-medium: var(--onyx-color-red-700);
@@ -119,7 +120,6 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-700);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-900);
-  --onyx-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/digits-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/digits-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "digits-light" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:07 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:18 GMT
  */
 :where(:root),
 .onyx-theme-digits-light {
@@ -94,6 +94,7 @@
   --onyx-color-component-focus-primary: var(--onyx-color-base-primary-200);
   --onyx-color-component-focus-success: var(--onyx-color-base-success-200);
   --onyx-color-component-focus-warning: var(--onyx-color-base-warning-200);
+  --onyx-color-component-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-color-text-icons-danger-bold: var(--onyx-color-red-700);
   --onyx-color-text-icons-danger-intense: var(--onyx-color-red-500);
   --onyx-color-text-icons-danger-medium: var(--onyx-color-red-300);
@@ -119,7 +120,6 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-300);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-200);
-  --onyx-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/digits-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/digits-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "digits-light" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:33 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:07 GMT
  */
 :where(:root),
 .onyx-theme-digits-light {
@@ -119,7 +119,7 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-300);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-200);
-  --onyx-opacity-backdrop: var(--onyx-number-opacity-soft);
+  --onyx-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/kaufland-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/kaufland-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "kaufland-dark" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:15 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:26 GMT
  */
 .dark,
 .onyx-theme-kaufland-dark {
@@ -94,6 +94,7 @@
   --onyx-color-component-focus-primary: var(--onyx-color-base-primary-500);
   --onyx-color-component-focus-success: var(--onyx-color-base-success-200);
   --onyx-color-component-focus-warning: var(--onyx-color-base-warning-200);
+  --onyx-color-component-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-color-text-icons-danger-bold: var(--onyx-color-red-400);
   --onyx-color-text-icons-danger-intense: var(--onyx-color-red-500);
   --onyx-color-text-icons-danger-medium: var(--onyx-color-red-700);
@@ -119,7 +120,6 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-700);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-900);
-  --onyx-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/kaufland-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/kaufland-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "kaufland-dark" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:41 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:15 GMT
  */
 .dark,
 .onyx-theme-kaufland-dark {
@@ -119,7 +119,7 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-700);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-900);
-  --onyx-opacity-backdrop: var(--onyx-number-opacity-medium);
+  --onyx-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/kaufland-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/kaufland-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "kaufland-light" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:07 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:18 GMT
  */
 :where(:root),
 .onyx-theme-kaufland-light {
@@ -94,6 +94,7 @@
   --onyx-color-component-focus-primary: var(--onyx-color-base-primary-400);
   --onyx-color-component-focus-success: var(--onyx-color-base-success-200);
   --onyx-color-component-focus-warning: var(--onyx-color-base-warning-200);
+  --onyx-color-component-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-color-text-icons-danger-bold: var(--onyx-color-red-700);
   --onyx-color-text-icons-danger-intense: var(--onyx-color-red-500);
   --onyx-color-text-icons-danger-medium: var(--onyx-color-red-300);
@@ -119,7 +120,6 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-300);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-200);
-  --onyx-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/kaufland-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/kaufland-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "kaufland-light" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:33 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:07 GMT
  */
 :where(:root),
 .onyx-theme-kaufland-light {
@@ -119,7 +119,7 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-300);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-200);
-  --onyx-opacity-backdrop: var(--onyx-number-opacity-soft);
+  --onyx-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/lidl-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/lidl-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "lidl-dark" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:41 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:15 GMT
  */
 .dark,
 .onyx-theme-lidl-dark {
@@ -119,7 +119,7 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-700);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-900);
-  --onyx-opacity-backdrop: var(--onyx-number-opacity-medium);
+  --onyx-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/lidl-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/lidl-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "lidl-dark" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:15 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:26 GMT
  */
 .dark,
 .onyx-theme-lidl-dark {
@@ -94,6 +94,7 @@
   --onyx-color-component-focus-primary: var(--onyx-color-base-primary-200);
   --onyx-color-component-focus-success: var(--onyx-color-base-success-200);
   --onyx-color-component-focus-warning: var(--onyx-color-base-warning-200);
+  --onyx-color-component-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-color-text-icons-danger-bold: var(--onyx-color-red-400);
   --onyx-color-text-icons-danger-intense: var(--onyx-color-red-500);
   --onyx-color-text-icons-danger-medium: var(--onyx-color-red-700);
@@ -119,7 +120,6 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-700);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-900);
-  --onyx-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/lidl-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/lidl-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "lidl-light" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:33 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:07 GMT
  */
 :where(:root),
 .onyx-theme-lidl-light {
@@ -119,7 +119,7 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-300);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-200);
-  --onyx-opacity-backdrop: var(--onyx-number-opacity-soft);
+  --onyx-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/lidl-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/lidl-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "lidl-light" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:07 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:18 GMT
  */
 :where(:root),
 .onyx-theme-lidl-light {
@@ -94,6 +94,7 @@
   --onyx-color-component-focus-primary: var(--onyx-color-base-primary-200);
   --onyx-color-component-focus-success: var(--onyx-color-base-success-200);
   --onyx-color-component-focus-warning: var(--onyx-color-base-warning-200);
+  --onyx-color-component-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-color-text-icons-danger-bold: var(--onyx-color-red-700);
   --onyx-color-text-icons-danger-intense: var(--onyx-color-red-500);
   --onyx-color-text-icons-danger-medium: var(--onyx-color-red-300);
@@ -119,7 +120,6 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-300);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-200);
-  --onyx-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/onyx-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/onyx-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "onyx-dark" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:26 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:38:59 GMT
  */
 .dark,
 .onyx-theme-default-dark {
@@ -119,7 +119,7 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-700);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-900);
-  --onyx-opacity-backdrop: var(--onyx-number-opacity-medium);
+  --onyx-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/onyx-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/onyx-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "onyx-dark" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:38:59 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:10 GMT
  */
 .dark,
 .onyx-theme-default-dark {
@@ -94,6 +94,7 @@
   --onyx-color-component-focus-primary: var(--onyx-color-base-primary-200);
   --onyx-color-component-focus-success: var(--onyx-color-base-success-200);
   --onyx-color-component-focus-warning: var(--onyx-color-base-warning-200);
+  --onyx-color-component-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-color-text-icons-danger-bold: var(--onyx-color-red-400);
   --onyx-color-text-icons-danger-intense: var(--onyx-color-red-500);
   --onyx-color-text-icons-danger-medium: var(--onyx-color-red-700);
@@ -119,7 +120,6 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-700);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-900);
-  --onyx-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/onyx-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/onyx-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "onyx-light" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:38:51 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:03 GMT
  */
 :where(:root),
 .onyx-theme-default {
@@ -94,6 +94,7 @@
   --onyx-color-component-focus-primary: var(--onyx-color-base-primary-200);
   --onyx-color-component-focus-success: var(--onyx-color-base-success-200);
   --onyx-color-component-focus-warning: var(--onyx-color-base-warning-200);
+  --onyx-color-component-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-color-text-icons-danger-bold: var(--onyx-color-red-700);
   --onyx-color-text-icons-danger-intense: var(--onyx-color-red-500);
   --onyx-color-text-icons-danger-medium: var(--onyx-color-red-300);
@@ -119,7 +120,6 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-300);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-200);
-  --onyx-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/onyx-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/onyx-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "onyx-light" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:18 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:38:51 GMT
  */
 :where(:root),
 .onyx-theme-default {
@@ -119,7 +119,7 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-300);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-200);
-  --onyx-opacity-backdrop: var(--onyx-number-opacity-soft);
+  --onyx-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/schwarz-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/schwarz-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "schwarz-dark" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:15 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:26 GMT
  */
 .dark,
 .onyx-theme-schwarz-dark {
@@ -94,6 +94,7 @@
   --onyx-color-component-focus-primary: var(--onyx-color-lime-700);
   --onyx-color-component-focus-success: var(--onyx-color-base-success-200);
   --onyx-color-component-focus-warning: var(--onyx-color-base-warning-200);
+  --onyx-color-component-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-color-text-icons-danger-bold: var(--onyx-color-red-400);
   --onyx-color-text-icons-danger-intense: var(--onyx-color-red-500);
   --onyx-color-text-icons-danger-medium: var(--onyx-color-red-700);
@@ -119,7 +120,6 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-700);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-900);
-  --onyx-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/schwarz-dark.css
+++ b/packages/sit-onyx/src/styles/variables/themes/schwarz-dark.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "schwarz-dark" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:41 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:15 GMT
  */
 .dark,
 .onyx-theme-schwarz-dark {
@@ -119,7 +119,7 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-700);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-900);
-  --onyx-opacity-backdrop: var(--onyx-number-opacity-medium);
+  --onyx-opacity-backdrop: var(--onyx-color-opacity-medium);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/schwarz-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/schwarz-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "schwarz-light" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:39:07 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:18 GMT
  */
 :where(:root),
 .onyx-theme-schwarz-light {
@@ -94,6 +94,7 @@
   --onyx-color-component-focus-primary: var(--onyx-color-lime-300);
   --onyx-color-component-focus-success: var(--onyx-color-base-success-200);
   --onyx-color-component-focus-warning: var(--onyx-color-base-warning-200);
+  --onyx-color-component-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-color-text-icons-danger-bold: var(--onyx-color-red-700);
   --onyx-color-text-icons-danger-intense: var(--onyx-color-red-500);
   --onyx-color-text-icons-danger-medium: var(--onyx-color-red-300);
@@ -119,7 +120,6 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-300);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-200);
-  --onyx-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/schwarz-light.css
+++ b/packages/sit-onyx/src/styles/variables/themes/schwarz-light.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "schwarz-light" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:33 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:39:07 GMT
  */
 :where(:root),
 .onyx-theme-schwarz-light {
@@ -119,7 +119,7 @@
   --onyx-color-text-icons-warning-intense: var(--onyx-color-orange-500);
   --onyx-color-text-icons-warning-medium: var(--onyx-color-orange-300);
   --onyx-color-text-icons-warning-soft: var(--onyx-color-orange-200);
-  --onyx-opacity-backdrop: var(--onyx-number-opacity-soft);
+  --onyx-opacity-backdrop: var(--onyx-color-opacity-soft);
   --onyx-radius-full: var(--onyx-number-radius-600);
   --onyx-radius-lg: var(--onyx-number-radius-400);
   --onyx-radius-md: var(--onyx-number-radius-300);

--- a/packages/sit-onyx/src/styles/variables/themes/value.css
+++ b/packages/sit-onyx/src/styles/variables/themes/value.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "value" theme.
- * Imported from Figma API on Thu, 12 Dec 2024 10:29:18 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:38:51 GMT
  */
 :where(:root),
 .onyx-theme-default {
@@ -91,6 +91,8 @@
   --onyx-color-onyx-1000: #005356;
   --onyx-color-onyx-1100: #003c3e;
   --onyx-color-onyx-1200: #002626;
+  --onyx-color-opacity-medium: #00000099;
+  --onyx-color-opacity-soft: #00000026;
   --onyx-color-orange-100: #faf6f2;
   --onyx-color-orange-200: #f8e7d7;
   --onyx-color-orange-300: #f6d1b1;
@@ -199,8 +201,6 @@
   --onyx-color-twogo-1000: #023e42;
   --onyx-color-twogo-1100: #012c2e;
   --onyx-color-twogo-1200: #00191b;
-  --onyx-number-opacity-medium: 3.75rem;
-  --onyx-number-opacity-soft: 0.9375rem;
   --onyx-number-radius-100: 0.125rem;
   --onyx-number-radius-200: 0.25rem;
   --onyx-number-radius-300: 0.5rem;

--- a/packages/sit-onyx/src/styles/variables/themes/value.css
+++ b/packages/sit-onyx/src/styles/variables/themes/value.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "value" theme.
- * Imported from Figma API on Mon, 16 Dec 2024 14:38:51 GMT
+ * Imported from Figma API on Mon, 16 Dec 2024 14:51:03 GMT
  */
 :where(:root),
 .onyx-theme-default {


### PR DESCRIPTION
closes #2229

In alignment with Jannick, we added a new variable in Figma for backdrops which contain the color + opacity in one single variable instead of having a dedicated numeric variable for the opacity.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
