### PR TITLE
chore: use turbo watch command for development

### DIFF
--- a/.github/workflows/playwright-screenshots.yml
+++ b/.github/workflows/playwright-screenshots.yml
@@ -1,47 +1,19 @@
 name: Update Playwright screenshots
 on:
   workflow_dispatch:
-  issue_comment:
-    types: [created]
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }}
 
-permissions:
-  contents: write
-
 jobs:
   screenshots:
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/update-screenshots') }}
     uses: ./.github/workflows/playwright.yml
     secrets: inherit
     with:
       update-snapshots: true
 
-  merge:
-    if: ${{ contains(github.event.comment.body, '/update-screenshots-and-merge') }}
-    name: Merge screenshots directly
-    runs-on: ubuntu-latest
-    needs: screenshots
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-
-      - name: Download screenshots
-        uses: actions/download-artifact@v4
-        with:
-          pattern: screenshots
-          merge-multiple: true
-
-      - uses: EndBug/add-and-commit@v9
-        with:
-          author_name: "github-actions[bot]"
-          author_email: "41898282+github-actions[bot]@users.noreply.github.com"
-          message: "chore: update Playwright screenshots"
-
+  # Download screenshots from all shards and create a pull request
   pr:
-    if: ${{ !contains(github.event.comment.body, '/update-screenshots-and-merge') }}
     name: Create pull request
     runs-on: ubuntu-latest
     needs: screenshots

--- a/.github/workflows/playwright-screenshots.yml
+++ b/.github/workflows/playwright-screenshots.yml
@@ -1,19 +1,47 @@
 name: Update Playwright screenshots
 on:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE__TURBO_TOKEN }}
 
+permissions:
+  contents: write
+
 jobs:
   screenshots:
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/update-screenshots') }}
     uses: ./.github/workflows/playwright.yml
     secrets: inherit
     with:
       update-snapshots: true
 
-  # Download screenshots from all shards and create a pull request
+  merge:
+    if: ${{ contains(github.event.comment.body, '/update-screenshots-and-merge') }}
+    name: Merge screenshots directly
+    runs-on: ubuntu-latest
+    needs: screenshots
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Download screenshots
+        uses: actions/download-artifact@v4
+        with:
+          pattern: screenshots
+          merge-multiple: true
+
+      - uses: EndBug/add-and-commit@v9
+        with:
+          author_name: "github-actions[bot]"
+          author_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          message: "chore: update Playwright screenshots"
+
   pr:
+    if: ${{ !contains(github.event.comment.body, '/update-screenshots-and-merge') }}
     name: Create pull request
     runs-on: ubuntu-latest
     needs: screenshots

--- a/apps/demo-app/package.json
+++ b/apps/demo-app/package.json
@@ -4,8 +4,7 @@
   "version": "1.0.0-beta.147",
   "type": "module",
   "scripts": {
-    "dev": "turbo run turbo:dev --filter=.",
-    "turbo:dev": "vite",
+    "dev": "vite",
     "build": "vue-tsc && vite build",
     "preview": "vite preview"
   },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,8 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "turbo run turbo:dev --filter=.",
-    "turbo:dev": "vitepress dev src",
+    "dev": "vitepress dev src",
     "build": "pnpm run '/type-check|build-only/'",
     "build-only": "vitepress build src",
     "type-check": "vue-tsc --noEmit",

--- a/apps/docs/src/principles/contributing/index.md
+++ b/apps/docs/src/principles/contributing/index.md
@@ -42,6 +42,7 @@ Here is a list of the most commonly used scripts.
 pnpm install # install all dependencies
 pnpm lint:fix:all # lint and fix all packages
 pnpm format:all # format all files
+pnpm dev <package-name> # run dev mode for the given `<package-name>`
 ```
 
 ```sh [packages/sit-onyx]

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -8,8 +8,7 @@
   "private": true,
   "homepage": "https://playground.onyx.schwarz",
   "scripts": {
-    "dev": "turbo run turbo:dev --filter=.",
-    "turbo:dev": "vite",
+    "dev": "vite",
     "preview": "vite preview",
     "build": "pnpm run '/type-check|build-only/'",
     "build-only": "vite build",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Schwarz IT KG",
   "license": "Apache-2.0",
   "scripts": {
+    "dev": "./scripts/dev.sh",
     "build:all": "turbo run build build:storybook",
     "test:all": "turbo run test:coverage",
     "test:playwright:all": "turbo run test:playwright --concurrency 1",

--- a/packages/chartjs-plugin/package.json
+++ b/packages/chartjs-plugin/package.json
@@ -23,8 +23,7 @@
     "url": "https://github.com/SchwarzIT/onyx/issues"
   },
   "scripts": {
-    "dev": "turbo run turbo:dev --filter=.",
-    "turbo:dev": "storybook dev -p 6006 --no-open",
+    "dev": "storybook dev -p 6006 --no-open",
     "build": "vue-tsc --noEmit",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -26,8 +26,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "turbo run turbo:dev --filter=.",
-    "turbo:dev": "nuxi dev playground",
+    "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "build": "pnpm run dev:prepare && nuxt-module-build build",

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -34,8 +34,7 @@
     "url": "https://github.com/SchwarzIT/onyx/issues"
   },
   "scripts": {
-    "dev": "turbo run turbo:dev --filter=.",
-    "turbo:dev": "storybook dev -p 6006 --no-open",
+    "dev": "storybook dev -p 6006 --no-open",
     "build": "vite build && vue-tsc -p tsconfig.app.json --composite false && vue-tsc -p tsconfig.locales.json --composite false",
     "build:storybook": "storybook build",
     "preview": "vite serve storybook-static",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -ex
+
+# Runs the dev script with turbo watch for the given package.
+# Turbo will run all dependency builds initially, but also watch and rebuild any changed dependencies 
+pnpm exec turbo watch $1#dev 

--- a/scripts/show-last-test-report.sh
+++ b/scripts/show-last-test-report.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -ex
 
 # check if gh cli is installed
 if ! command -v gh &>/dev/null; then

--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,7 @@
       "outputs": ["playwright-report", "test-results", "blob-reports"],
       "cache": false
     },
-    "turbo:dev": {
+    "dev": {
       "dependsOn": ["^build"],
       "cache": false,
       "persistent": true


### PR DESCRIPTION
- **use turbo watch command for development:**
Finally figured out how to use `turbo watch` correctly.
It only works from the root of the project.
Added a small helper script to let you start the dev mode more easily.
Updated relevant docs. Removed now redundant `turbo:dev` npm scripts.
- **updated shell scripts to print commands and exit on first error**