### PR TITLE
refactor(stylelint): run with turbo

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,7 +11,8 @@
     "type-check": "vue-tsc --noEmit",
     "preview": "vitepress preview src",
     "storybook": "storybook dev -p 6006 --no-open",
-    "test:playwright": "playwright install && playwright test"
+    "test:playwright": "playwright install && playwright test",
+    "stylelint": "stylelint \"src/.vitepress/dist/**/*.css\""
   },
   "devDependencies": {
     "@playwright/test": "^1.49.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:playwright:all": "turbo run test:playwright --concurrency 1",
     "format:all": "prettier --write .",
     "format:check:all": "prettier --check .",
-    "stylelint": "stylelint \"packages/sit-onyx/dist/*.css\"",
+    "stylelint": "turbo run stylelint",
     "lint:all": "eslint .",
     "lint:fix:all": "pnpm run lint:all --fix",
     "lint:ci:all": "pnpm run lint:all --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -41,7 +41,8 @@
     "preview": "vite serve storybook-static",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:playwright": "playwright install && playwright test"
+    "test:playwright": "playwright install && playwright test",
+    "stylelint": "stylelint \"dist/**/*.css\""
   },
   "peerDependencies": {
     "@sit-onyx/icons": "workspace:^",

--- a/packages/storybook-utils/package.json
+++ b/packages/storybook-utils/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "build": "tsc --noEmit",
     "test": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "stylelint": "stylelint \"src/**/*.css\""
   },
   "peerDependencies": {
     "@sit-onyx/icons": "workspace:^",

--- a/turbo.json
+++ b/turbo.json
@@ -31,7 +31,7 @@
       "persistent": true
     },
     "stylelint": {
-      "dependsOn": ["sit-onyx#build"]
+      "dependsOn": ["^build"]
     }
   }
 }


### PR DESCRIPTION
Relates to #2128

Implement PR feedback for stlylint PR #2128. Changes:
- run stylelint with turborepo to keep correct dependency build order
- add stylelint to more packages inside the monorepo
- use `**/*.css` glob to also include css files inside nested folders