### PR TITLE
chore(CI): add `merge_group` trigger to check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,7 @@ name: Check code quality
 on:
   pull_request:
   workflow_dispatch:
+  merge_group:
 
 # cancel previous runs if new changes are pushed to the branch/PR
 # see: https://stackoverflow.com/a/72408109

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,7 @@ name: Check code quality
 on:
   pull_request:
   workflow_dispatch:
+  # see: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues
   merge_group:
 
 # cancel previous runs if new changes are pushed to the branch/PR


### PR DESCRIPTION
I would like to enable the GitHub [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) for our repository.

The benefit of the merge queue is that we no longer have to manually rebase our ready PRs from main every time there are updates on main because another PR was merged in the meantime. This slows down our workflow.

The GitHub merge queue will automate this by allowing us to add all ready PRs to the queue and will then update them one by one, ensure all required CI checks run successfully and merge them into main afterwards.