### PR TITLE
chore: update issue templates to use type field

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.yml
@@ -1,8 +1,7 @@
 name: Report a bug 🐞
 description: You found a bug in onyx? You can report it with the form below.
 title: "[Bug]: "
-labels:
-  - bug
+type: Bug
 
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/02-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature_request.yml
@@ -3,6 +3,7 @@ description: >-
   Do you want to request a new feature to be added to onyx? You can request it
   with the form below.
 title: "[Feature request]: "
+type: Feature
 labels:
   - enhancement
 


### PR DESCRIPTION
We switched from labels to the new `type` field for bugs.