### PR TITLE
fix(shared): change vite dependencies to optionalDependencies

### DIFF
--- a/.changeset/giant-camels-judge.md
+++ b/.changeset/giant-camels-judge.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix 'failed to resolve import source "./components/OnyxDataGrid/features/index.ts"' error

--- a/.changeset/rotten-scissors-remember.md
+++ b/.changeset/rotten-scissors-remember.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/shared": patch
+---
+
+fix(shared): change vite dependencies to optionalDependencies

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,8 +16,8 @@
       "import": "./dist/*.js"
     }
   },
-  "peerDependencies": {
-    "@vitejs/plugin-vue": "^5.1.4",
+  "optionalDependencies": {
+    "@vitejs/plugin-vue": ">= 5",
     "sass-embedded": ">= 1.74.0",
     "vite": ">= 6"
   }

--- a/packages/sit-onyx/src/index.ts
+++ b/packages/sit-onyx/src/index.ts
@@ -43,7 +43,7 @@ export { default as OnyxDataGrid } from "./components/OnyxDataGrid/OnyxDataGrid.
 export * from "./components/OnyxDataGrid/types";
 
 export * as DataGridFeatures from "./components/OnyxDataGrid/features/all";
-export * from "./components/OnyxDataGrid/features/index.ts";
+export * from "./components/OnyxDataGrid/features/index";
 
 export { default as OnyxDatePicker } from "./components/OnyxDatePicker/OnyxDatePicker.vue";
 export * from "./components/OnyxDatePicker/types";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,9 +387,9 @@ importers:
         version: 6.0.7(@types/node@22.10.7)(jiti@2.4.2)(sass-embedded@1.83.4)(sass@1.83.0)(stylus@0.57.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
 
   packages/shared:
-    dependencies:
+    optionalDependencies:
       '@vitejs/plugin-vue':
-        specifier: ^5.1.4
+        specifier: '>= 5'
         version: 5.2.1(vite@6.0.7(@types/node@22.10.7)(jiti@2.4.2)(sass-embedded@1.83.4)(sass@1.83.0)(stylus@0.57.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
       sass-embedded:
         specifier: 1.83.4


### PR DESCRIPTION
When installing the latest onyx version in a project that uses Vite 5, it will show a peerDependency mismatch warning since `@sit-onyx/shared` is declared to required Vite 6. However, the vite dependencies are only needed when importing the shared vite config which is mainly done inside our monorepo.

I changed the dependencies to be optionalDependencies to get rid of the warning.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
