### PR TITLE
feat(OnyxHeadline): automatically normalize hash

### DIFF
--- a/.changeset/seven-worms-happen.md
+++ b/.changeset/seven-worms-happen.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxHeadline): automatically normalize hash

--- a/.changeset/seven-worms-happen.md
+++ b/.changeset/seven-worms-happen.md
@@ -7,5 +7,5 @@ feat(OnyxHeadline): automatically normalize hash
 Other changes:
 
 - hide `#` when hash is set for screen readers
-- add title and aria description to hash link
+- add hover title and screen reader text to hash link
 - remove `normalizeUrlHash()` method since this is now automatically done by the OnyxHeadline

--- a/.changeset/seven-worms-happen.md
+++ b/.changeset/seven-worms-happen.md
@@ -1,5 +1,5 @@
 ---
-"sit-onyx": minor
+"sit-onyx": major
 ---
 
 feat(OnyxHeadline): automatically normalize hash
@@ -8,3 +8,4 @@ Other changes:
 
 - hide `#` when hash is set for screen readers
 - add title and aria description to hash link
+- remove `normalizeUrlHash()` method since this is now automatically done by the OnyxHeadline

--- a/.changeset/seven-worms-happen.md
+++ b/.changeset/seven-worms-happen.md
@@ -3,3 +3,8 @@
 ---
 
 feat(OnyxHeadline): automatically normalize hash
+
+Other changes:
+
+- hide `#` when hash is set for screen readers
+- add title and aria description to hash link

