### PR TITLE
feat(OnyxHeadline): support `visualSize` property

### DIFF
--- a/.changeset/great-walls-juggle.md
+++ b/.changeset/great-walls-juggle.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxHeadline): support `visualSize` property

--- a/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.ct.tsx
@@ -16,6 +16,19 @@ test.describe("Screenshot tests", () => {
   });
 });
 
+test.describe("Screenshot tests (visual size)", () => {
+  executeMatrixScreenshotTest({
+    name: "Headline (visual sizes)",
+    columns: ["h1", "h2", "h3", "h4"],
+    rows: HEADLINE_TYPES,
+    component: (column, row) => (
+      <OnyxHeadline is={row} visualSize={column}>
+        Hello World
+      </OnyxHeadline>
+    ),
+  });
+});
+
 test.describe("Screenshot tests (hash)", () => {
   executeMatrixScreenshotTest({
     name: "Headline (hash)",

--- a/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
+++ b/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.vue
@@ -22,6 +22,7 @@ const { t } = injectI18n();
 const skeleton = useSkeletonContext(props);
 
 const normalizedHash = computed(() => (props.hash ? normalizeUrlHash(props.hash) : undefined));
+const visualSize = computed(() => props.visualSize ?? props.is);
 
 const copyLink = async (hash: string) => {
   const { origin, pathname, search } = window.location;
@@ -33,14 +34,14 @@ const copyLink = async (hash: string) => {
 <template>
   <OnyxSkeleton
     v-if="skeleton"
-    :class="['onyx-headline-skeleton', `onyx-headline-skeleton--${props.is}`]"
+    :class="['onyx-headline-skeleton', `onyx-headline-skeleton--${visualSize}`]"
   />
 
   <component
     :is="props.is"
     v-else
     :id="normalizedHash"
-    :class="['onyx-component', 'onyx-headline', `onyx-headline--${props.is}`]"
+    :class="['onyx-component', 'onyx-headline', `onyx-headline--${visualSize}`]"
   >
     <a
       v-if="normalizedHash"

--- a/packages/sit-onyx/src/components/OnyxHeadline/types.ts
+++ b/packages/sit-onyx/src/components/OnyxHeadline/types.ts
@@ -2,10 +2,14 @@ import type { SkeletonInjected } from "../../composables/useSkeletonState";
 
 export type OnyxHeadlineProps = {
   /**
-   * Headline type. Please note that only h1-h4 are intended to be used from UX perspective.
-   * h5 and h6 will have the same styles as h4 and should only be used for semantic reasons.
+   * Semantical headline type. Should match the page hierarchy and should not skip hierarchies (e.g. h2 should be follow by h3 etc.).
    */
   is: HeadlineType;
+  /**
+   * Visual size of the headline (h1-h6). Will default to but can be different from the semantical `is` property.
+   * Please note that only h1-h4 are intended to be used from UX perspective, h5 and h6 will have the same styles as h4.
+   */
+  visualSize?: Exclude<HeadlineType, "h5" | "h6">;
   /**
    * Unique headline hash/ID (without "#") that is used to show a "#" icon on hover. Makes the headline clickable and a URL that points to this headline
    * is copied to the users clipboard. Will be automatically normalized when containing non URL-safe characters.


### PR DESCRIPTION
Relates to #2451 

Add new `visualSize` property to allow defining a different visual size instead of the semantical type.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] All changes are documented in the documentation app (folder `apps/docs`)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
