### PR TITLE
chore: Reduce resources for turbo remote cache

### DIFF
--- a/apps/turbo-remote-cache/.cloud-foundry/manifest-prod.yml
+++ b/apps/turbo-remote-cache/.cloud-foundry/manifest-prod.yml
@@ -1,7 +1,7 @@
 applications:
   - name: turbo-remote-cache
     instances: 2
-    memory: 256MB
+    memory: 128MB
     disk_quota: 1GB
     docker:
       image: ducktors/turborepo-remote-cache


### PR DESCRIPTION
Even when running our tests (with 12 shards loading from the cache) we barely use 30% of the assigned memory:

<img width="432" alt="Screenshot 2025-02-19 at 11 52 25" src="https://github.com/user-attachments/assets/215abbb8-eedd-4e1e-ae6d-7b96b507530b" />

So we should be able to reduce the cost and memory assigned by 50%.