--- a/apps/docs/src/.vitepress/components/DesignVariableHeader.vue
+++ b/apps/docs/src/.vitepress/components/DesignVariableHeader.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { OnyxButton, OnyxHeadline, normalizeUrlHash } from "sit-onyx";
+import { OnyxButton, OnyxHeadline } from "sit-onyx";
 
 const props = defineProps<{
   /** Headline to show on the left side of the header. */
@@ -18,12 +18,7 @@ const emit = defineEmits<{
 
 <template>
   <div class="header vp-raw">
-    <OnyxHeadline
-      is="h3"
-      v-if="props.headline"
-      class="header__headline"
-      :hash="normalizeUrlHash(props.headline)"
-    >
+    <OnyxHeadline is="h3" v-if="props.headline" class="header__headline" :hash="props.headline">
       {{ props.headline }}
     </OnyxHeadline>
 

--- a/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
+++ b/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { OnyxHeadline, OnyxInput, normalizeUrlHash } from "sit-onyx";
+import { OnyxHeadline, OnyxInput } from "sit-onyx";
 import { computed, ref } from "vue";
 import { getEnrichedIconCategoryList } from "../utils-icons";
 import IconLibraryItem from "./IconLibraryItem.vue";
@@ -48,7 +48,7 @@ const filteredCategories = computed(() => {
     />
 
     <section v-for="category in filteredCategories" :key="category.name" class="category">
-      <OnyxHeadline is="h3" class="category__headline" :hash="normalizeUrlHash(category.name)">
+      <OnyxHeadline is="h3" class="category__headline" :hash="category.name">
         {{ category.name }}
       </OnyxHeadline>
 

--- a/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
+++ b/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
@@ -108,7 +108,7 @@ const copyLink = async (hash: string) => {
           // the / "" is used to ignore the content for screen readers, see:
           // https://developer.mozilla.org/en-US/docs/Web/CSS/content#alternative_text_string_counter
           // we still set 'content: "#"' in case the browser does not support the alternative syntax
-          // content: "#";
+          content: "#";
           content: "#" / "";
         }
       }

--- a/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
+++ b/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
@@ -4,6 +4,7 @@ import { SKELETON_INJECTED_SYMBOL, useSkeletonContext } from "../../composables/
 import { injectI18n } from "../../i18n";
 import { normalizeUrlHash } from "../../utils/strings";
 import OnyxSkeleton from "../OnyxSkeleton/OnyxSkeleton.vue";
+import OnyxVisuallyHidden from "../OnyxVisuallyHidden/OnyxVisuallyHidden.vue";
 import type { OnyxHeadlineProps } from "./types";
 
 const props = withDefaults(defineProps<OnyxHeadlineProps>(), {
@@ -46,10 +47,10 @@ const copyLink = async (hash: string) => {
       :href="`#${normalizedHash}`"
       target="_self"
       class="onyx-headline__hash"
-      :title="t('headline.copyPermalink')"
-      :aria-description="t('headline.copyPermalink')"
+      :title="t('headline.copyLink')"
       @click="copyLink(normalizedHash)"
     >
+      <OnyxVisuallyHidden>{{ t("headline.copyLinkTo") }}</OnyxVisuallyHidden>
       <slot />
     </a>
 

--- a/packages/sit-onyx/src/components/OnyxHeadline/types.ts
+++ b/packages/sit-onyx/src/components/OnyxHeadline/types.ts
@@ -8,9 +8,7 @@ export type OnyxHeadlineProps = {
   is: HeadlineType;
   /**
    * Unique headline hash/ID (without "#") that is used to show a "#" icon on hover. Makes the headline clickable and a URL that points to this headline
-   * is copied to the users clipboard. Must be URL-safe, e.g. not containing whitespaces etc.
-   *
-   * If your headline content is dynamic, you can use our `normalizeUrlHash()` utility to generate it.
+   * is copied to the users clipboard. Will be automatically normalized when containing non URL-safe characters.
    *
    * @example "about-us"
    */

--- a/packages/sit-onyx/src/i18n/locales/de-DE.json
+++ b/packages/sit-onyx/src/i18n/locales/de-DE.json
@@ -149,6 +149,7 @@
     "close": "Dialog schließen"
   },
   "headline": {
-    "copyPermalink": "Link zu dieser Überschrift kopieren"
+    "copyLink": "Link zu dieser Überschrift kopieren",
+    "copyLinkTo": "Link kopieren zu Überschrift:"
   }
 }

--- a/packages/sit-onyx/src/i18n/locales/de-DE.json
+++ b/packages/sit-onyx/src/i18n/locales/de-DE.json
@@ -147,5 +147,8 @@
   },
   "dialog": {
     "close": "Dialog schließen"
+  },
+  "headline": {
+    "copyPermalink": "Link zu dieser Überschrift kopieren"
   }
 }

--- a/packages/sit-onyx/src/i18n/locales/en-US.json
+++ b/packages/sit-onyx/src/i18n/locales/en-US.json
@@ -149,6 +149,7 @@
     "close": "Close dialog"
   },
   "headline": {
-    "copyPermalink": "Copy link to this headline"
+    "copyLink": "Copy link to this headline",
+    "copyLinkTo": "Copy link to headline:"
   }
 }

--- a/packages/sit-onyx/src/i18n/locales/en-US.json
+++ b/packages/sit-onyx/src/i18n/locales/en-US.json
@@ -147,5 +147,8 @@
   },
   "dialog": {
     "close": "Close dialog"
+  },
+  "headline": {
+    "copyPermalink": "Copy link to this headline"
   }
 }

--- a/packages/sit-onyx/src/index.ts
+++ b/packages/sit-onyx/src/index.ts
@@ -158,6 +158,6 @@ export { provideI18n, type TranslationFunction } from "./i18n";
 export type { OnyxTranslations, ProvideI18nOptions } from "./i18n";
 export * from "./types";
 export { createOnyx } from "./utils/plugin";
-export { normalizeUrlHash, normalizedIncludes } from "./utils/strings";
+export { normalizedIncludes } from "./utils/strings";
 
 export * from "./composables/themeTransition";

--- a/packages/sit-onyx/src/utils/strings.spec.ts
+++ b/packages/sit-onyx/src/utils/strings.spec.ts
@@ -32,6 +32,7 @@ test.each([
   { text: "Hello World", expected: "hello-world" },
   { text: "   Hello World   ", expected: "hello-world" },
   { text: "hello-world", expected: "hello-world" },
+  { text: "a & b . c / d = e , f ; g : h", expected: "a---b---c---d---e---f---g---h" },
 ])("should transform $text to $expected when normalizing as hash", ({ text, expected }) => {
   // ACT
   const result = normalizeUrlHash(text);


### PR DESCRIPTION
Relates to https://github.com/SchwarzIT/onyx/issues/569#issuecomment-2580111683

- hide `#` for screen readers
- add title and aria description
- automatically normalize hash so the user doesn't have to do this

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
