### PR TITLE
fix(OnyxSelect): do not scroll whole page when opening with selected value

### DIFF
--- a/.changeset/good-hotels-brake.md
+++ b/.changeset/good-hotels-brake.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/headless": patch
+---
+
+fix(createListbox): do not scroll whole page when opening with selected value

--- a/.changeset/red-candles-sin.md
+++ b/.changeset/red-candles-sin.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxSelect): do not scroll whole page when opening with selected value

--- a/packages/headless/src/composables/listbox/createListbox.ts
+++ b/packages/headless/src/composables/listbox/createListbox.ts
@@ -109,13 +109,13 @@ export const createListbox = createBuilder(
         !isExpanded.value ||
         options.activeOption.value == undefined ||
         (!isFocused.value && !options.controlled)
-      )
+      ) {
         return;
-      const id = getOptionId(options.activeOption.value);
+      }
 
-      await nextTick(() => {
-        document.getElementById(id)?.scrollIntoView({ block: "end", inline: "nearest" });
-      });
+      const id = getOptionId(options.activeOption.value);
+      await nextTick();
+      document.getElementById(id)?.scrollIntoView({ block: "nearest", inline: "nearest" });
     });
 
     const typeAhead = useTypeAhead((inputString) => options.onTypeAhead?.(inputString));


### PR DESCRIPTION
Relates to #2198

Fix scroll behavior to not scroll the whole page to the bottom of the screen if an option is selected.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
