### PR TITLE
docs: show `new` badges for new components and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/98-dev-story.yml
+++ b/.github/ISSUE_TEMPLATE/98-dev-story.yml
@@ -94,6 +94,7 @@ body:
           - [ ] Storybook can show the feature
           - [ ] Storybook code snippet of new/changed examples are checked that they are generated correctly
           - [ ] Namings are aligned with Figma
+          - [ ] Storybook sidebar badge for "New" is added on component or story level if needed. See: https://github.com/Sidnioulz/storybook-addon-tag-badges/?tab=readme-ov-file
 
 
         #### Approval

--- a/packages/sit-onyx/.storybook/main.ts
+++ b/packages/sit-onyx/.storybook/main.ts
@@ -10,7 +10,12 @@ const onyxLayers = readFileSync(
 
 const config: StorybookConfig = {
   stories: ["./pages/*.mdx", "../src/**/*.stories.ts"],
-  addons: ["@storybook/addon-essentials", "storybook-dark-mode", "@storybook/addon-a11y"],
+  addons: [
+    "@storybook/addon-essentials",
+    "storybook-dark-mode",
+    "@storybook/addon-a11y",
+    "storybook-addon-tag-badges",
+  ],
   staticDirs: ["./public"],
   framework: {
     name: "@storybook/vue3-vite",

--- a/packages/sit-onyx/.storybook/manager.ts
+++ b/packages/sit-onyx/.storybook/manager.ts
@@ -1,0 +1,35 @@
+import type { Badge, TagBadgeParameters } from "storybook-addon-tag-badges";
+import { addons } from "storybook/internal/manager-api";
+
+addons.setConfig({
+  tagBadges: [
+    {
+      tags: {
+        prefix: "new:*",
+      },
+      display: {
+        toolbar: false,
+      },
+      badge: ({ getTagSuffix, tag }) => {
+        const type: string = getTagSuffix(tag);
+
+        const TAG_TYPES: Record<string, Omit<Badge, "text">> = {
+          component: {
+            bgColor: "#7392aa",
+            fgColor: "#fff",
+          },
+          feature: {
+            bgColor: "#e3eaf0",
+            borderColor: "#7392aa",
+            fgColor: "#697985",
+          },
+        };
+
+        return {
+          text: "New",
+          ...TAG_TYPES[type],
+        };
+      },
+    },
+  ] satisfies TagBadgeParameters,
+});

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -60,6 +60,7 @@
     "axe-core": "^4.10.2",
     "eslint-plugin-vue-scoped-css": "^2.9.0",
     "sass-embedded": "catalog:",
+    "storybook-addon-tag-badges": "^1.4.0",
     "storybook-dark-mode": "^4.0.2",
     "vue": "catalog:",
     "vue-component-type-helpers": "^2.2.2",

--- a/packages/sit-onyx/src/components/OnyxAccordion/OnyxAccordion.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxAccordion/OnyxAccordion.stories.ts
@@ -10,6 +10,7 @@ import OnyxAccordion from "./OnyxAccordion.vue";
 const meta: Meta<typeof OnyxAccordion> = {
   title: "Basic/Accordion",
   component: OnyxAccordion,
+  tags: ["new:component"],
   argTypes: {
     default: {
       control: { disable: true },

--- a/packages/sit-onyx/src/components/OnyxButton/OnyxButton.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxButton/OnyxButton.stories.ts
@@ -58,6 +58,7 @@ export const Danger = {
  * This example shows the button that opens a link.
  */
 export const WithLink = {
+  tags: ["new:feature"],
   args: {
     label: "Click to open link",
     link: {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.stories.ts
@@ -73,7 +73,8 @@ export const HeaderInteractions = {
   },
 } satisfies Story;
 
-export const WithDifferentColTypes = {
+export const ColumnTypes = {
+  tags: ["new:feature"],
   args: {
     columns: ["name", { key: "age", type: "number" }, { key: "birthday", type: "string" }],
     data: [
@@ -88,6 +89,6 @@ export const CustomEmptyState = {
   args: {
     ...Default.args,
     data: [],
-    empty: () => h(OnyxEmpty, null, { default: "DataGrid is empty" }),
+    empty: () => h(OnyxEmpty, null, () => "Data grid is empty"),
   },
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/selection/selection.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/selection/selection.stories.ts
@@ -6,7 +6,7 @@ import SelectionDataGridExampleCode from "../../../examples/DataGrid/SelectionDa
 const meta: Meta<typeof SelectionDataGrid> = {
   title: "Data/DataGrid/Features", // new features can add their story under the same title
   component: SelectionDataGrid,
-  tags: ["!autodocs"],
+  tags: ["!autodocs", "new:feature"],
   argTypes: {
     selectionState: {
       table: {

--- a/packages/sit-onyx/src/components/OnyxIconButton/OnyxIconButton.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxIconButton/OnyxIconButton.stories.ts
@@ -58,6 +58,7 @@ export const Danger = {
  * This example shows the button in danger color.
  */
 export const WithLink = {
+  tags: ["new:feature"],
   args: {
     icon: expandWindow,
     label: "Open documentation",

--- a/packages/sit-onyx/src/components/OnyxSystemButton/OnyxSystemButton.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxSystemButton/OnyxSystemButton.stories.ts
@@ -31,6 +31,7 @@ export const WithText = {
 } satisfies Story;
 
 export const WithLink = {
+  tags: ["new:feature"],
   args: {
     label: "Open documentation",
     icon: expandWindow,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,15 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    chart.js:
-      specifier: ^4.4.7
-      version: 4.4.7
-    typescript:
-      specifier: 5.6.3
-      version: 5.6.3
-
 overrides:
   '@vue/compiler-core': 3.5.13
   '@vue/compiler-dom': 3.5.13
@@ -437,6 +428,9 @@ importers:
       sass-embedded:
         specifier: 1.85.0
         version: 1.85.0
+      storybook-addon-tag-badges:
+        specifier: ^1.4.0
+        version: 1.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.5.6(prettier@3.5.1))
       storybook-dark-mode:
         specifier: ^4.0.2
         version: 4.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.5.6(prettier@3.5.1))
@@ -2208,11 +2202,6 @@ packages:
 
   '@storybook/manager-api@8.5.3':
     resolution: {integrity: sha512-JtfuMgQpKIPU0ARn1jNPce8FmknpM0Ap0mppWl+KGAWWGadJPDaX/nrY/19dT1kRgIhyOnbX6tgJxII4E9dE5w==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
-  '@storybook/manager-api@8.5.4':
-    resolution: {integrity: sha512-kFK5DM+4YPob0qdiXN5DJh33fDyQvNJb7IAobDS/rPo2L+t6M+DAgqEsXLQXT9nUbnUD9IcCjwEnjKa+EHU2RA==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
@@ -6009,6 +5998,12 @@ packages:
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
+  storybook-addon-tag-badges@1.4.0:
+    resolution: {integrity: sha512-ecVwNVT4zIpnB14ltXCTHsWqykW2lgiHrDJW1VeblI3+aU9uMaSZG0zuey+r3vehMeODADnRNrcdk6sN9MAmBA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      storybook: ^8.4.0
+
   storybook-dark-mode@4.0.2:
     resolution: {integrity: sha512-zjcwwQ01R5t1VsakA6alc2JDIRVtavryW8J3E3eKLDIlAMcvsgtpxlelWkZs2cuNspk6Z10XzhQVrUWtYc3F0w==}
 
@@ -7869,7 +7864,7 @@ snapshots:
   '@eslint/config-array@0.19.2':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7899,7 +7894,7 @@ snapshots:
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -9073,10 +9068,6 @@ snapshots:
       storybook: 8.5.6(prettier@3.5.1)
 
   '@storybook/manager-api@8.5.3(storybook@8.5.6(prettier@3.5.1))':
-    dependencies:
-      storybook: 8.5.6(prettier@3.5.1)
-
-  '@storybook/manager-api@8.5.4(storybook@8.5.6(prettier@3.5.1))':
     dependencies:
       storybook: 8.5.6(prettier@3.5.1)
 
@@ -10417,6 +10408,10 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@9.4.0):
     dependencies:
       ms: 2.1.3
@@ -10609,7 +10604,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.24.2):
     dependencies:
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       esbuild: 0.24.2
     transitivePeerDependencies:
       - supports-color
@@ -10900,7 +10895,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -12765,7 +12760,7 @@ snapshots:
 
   postcss-styl@0.12.3:
     dependencies:
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       fast-diff: 1.3.0
       lodash.sortedlastindex: 4.1.0
       postcss: 8.5.2
@@ -13414,13 +13409,21 @@ snapshots:
 
   std-env@3.8.0: {}
 
+  storybook-addon-tag-badges@1.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.5.6(prettier@3.5.1)):
+    dependencies:
+      '@storybook/icons': 1.3.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      storybook: 8.5.6(prettier@3.5.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   storybook-dark-mode@4.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.5.6(prettier@3.5.1)):
     dependencies:
       '@storybook/components': 8.5.4(storybook@8.5.6(prettier@3.5.1))
       '@storybook/core-events': 8.5.4(storybook@8.5.6(prettier@3.5.1))
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.3.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@storybook/manager-api': 8.5.4(storybook@8.5.6(prettier@3.5.1))
+      '@storybook/manager-api': 8.5.6(storybook@8.5.6(prettier@3.5.1))
       '@storybook/theming': 8.5.4(storybook@8.5.6(prettier@3.5.1))
       fast-deep-equal: 3.1.3
       memoizerific: 1.11.3
@@ -13572,7 +13575,7 @@ snapshots:
   stylus@0.57.0:
     dependencies:
       css: 3.0.0
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       glob: 7.2.3
       safer-buffer: 2.1.2
       sax: 1.2.4
@@ -14411,7 +14414,7 @@ snapshots:
 
   vue-eslint-parser@9.4.3(eslint@9.20.1(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       eslint: 9.20.1(jiti@2.4.2)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3


### PR DESCRIPTION
Relates to #2369

Configure Storybook addon to show "new" badges for new components and features.
