### PR TITLE
fix(OnyxInfoTooltip): add missing props from OnyxTooltip

### DIFF
--- a/.changeset/hungry-mayflies-do.md
+++ b/.changeset/hungry-mayflies-do.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxInfoTooltip): add missing props from OnyxTooltip

--- a/.changeset/hungry-mayflies-do.md
+++ b/.changeset/hungry-mayflies-do.md
@@ -3,3 +3,5 @@
 ---
 
 fix(OnyxInfoTooltip): add missing props from OnyxTooltip
+
+These props are now also supported for the info tooltip: alignment. density, icon

--- a/packages/sit-onyx/src/components/OnyxInfoTooltip/OnyxInfoTooltip.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxInfoTooltip/OnyxInfoTooltip.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/vue3";
+import { defineIconSelectArgType } from "../../utils/storybook";
 import OnyxInfoTooltip from "./OnyxInfoTooltip.vue";
 
 /**
@@ -16,6 +17,9 @@ const meta: Meta<typeof OnyxInfoTooltip> = {
         </div>`,
     }),
   ],
+  argTypes: {
+    icon: defineIconSelectArgType(),
+  },
 };
 
 export default meta;

--- a/packages/sit-onyx/src/components/OnyxInfoTooltip/OnyxInfoTooltip.vue
+++ b/packages/sit-onyx/src/components/OnyxInfoTooltip/OnyxInfoTooltip.vue
@@ -21,12 +21,7 @@ const type = computed(() => {
 <template>
   <span class="onyx-component onyx-info-tooltip">
     <template v-if="type === 'click'">
-      <OnyxTooltip
-        :text="props.text"
-        :open="props.open"
-        :color="props.color"
-        :position="props.position"
-      >
+      <OnyxTooltip v-bind="props">
         <template #default="{ trigger }">
           <button type="button" class="onyx-info-tooltip__trigger" v-bind="trigger">
             <OnyxIcon :icon="circleInformation" />
@@ -36,13 +31,7 @@ const type = computed(() => {
     </template>
     <template v-else>
       <!-- The info tooltip is not accessible when it's triggered on hover. Its trigger element ist not focusable, so instead we provide it's text visually hidden -->
-      <OnyxTooltip
-        aria-hidden="true"
-        :text="props.text"
-        :open="props.open"
-        :color="props.color"
-        :position="props.position"
-      >
+      <OnyxTooltip aria-hidden="true" v-bind="props">
         <template #default="{ trigger }">
           <span class="onyx-info-tooltip__trigger" v-bind="trigger">
             <OnyxIcon :icon="circleInformation" />

--- a/packages/sit-onyx/src/components/OnyxInfoTooltip/types.ts
+++ b/packages/sit-onyx/src/components/OnyxInfoTooltip/types.ts
@@ -1,4 +1,4 @@
 import type { OnyxTooltipProps } from "../OnyxTooltip/types";
 
 export type OnyxInfoTooltipProps = Required<Pick<OnyxTooltipProps, "text">> &
-  Pick<OnyxTooltipProps, "position" | "open" | "color">;
+  Omit<OnyxTooltipProps, "text" | "fitParent">;


### PR DESCRIPTION
Allow passing all props of the OnyxTooltip to the OnyxInfoTooltip. Currently we limited the props which does not make sense

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
