### PR TITLE
fix(OnyxDataGrid): export sorting types

### DIFF
--- a/.changeset/twenty-swans-eat.md
+++ b/.changeset/twenty-swans-eat.md
@@ -3,3 +3,7 @@
 ---
 
 fix(OnyxDataGrid): export sorting types
+
+Previously, all data grid types were exported under the `DataGridFeatures` namespace so if you e.g. wanted to use the `SortState` type, you'd need to use `DataGridFeatures.SortState`.
+
+This is unintuitive so those types are now directly exported individually from `sit-onyx`. The data grid features itself are still exported under the `DataGridFeatures` namespace.

--- a/.changeset/twenty-swans-eat.md
+++ b/.changeset/twenty-swans-eat.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxDataGrid): export sorting types

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/all.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/all.ts
@@ -1,3 +1,7 @@
 export * from "./sorting/types";
 
-export { useSorting } from "./sorting/sorting";
+import { useSorting } from "./sorting/sorting";
+
+export const DataGridFeatures = {
+  useSorting,
+};

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/TestCase.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/TestCase.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
-import type { DataGridEntry, OnyxDataGridProps } from "../../../..";
+import type { DataGridEntry, OnyxDataGridProps, SortState } from "../../../..";
 import { DataGridFeatures, OnyxDataGrid } from "../../../..";
 
 const { columns, data } = defineProps<Pick<OnyxDataGridProps, "columns" | "data">>();
 
 const emit = defineEmits<{
-  sortChange: [sortState: DataGridFeatures.SortState<DataGridEntry>];
+  sortChange: [sortState: SortState<DataGridEntry>];
 }>();
 
-const sortState = ref<DataGridFeatures.SortState<DataGridEntry>>({
+const sortState = ref<SortState<DataGridEntry>>({
   column: undefined,
   direction: "none",
 });

--- a/packages/sit-onyx/src/index.ts
+++ b/packages/sit-onyx/src/index.ts
@@ -42,7 +42,7 @@ export * from "./components/OnyxDataGrid/OnyxDataGridRenderer/types";
 export { default as OnyxDataGrid } from "./components/OnyxDataGrid/OnyxDataGrid.vue";
 export * from "./components/OnyxDataGrid/types";
 
-export * as DataGridFeatures from "./components/OnyxDataGrid/features/all";
+export * from "./components/OnyxDataGrid/features/all";
 export * from "./components/OnyxDataGrid/features/index";
 
 export { default as OnyxDatePicker } from "./components/OnyxDatePicker/OnyxDatePicker.vue";


### PR DESCRIPTION
Remove scoped namespace for exporting data grid feature types.

Feedback from @oemueller 

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
