### PR TITLE
fix: correctly detect links as external

### DIFF
--- a/.changeset/lazy-pumpkins-develop.md
+++ b/.changeset/lazy-pumpkins-develop.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix: correctly detect links as external

--- a/.changeset/lazy-pumpkins-develop.md
+++ b/.changeset/lazy-pumpkins-develop.md
@@ -3,3 +3,8 @@
 ---
 
 fix: correctly detect links as external
+
+Previously only links starting with `http://` or `https://` we detected as external links, meaning all other links we treated as internal and navigated using the [provided Vue Router](https://onyx.schwarz/development/router.html).
+
+Since this is incorrect for links like `mailto:`, `tel:` etc. this behavior has been fixed.
+Now only links starting with `/` and `#` are treated as **internal**. All other links are treated as **external**.

--- a/.changeset/lazy-pumpkins-develop.md
+++ b/.changeset/lazy-pumpkins-develop.md
@@ -7,4 +7,4 @@ fix: correctly detect links as external
 Previously only links starting with `http://` or `https://` we detected as external links, meaning all other links we treated as internal and navigated using the [provided Vue Router](https://onyx.schwarz/development/router.html).
 
 Since this is incorrect for links like `mailto:`, `tel:` etc. this behavior has been fixed.
-Now only links starting with `/` and `#` are treated as **internal**. All other links are treated as **external**.
+Now only links starting with `/`, `#`, `./` and `../` are treated as **internal**. All other links are treated as **external**.

--- a/packages/sit-onyx/src/components/OnyxExternalLinkIcon/OnyxExternalLinkIcon.vue
+++ b/packages/sit-onyx/src/components/OnyxExternalLinkIcon/OnyxExternalLinkIcon.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import arrowSmallUpRight from "@sit-onyx/icons/arrow-small-up-right.svg?raw";
 import { computed } from "vue";
-import { isExternalLink } from "../../utils";
+import { isInternalLink } from "../../utils";
 import OnyxIcon from "../OnyxIcon/OnyxIcon.vue";
 import type { OnyxExternalLinkIconProps } from "./types";
 
@@ -12,7 +12,7 @@ const props = withDefaults(defineProps<OnyxExternalLinkIconProps>(), {
 const isVisible = computed(() => {
   const withExternalIcon = props.withExternalIcon;
   if (withExternalIcon !== "auto") return withExternalIcon;
-  return isExternalLink(props.href ?? "");
+  return !isInternalLink(props.href ?? "");
 });
 </script>
 

--- a/packages/sit-onyx/src/composables/useLink.ts
+++ b/packages/sit-onyx/src/composables/useLink.ts
@@ -1,6 +1,6 @@
 import { computed, inject, unref, type InjectionKey, type Ref } from "vue";
 import type { SharedLinkProps } from "../components/OnyxRouterLink/types";
-import { isExternalLink } from "../utils";
+import { isInternalLink } from "../utils";
 import { extractLinkProps } from "../utils/router";
 
 /**
@@ -41,7 +41,7 @@ export const useLink = () => {
    * ```
    */
   const navigate = (e: MouseEvent, href: string) => {
-    if (router && !isExternalLink(href) && shouldHandleNavigation(e)) {
+    if (router && isInternalLink(href) && shouldHandleNavigation(e)) {
       // prevent actual navigation so we can handle this with the user provided router
       e.preventDefault();
       router.push(href);

--- a/packages/sit-onyx/src/utils/index.spec.ts
+++ b/packages/sit-onyx/src/utils/index.spec.ts
@@ -1,17 +1,19 @@
 import { describe, expect, test } from "vitest";
-import { isExternalLink } from ".";
+import { isInternalLink } from ".";
 
-describe("isExternalLink", () => {
-  test.each<{ href: string; external: boolean }>([
-    { href: "http://example.com", external: true },
-    { href: "https://example.com", external: true },
-    { href: "#", external: false },
-    { href: "/some/internal/page", external: false },
-    { href: "mailto:john.doe@example.com", external: false },
-    { href: "tel:12345678", external: false },
-    { href: "data:test", external: false },
-    { href: "blob:test", external: false },
-  ])(`$href should be external: $external`, ({ href, external }) => {
-    expect(isExternalLink(href)).toBe(external);
+describe("isInternalLink", () => {
+  test.each<{ href: string; internal: boolean }>([
+    // internal links
+    { href: "#", internal: true },
+    { href: "/some/internal/page", internal: true },
+    // external links
+    { href: "http://example.com", internal: false },
+    { href: "https://example.com", internal: false },
+    { href: "mailto:john.doe@example.com", internal: false },
+    { href: "tel:12345678", internal: false },
+    { href: "data:test", internal: false },
+    { href: "blob:test", internal: false },
+  ])(`$href should be internal: $internal`, ({ href, internal }) => {
+    expect(isInternalLink(href)).toBe(internal);
   });
 });

--- a/packages/sit-onyx/src/utils/index.spec.ts
+++ b/packages/sit-onyx/src/utils/index.spec.ts
@@ -6,6 +6,8 @@ describe("isInternalLink", () => {
     // internal links
     { href: "#", internal: true },
     { href: "/some/internal/page", internal: true },
+    { href: "./some/path", internal: true },
+    { href: "../some/path", internal: true },
     // external links
     { href: "http://example.com", internal: false },
     { href: "https://example.com", internal: false },

--- a/packages/sit-onyx/src/utils/index.spec.ts
+++ b/packages/sit-onyx/src/utils/index.spec.ts
@@ -8,6 +8,7 @@ describe("isInternalLink", () => {
     { href: "/some/internal/page", internal: true },
     { href: "./some/path", internal: true },
     { href: "../some/path", internal: true },
+    { href: "", internal: true },
     // external links
     { href: "http://example.com", internal: false },
     { href: "https://example.com", internal: false },

--- a/packages/sit-onyx/src/utils/index.ts
+++ b/packages/sit-onyx/src/utils/index.ts
@@ -1,6 +1,6 @@
 /**
- * Checks whether the given link is external (starts with http:// or https://).
+ * Checks whether the given link is internal / a relative link of the current application.
  */
-export const isExternalLink = (href: string): href is `http${"s" | ""}://${string}` => {
-  return /^http(s?):\/\//.test(href);
+export const isInternalLink = (href: string) => {
+  return href.startsWith("/") || href.startsWith("#");
 };

--- a/packages/sit-onyx/src/utils/index.ts
+++ b/packages/sit-onyx/src/utils/index.ts
@@ -2,5 +2,5 @@
  * Checks whether the given link is internal / a relative link of the current application.
  */
 export const isInternalLink = (href: string) => {
-  return href.startsWith("/") || href.startsWith("#") || /^\.+\//.test(href);
+  return href === "" || href.startsWith("/") || href.startsWith("#") || /^\.+\//.test(href);
 };

--- a/packages/sit-onyx/src/utils/index.ts
+++ b/packages/sit-onyx/src/utils/index.ts
@@ -2,5 +2,7 @@
  * Checks whether the given link is internal / a relative link of the current application.
  */
 export const isInternalLink = (href: string) => {
-  return href === "" || href.startsWith("/") || href.startsWith("#") || /^\.+\//.test(href);
+  // if link can be parsed, it is a full URL with some protocol and domain and no relative link
+  // see: https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static
+  return !URL.canParse(href);
 };

--- a/packages/sit-onyx/src/utils/index.ts
+++ b/packages/sit-onyx/src/utils/index.ts
@@ -2,5 +2,5 @@
  * Checks whether the given link is internal / a relative link of the current application.
  */
 export const isInternalLink = (href: string) => {
-  return href.startsWith("/") || href.startsWith("#");
+  return href.startsWith("/") || href.startsWith("#") || /^\.+\//.test(href);
 };


### PR DESCRIPTION
Relates to #447 

Fix detection of external links. Since there are way more variations for external than for internal links, we will just detect if the link is internal and treat all other links as external.

Previously only links starting with `http://` or `https://` we detected as external links, meaning all other links we treated as internal and navigated using the [provided Vue Router](https://onyx.schwarz/development/router.html).

Since this is incorrect for links like `mailto:`, `tel:` etc. this behavior has been fixed.
Now only links starting with `/` and `#` are treated as **internal**. All other links are treated as **external**.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
