### PR TITLE
docs(OnyxColorSchemeDialog): fix Storybook example when open property is set manually

### DIFF
--- a/packages/sit-onyx/src/components/OnyxAlertDialog/OnyxAlertDialog.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxAlertDialog/OnyxAlertDialog.stories.ts
@@ -1,8 +1,10 @@
 import circleAttention from "@sit-onyx/icons/circle-attention.svg?raw";
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { h, ref, watchEffect } from "vue";
+import { useArgs } from "storybook/internal/preview-api";
+import { h, ref, watch, watchEffect } from "vue";
 import OnyxButton from "../OnyxButton/OnyxButton.vue";
 import OnyxAlertDialog from "./OnyxAlertDialog.vue";
+import type { OnyxAlertDialogProps } from "./types";
 
 /**
  * The alert dialog is used to provide important information to the user.
@@ -32,25 +34,34 @@ export const Default = {
       icon: circleAttention,
       color: "danger",
     },
-    actions: [
+    actions: () => [
       h(OnyxButton, { label: "Cancel", color: "neutral", mode: "plain", autofocus: true }),
       h(OnyxButton, { label: "Delete", color: "danger" }),
     ],
   },
   decorators: [
-    (story, ctx) => ({
-      components: { story, OnyxButton },
-      setup: () => {
-        const isOpen = ref(false);
-        watchEffect(() => {
-          ctx.args.open = isOpen.value;
-        });
-        return { isOpen };
-      },
-      template: `<div>
-        <OnyxButton label="Show alert modal" @click="isOpen = true" />
-        <story :open="isOpen" @close="isOpen = false;" />
-      </div>`,
-    }),
+    (story) => {
+      const [args, updateArgs] = useArgs<OnyxAlertDialogProps>();
+
+      return {
+        components: { story, OnyxButton },
+        setup: () => {
+          const isOpen = ref(false);
+
+          watch(
+            () => args.open,
+            (newOpen) => (isOpen.value = !!newOpen),
+            { immediate: true },
+          );
+
+          watchEffect(() => updateArgs({ open: isOpen.value }));
+          return { isOpen };
+        },
+        template: `<div>
+          <OnyxButton label="Show alert modal" @click="isOpen = true" />
+          <story :open="isOpen" @close="isOpen = false;" />
+        </div>`,
+      };
+    },
   ],
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxModalDialog/OnyxModalDialog.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxModalDialog/OnyxModalDialog.stories.ts
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { h, ref, watchEffect } from "vue";
+import { useArgs } from "storybook/internal/preview-api";
+import { h, ref, watch, watchEffect } from "vue";
 import OnyxButton from "../OnyxButton/OnyxButton.vue";
 import OnyxModalDialog from "./OnyxModalDialog.vue";
+import type { OnyxModalDialogProps } from "./types";
 
 /**
  * The modal dialog is used to provide information to the user while interaction with the rest of the page is prevented and a backdrop is displayed.
@@ -38,19 +40,28 @@ export const Default = {
     ),
   },
   decorators: [
-    (story, ctx) => ({
-      components: { story, OnyxButton },
-      setup: () => {
-        const isOpen = ref(false);
-        watchEffect(() => {
-          ctx.args.open = isOpen.value;
-        });
-        return { isOpen };
-      },
-      template: `<div>
-        <OnyxButton label="Show modal" @click="isOpen = true" />
-        <story :open="isOpen" @close="isOpen = false;" />
-      </div>`,
-    }),
+    (story) => {
+      const [args, updateArgs] = useArgs<OnyxModalDialogProps>();
+
+      return {
+        components: { story, OnyxButton },
+        setup: () => {
+          const isOpen = ref(false);
+
+          watch(
+            () => args.open,
+            (newOpen) => (isOpen.value = !!newOpen),
+            { immediate: true },
+          );
+
+          watchEffect(() => updateArgs({ open: isOpen.value }));
+          return { isOpen };
+        },
+        template: `<div>
+          <OnyxButton label="Show modal" @click="isOpen = true" />
+          <story :open="isOpen" @close="isOpen = false;" />
+        </div>`,
+      };
+    },
   ],
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxColorSchemeDialog/OnyxColorSchemeDialog.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxColorSchemeDialog/OnyxColorSchemeDialog.stories.ts
@@ -24,15 +24,11 @@ const meta: Meta<typeof OnyxColorSchemeDialog> = {
 
           watch(
             () => args.open,
-            (newOpen) => {
-              isOpen.value = !!newOpen;
-            },
+            (newOpen) => (isOpen.value = !!newOpen),
             { immediate: true },
           );
 
-          watchEffect(() => {
-            updateArgs({ open: isOpen.value });
-          });
+          watchEffect(() => updateArgs({ open: isOpen.value }));
           return { isOpen };
         },
         template: `<div>

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxColorSchemeDialog/OnyxColorSchemeDialog.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxColorSchemeDialog/OnyxColorSchemeDialog.stories.ts
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/vue3";
-import { ref, watchEffect } from "vue";
+import { useArgs } from "storybook/internal/preview-api";
+import { ref, watch, watchEffect } from "vue";
 import OnyxButton from "../../../OnyxButton/OnyxButton.vue";
 import OnyxColorSchemeDialog from "./OnyxColorSchemeDialog.vue";
+import type { OnyxColorSchemeDialogProps } from "./types";
 
 /**
  * Pre-built dialog where the user can select which color scheme (light/dark mode or auto) to use for the application.
@@ -12,20 +14,33 @@ const meta: Meta<typeof OnyxColorSchemeDialog> = {
   title: "Navigation/modules/ColorSchemeDialog",
   component: OnyxColorSchemeDialog,
   decorators: [
-    (story, ctx) => ({
-      components: { story, OnyxButton },
-      setup: () => {
-        const isOpen = ref(false);
-        watchEffect(() => {
-          ctx.args.open = isOpen.value;
-        });
-        return { isOpen };
-      },
-      template: `<div>
-          <OnyxButton label="Show dialog" @click="isOpen = true" />
-          <story :open="isOpen" @close="isOpen = false;" />
-        </div>`,
-    }),
+    (story) => {
+      const [args, updateArgs] = useArgs<OnyxColorSchemeDialogProps>();
+
+      return {
+        components: { story, OnyxButton },
+        setup: () => {
+          const isOpen = ref(false);
+
+          watch(
+            () => args.open,
+            (newOpen) => {
+              isOpen.value = !!newOpen;
+            },
+            { immediate: true },
+          );
+
+          watchEffect(() => {
+            updateArgs({ open: isOpen.value });
+          });
+          return { isOpen };
+        },
+        template: `<div>
+            <OnyxButton label="Show dialog" @click="isOpen = true" />
+            <story :open="isOpen" @close="isOpen = false;" />
+          </div>`,
+      };
+    },
   ],
 };
 


### PR DESCRIPTION
Relates to https://github.com/SchwarzIT/onyx/issues/2384#issuecomment-2611865738

Currently, when setting the `open` property manually, the close button did not close the dialog again.
