### PR TITLE
fix(OnyxAccordionItem): fix open indicator displaying parent state instead of their own

### DIFF
--- a/.changeset/cold-pugs-push.md
+++ b/.changeset/cold-pugs-push.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxAccordionItem): fix open indicator displaying parent state instead of their own

--- a/packages/sit-onyx/src/components/OnyxAccordionItem/OnyxAccordionItem.vue
+++ b/packages/sit-onyx/src/components/OnyxAccordionItem/OnyxAccordionItem.vue
@@ -152,7 +152,7 @@ const panelId = computed(() => `panel-${props.value.toString()}`);
       transition: transform var(--onyx-accordion-toggle-duration) ease;
     }
 
-    &[open] &__header-icon {
+    &[open] > &__header &__header-icon {
       transform: rotate(180deg);
     }
 


### PR DESCRIPTION
Closes #2919 