### PR TITLE
feat(DataGrid): add empty state slot

### DIFF
--- a/.changeset/strange-teachers-hope.md
+++ b/.changeset/strange-teachers-hope.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+Added empty slot to DataGrid to be able to pass custom empty content

--- a/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.stories.ts
@@ -3,6 +3,7 @@ import pin from "@sit-onyx/icons/pin.svg?raw";
 import trash from "@sit-onyx/icons/trash.svg?raw";
 import type { Meta, StoryObj } from "@storybook/vue3";
 import { h } from "vue";
+import OnyxEmpty from "../OnyxEmpty/OnyxEmpty.vue";
 import OnyxIcon from "../OnyxIcon/OnyxIcon.vue";
 import OnyxMenuItem from "../OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue";
 import OnyxSystemButton from "../OnyxSystemButton/OnyxSystemButton.vue";
@@ -70,5 +71,13 @@ export const HeaderInteractions = {
       { id: 4, name: "John", age: 28, birthday: new Date("2003-04-10") },
       { id: 5, name: "Charlotte", age: 28, birthday: new Date("2000-11-08") },
     ],
+  },
+} satisfies Story;
+
+export const CustomEmptyState = {
+  args: {
+    columns: ["name", "age", "birthday"],
+    data: undefined,
+    empty: () => h(OnyxEmpty, null, { default: "DataGrid is empty" }),
   },
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.stories.ts
@@ -77,7 +77,6 @@ export const HeaderInteractions = {
 export const CustomEmptyState = {
   args: {
     columns: ["name", "age", "birthday"],
-    data: undefined,
     empty: () => h(OnyxEmpty, null, { default: "DataGrid is empty" }),
   },
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.vue
@@ -16,6 +16,15 @@ const props = withDefaults(defineProps<OnyxDataGridProps<TEntry, TFeatures>>(), 
 
 const { t } = injectI18n();
 
+defineSlots<{
+  /**
+   * Optional slot to customize the empty state when no data exist.
+   *
+   * If unset, the default empty content of OnyxTable will be displayed.
+   */
+  empty?(): unknown;
+}>();
+
 // Using Ref types to avoid `UnwrapRef` issues
 const renderColumns: Ref<DataGridRendererColumn<TEntry, object>[]> = ref([]);
 const renderRows: Ref<DataGridRendererRow<TEntry, DataGridMetadata>[]> = ref([]);
@@ -53,5 +62,9 @@ watch(
 </script>
 
 <template>
-  <OnyxDataGridRenderer :columns="renderColumns" :rows="renderRows" />
+  <OnyxDataGridRenderer :columns="renderColumns" :rows="renderRows">
+    <template #empty>
+      <slot name="empty" />
+    </template>
+  </OnyxDataGridRenderer>
 </template>

--- a/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGridRenderer/OnyxDataGridRenderer.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGridRenderer/OnyxDataGridRenderer.vue
@@ -9,6 +9,15 @@ const props = withDefaults(defineProps<OnyxDataGridRendererProps<TEntry, TMetada
   striped: true,
   withVerticalBorders: true,
 });
+
+defineSlots<{
+  /**
+   * Optional slot to customize the empty state when no data exist.
+   *
+   * If unset, the default empty content of OnyxTable will be displayed.
+   */
+  empty?(): unknown;
+}>();
 </script>
 
 <template>
@@ -34,6 +43,10 @@ const props = withDefaults(defineProps<OnyxDataGridRendererProps<TEntry, TMetada
         </td>
       </template>
     </tr>
+
+    <template #empty>
+      <slot name="empty" />
+    </template>
   </OnyxTable>
 </template>
 


### PR DESCRIPTION
Added empty slot to DataGrid to be able to pass custom empty content

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
