### PR TITLE
fix(i18n): prevent message compilation error in Nuxt

### DIFF
--- a/.changeset/tall-carrots-flash.md
+++ b/.changeset/tall-carrots-flash.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(i18n): prevent message compilation error in Nuxt

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -64,6 +64,7 @@
     "storybook-dark-mode": "^4.0.2",
     "vue": "catalog:",
     "vue-component-type-helpers": "^2.2.2",
+    "vue-i18n": "^11.1.1",
     "vue-router": "^4.5.0"
   }
 }

--- a/packages/sit-onyx/src/i18n/index.spec.ts
+++ b/packages/sit-onyx/src/i18n/index.spec.ts
@@ -255,7 +255,7 @@ test.each(LOCALES.map((locale) => ({ locale })))(
     });
 
     const keys = Object.entries(localeMessages).flatMap(([key, value]) =>
-      getObjectKeys(key, value),
+      getFlattenedTranslationKeys(key, value),
     );
 
     for (const key of keys) {
@@ -266,9 +266,14 @@ test.each(LOCALES.map((locale) => ({ locale })))(
   },
 );
 
-function getObjectKeys(key: string, value: TranslationValue): string[] {
+/**
+ * Gets all nested keys of the given translation entry as a flattened array.
+ *
+ * @example ["key", "key.nested.child"]
+ */
+function getFlattenedTranslationKeys(key: string, value: TranslationValue): string[] {
   if (typeof value === "string") return [key];
   return Object.entries(value).flatMap(([nestedKey, nestedValue]) =>
-    getObjectKeys(`${key}.${nestedKey}`, nestedValue),
+    getFlattenedTranslationKeys(`${key}.${nestedKey}`, nestedValue),
   );
 }

--- a/packages/sit-onyx/src/i18n/index.ts
+++ b/packages/sit-onyx/src/i18n/index.ts
@@ -181,13 +181,17 @@ const replacePlaceholders = (
 ): string => {
   if (!placeholders) return message;
 
-  const replacedMessage = Object.entries(placeholders).reduce((replacedMessage, [key, value]) => {
+  let replacedMessage = Object.entries(placeholders).reduce((replacedMessage, [key, value]) => {
     if (value === undefined) return replacedMessage;
     // "gi" is used to replace all occurrences because String.replaceAll() is not available
     // in our specified EcmaScript target
     return replacedMessage.replace(new RegExp(`{${key}}`, "gi"), value.toString());
   }, message);
 
+  // replace string literals, e.g. replace {'@'} with @
+  // see: https://vue-i18n.intlify.dev/guide/essentials/syntax#special-characters
+  replacedMessage = replacedMessage.replace(/{'(.*?)'}/g, "$1");
+
   // remove all left-over placeholders that have no provided value to align with "vue-i18n"
-  return replacedMessage.replace(/\s?{.*}\s?/gi, "");
+  return replacedMessage.replace(/{.*}\s?/gi, "");
 };

--- a/packages/sit-onyx/src/i18n/locales/de-DE.json
+++ b/packages/sit-onyx/src/i18n/locales/de-DE.json
@@ -73,7 +73,7 @@
       },
       "email": {
         "preview": "Ungültige E-Mail",
-        "fullError": "Die Eingabe \"{value}\" ist keine gültige E-Mail Adresse. Sie sollte ähnlich zu \"maxmustermann@beispiel.de\" sein (muss ein @-Symbol und einen Punkt enthalten)."
+        "fullError": "Die Eingabe \"{value}\" ist keine gültige E-Mail Adresse. Sie sollte ähnlich zu \"maxmustermann{'@'}beispiel.de\" sein (muss ein {'@'}-Symbol und einen Punkt enthalten)."
       },
       "number": {
         "preview": "Ungültige Zahl",

--- a/packages/sit-onyx/src/i18n/locales/en-US.json
+++ b/packages/sit-onyx/src/i18n/locales/en-US.json
@@ -73,7 +73,7 @@
       },
       "email": {
         "preview": "Invalid mail",
-        "fullError": "\"{value}\" is not a valid email address. It should be similar to \"johndoe@example.com\" (Must contain one @ symbol and a period)."
+        "fullError": "\"{value}\" is not a valid email address. It should be similar to \"johndoe{'@'}example.com\" (Must contain one {'@'} symbol and a period)."
       },
       "number": {
         "preview": "Invalid number",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       vue-component-type-helpers:
         specifier: ^2.2.2
         version: 2.2.2
+      vue-i18n:
+        specifier: ^11.1.1
+        version: 11.1.1(vue@3.5.13(typescript@5.7.3))
       vue-router:
         specifier: ^4.5.0
         version: 4.5.0(vue@3.5.13(typescript@5.7.3))
@@ -9166,9 +9169,9 @@ snapshots:
       find-package-json: 1.2.0
       magic-string: 0.30.17
       storybook: 8.5.8(prettier@3.5.1)
-      typescript: 5.6.3
+      typescript: 5.7.3
       vite: 6.1.1(@types/node@22.13.4)(jiti@2.4.2)(sass-embedded@1.85.0)(sass@1.83.4)(stylus@0.57.0)(terser@5.38.2)(tsx@4.19.3)(yaml@2.7.0)
-      vue-component-meta: 2.2.2(typescript@5.6.3)
+      vue-component-meta: 2.2.2(typescript@5.7.3)
       vue-docgen-api: 4.79.2(vue@3.5.13(typescript@5.6.3))
     transitivePeerDependencies:
       - vue
@@ -9788,6 +9791,19 @@ snapshots:
       path-browserify: 1.0.1
     optionalDependencies:
       typescript: 5.6.3
+
+  '@vue/language-core@2.2.2(typescript@5.7.3)':
+    dependencies:
+      '@volar/language-core': 2.4.11
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.13
+      alien-signals: 1.0.3
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.7.3
 
   '@vue/reactivity@3.5.13':
     dependencies:
@@ -14464,14 +14480,14 @@ snapshots:
       chart.js: 4.4.8
       vue: 3.5.13(typescript@5.7.3)
 
-  vue-component-meta@2.2.2(typescript@5.6.3):
+  vue-component-meta@2.2.2(typescript@5.7.3):
     dependencies:
       '@volar/typescript': 2.4.11
-      '@vue/language-core': 2.2.2(typescript@5.6.3)
+      '@vue/language-core': 2.2.2(typescript@5.7.3)
       path-browserify: 1.0.1
       vue-component-type-helpers: 2.2.2
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.3
 
   vue-component-type-helpers@2.2.2: {}
 


### PR DESCRIPTION
Currently the `<OnyxInput type="email" />` will crash/throw an error if the error message is shown when used inside Nuxt.
This is caused because in our Nuxt module, the `t` function from vue-i18n is used instead of our onyx t function.
Because in vue-i18n, some characters needs to be escaped (like `@`).

I updated the onyx i18n implementation to escape those characters and also added unit tests to ensure that all onyx messages can be compiled without errors with vue-i18n

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
