### PR TITLE
feat(OnyxDataGrid): support column type `date`, `datetime-local`, `time` and `timestamp`

### DIFF
--- a/.changeset/great-cameras-give.md
+++ b/.changeset/great-cameras-give.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxDataGrid): support column type `date`, `datetime`, `time` and `timestamp`

--- a/.changeset/great-cameras-give.md
+++ b/.changeset/great-cameras-give.md
@@ -2,11 +2,11 @@
 "sit-onyx": minor
 ---
 
-feat(OnyxDataGrid): support column type `date`, `datetime`, `time` and `timestamp`
+feat(OnyxDataGrid): support column type `date`, `datetime-local`, `time` and `timestamp`
 
-| Type      | Example output              |
-| --------- | --------------------------- |
-| date      | Mar 11, 2025                |
-| datetime  | Mar 11, 2025, 9:51 AM       |
-| time      | 9:51 AM                     |
-| timestamp | 03/11/2025, 09:51:27 AM GMT |
+| Type           | Example output              |
+| -------------- | --------------------------- |
+| date           | Mar 11, 2025                |
+| datetime-local | Mar 11, 2025, 9:51 AM       |
+| time           | 9:51 AM                     |
+| timestamp      | 03/11/2025, 09:51:27 AM GMT |

--- a/.changeset/great-cameras-give.md
+++ b/.changeset/great-cameras-give.md
@@ -3,3 +3,10 @@
 ---
 
 feat(OnyxDataGrid): support column type `date`, `datetime`, `time` and `timestamp`
+
+| Type      | Example output              |
+| --------- | --------------------------- |
+| date      | Mar 11, 2025                |
+| datetime  | Mar 11, 2025, 9:51 AM       |
+| time      | 9:51 AM                     |
+| timestamp | 03/11/2025, 09:51:27 AM GMT |

--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/CustomFeatureExample.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/CustomFeatureExample.vue
@@ -31,7 +31,7 @@ const data: TEntry[] = [
 const columns: ColumnConfig<TEntry, ColumnGroupConfig, never>[] = [
   { key: "name", label: "Name" },
   { key: "age", label: "Age", type: "number" },
-  { key: "birthday", label: "Birthday" },
+  { key: "birthday", label: "Birthday", type: "date" },
 ];
 
 // create a custom reusable data grid feature that you can also e.g. share / re-use in your project

--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/DefaultExample.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/DefaultExample.vue
@@ -19,7 +19,7 @@ const data: TEntry[] = [
 const columns: ColumnConfig<TEntry, ColumnGroupConfig, never>[] = [
   { key: "name", label: "Name" },
   { key: "age", label: "Age", type: "number" },
-  { key: "birthday", label: "Birthday" },
+  { key: "birthday", label: "Birthday", type: "timestamp" },
 ];
 </script>
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/DefaultExample.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/DefaultExample.vue
@@ -19,7 +19,7 @@ const data: TEntry[] = [
 const columns: ColumnConfig<TEntry, ColumnGroupConfig, never>[] = [
   { key: "name", label: "Name" },
   { key: "age", label: "Age", type: "number" },
-  { key: "birthday", label: "Birthday", type: "timestamp" },
+  { key: "birthday", label: "Birthday", type: "date" },
 ];
 </script>
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/FilteringExample.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/FilteringExample.vue
@@ -24,7 +24,7 @@ const data: TEntry[] = [
 const columns: ColumnConfig<TEntry, ColumnGroupConfig, never>[] = [
   { key: "name", label: "Name" },
   { key: "age", label: "Age" },
-  { key: "birthday", label: "Birthday" },
+  { key: "birthday", label: "Birthday", type: "date" },
 ];
 
 const withFiltering = DataGridFeatures.useFiltering<TEntry>({

--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/SelectionExample.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/SelectionExample.vue
@@ -25,7 +25,7 @@ const data: TEntry[] = [
 const columns: ColumnConfig<TEntry, ColumnGroupConfig, never>[] = [
   { key: "name", label: "Name" },
   { key: "age", label: "Rank" },
-  { key: "birthday", label: "Birthday" },
+  { key: "birthday", label: "Birthday", type: "date" },
 ];
 
 const selectionState = ref<DataGridFeatures.SelectionState>({

--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/SortingExample.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/SortingExample.vue
@@ -25,7 +25,7 @@ const data: TEntry[] = [
 const columns: ColumnConfig<TEntry, ColumnGroupConfig, never>[] = [
   { key: "name", label: "Name" },
   { key: "age", label: "Rank" },
-  { key: "birthday", label: "Birthday" },
+  { key: "birthday", label: "Birthday", type: "date" },
 ];
 
 const sortState = ref<DataGridFeatures.SortState<TEntry>>({

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
@@ -57,7 +57,13 @@ export type ColumnConfig<
   TTypes,
 > = keyof TEntry | PublicNormalizedColumnConfig<TEntry, TColumnGroup, TTypes>;
 
-export type DefaultSupportedTypes = "string" | "number";
+export type DefaultSupportedTypes =
+  | "string"
+  | "number"
+  | "date"
+  | "datetime"
+  | "time"
+  | "timestamp";
 
 /**
  * Configuration for the column groupings.

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
@@ -61,7 +61,7 @@ export type DefaultSupportedTypes =
   | "string"
   | "number"
   | "date"
-  | "datetime"
+  | "datetime-local"
   | "time"
   | "timestamp";
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.ts
@@ -47,7 +47,7 @@ const stringFormatter = <TEntry extends DataGridEntry>(
 
 const dateFormatter = <TEntry extends DataGridEntry>(
   value: TEntry[keyof TEntry] | undefined,
-  type: "date" | "datetime" | "time" | "timestamp",
+  type: "date" | "datetime-local" | "time" | "timestamp",
 ): string => {
   // using loose "==" here to catch both undefined and null
   if (value == undefined || typeof value === "boolean") return FALLBACK_RENDER_VALUE;
@@ -56,7 +56,7 @@ const dateFormatter = <TEntry extends DataGridEntry>(
 
   const formatterOptions = {
     date: { dateStyle: "medium" },
-    datetime: { dateStyle: "medium", timeStyle: "short" },
+    "datetime-local": { dateStyle: "medium", timeStyle: "short" },
     time: { timeStyle: "short" },
     timestamp: {
       year: "numeric",
@@ -97,7 +97,7 @@ const DATE_RENDERER = Object.freeze({
 
 const DATETIME_RENDERER = Object.freeze({
   header: { component: HeaderCell },
-  cell: { component: (props) => dateFormatter(props.modelValue, "datetime") },
+  cell: { component: (props) => dateFormatter(props.modelValue, "datetime-local") },
 }) satisfies TypeRenderer<DataGridEntry>;
 
 const TIME_RENDERER = Object.freeze({
@@ -114,7 +114,7 @@ const BASE_RENDERER_MAP = Object.freeze({
   number: NUMBER_RENDERER,
   string: STRING_RENDERER,
   date: DATE_RENDERER,
-  datetime: DATETIME_RENDERER,
+  "datetime-local": DATETIME_RENDERER,
   time: TIME_RENDERER,
   timestamp: TIMESTAMP_RENDERER,
 }) satisfies Record<DefaultSupportedTypes, TypeRenderer<DataGridEntry>>;

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.ts
@@ -47,12 +47,10 @@ const stringFormatter = <TEntry extends DataGridEntry>(
 
 const dateFormatter = <TEntry extends DataGridEntry>(
   value: TEntry[keyof TEntry] | undefined,
-  type: "date" | "datetime-local" | "time" | "timestamp",
+  type: Extract<DefaultSupportedTypes, "date" | "datetime-local" | "time" | "timestamp">,
 ): string => {
   // using loose "==" here to catch both undefined and null
   if (value == undefined || typeof value === "boolean") return FALLBACK_RENDER_VALUE;
-
-  const locale = injectI18n().locale;
 
   const formatterOptions = {
     date: { dateStyle: "medium" },
@@ -68,6 +66,8 @@ const dateFormatter = <TEntry extends DataGridEntry>(
       timeZoneName: "shortOffset",
     },
   } satisfies Record<typeof type, Intl.DateTimeFormatOptions>;
+
+  const locale = injectI18n().locale;
   const formatter = new Intl.DateTimeFormat(locale.value, formatterOptions[type]);
 
   try {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/renderers.spec.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/renderers.spec.ts
@@ -60,16 +60,16 @@ describe("renderers", () => {
    * Test cases for date type renderers. Key = type, value = expected output.
    */
   const DATE_TEST_CASES = {
-    date: "Apr 11, 2025",
-    datetime: "Apr 11, 2025, 3:42 PM",
-    time: "3:42 PM",
-    timestamp: "04/11/2025, 03:42:27 PM GMT",
+    date: "Mar 11, 2025",
+    datetime: "Mar 11, 2025, 9:51 AM",
+    time: "9:51 AM",
+    timestamp: "03/11/2025, 09:51:27 AM GMT",
   } as const satisfies Partial<Record<DefaultSupportedTypes, string>>;
 
   for (const type in DATE_TEST_CASES) {
     const rendererType = type as keyof typeof DATE_TEST_CASES;
     const expected = DATE_TEST_CASES[rendererType];
-    const value = new Date(2025, 3, 11, 15, 42, 27);
+    const value = new Date(2025, 2, 11, 9, 51, 27);
 
     test.each([
       // positive cases:

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/renderers.spec.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/renderers.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
-import { ref, type FunctionalComponent } from "vue";
+import { ref } from "vue";
+import type { DefaultSupportedTypes } from ".";
 import { createRenderer, FALLBACK_RENDER_VALUE } from "./renderer";
 
 vi.mock("../../../i18n", () => ({
@@ -26,17 +27,9 @@ describe("renderers", () => {
   ])(
     "should format cell value $value to $expected with string and fallback renderer",
     ({ value, expected }) => {
-      // ARRANGE
-      const { getFor } = createRenderer([]);
-
-      const props = [
-        { modelValue: value, row: { id: 1 } },
-        { attrs: {}, slots: {}, emit: () => ({}) },
-      ] satisfies Parameters<FunctionalComponent>;
-
       // ACT
-      const fallbackActual = getFor("cell").component(...props);
-      const stringActual = getFor("cell", "string").component(...props);
+      const fallbackActual = getRendererCellValue(value);
+      const stringActual = getRendererCellValue(value, "string");
 
       // ASSERT
       expect(fallbackActual).toBe(expected);
@@ -59,16 +52,98 @@ describe("renderers", () => {
     { value: new Date(), expected: FALLBACK_RENDER_VALUE },
     { value: Symbol("test-symbol"), expected: FALLBACK_RENDER_VALUE },
   ])("should format cell value $value to $expected with number renderer", ({ value, expected }) => {
-    // ARRANGE
-    const { getFor } = createRenderer([]);
-
     // ACT
-    const actual = getFor("cell", "number").component(
-      { modelValue: value, row: { id: 1 } },
-      { attrs: {}, slots: {}, emit: () => ({}) },
-    );
+    const actual = getRendererCellValue(value, "number");
 
     // ASSERT
     expect(actual).toBe(expected);
   });
+
+  const DATE_INVALID_TEST_CASES = [
+    { value: new Date("invalid-date"), expected: FALLBACK_RENDER_VALUE },
+    { value: NaN, expected: FALLBACK_RENDER_VALUE },
+    { value: undefined, expected: FALLBACK_RENDER_VALUE },
+    { value: null, expected: FALLBACK_RENDER_VALUE },
+    { value: "definitely-no-number", expected: FALLBACK_RENDER_VALUE },
+    { value: true, expected: FALLBACK_RENDER_VALUE },
+    { value: false, expected: FALLBACK_RENDER_VALUE },
+    { value: { foo: 42 }, expected: FALLBACK_RENDER_VALUE },
+    { value: ["foo", "bar"], expected: FALLBACK_RENDER_VALUE },
+    { value: Symbol("test-symbol"), expected: FALLBACK_RENDER_VALUE },
+  ];
+
+  test.each([
+    { value: new Date(2025, 3, 11), expected: "Apr 11, 2025" },
+    { value: new Date(2025, 3, 11).toISOString(), expected: "Apr 11, 2025" },
+    { value: new Date(2025, 3, 11).getTime(), expected: "Apr 11, 2025" },
+    { value: BigInt(new Date(2025, 3, 11).getTime()), expected: "Apr 11, 2025" },
+    ...DATE_INVALID_TEST_CASES,
+  ])("should format cell value $value to $expected with date renderer", ({ value, expected }) => {
+    // ACT
+    const actual = getRendererCellValue(value, "date");
+
+    // ASSERT
+    expect(actual).toBe(expected);
+  });
+
+  test.each([
+    { value: new Date(2025, 3, 11, 15, 42), expected: "Apr 11, 2025, 3:42 PM" },
+    { value: new Date(2025, 3, 11, 15, 42).toISOString(), expected: "Apr 11, 2025, 3:42 PM" },
+    { value: new Date(2025, 3, 11, 15, 42).getTime(), expected: "Apr 11, 2025, 3:42 PM" },
+    { value: BigInt(new Date(2025, 3, 11, 15, 42).getTime()), expected: "Apr 11, 2025, 3:42 PM" },
+    ...DATE_INVALID_TEST_CASES,
+  ])(
+    "should format cell value $value to $expected with datetime renderer",
+    ({ value, expected }) => {
+      // ACT
+      const actual = getRendererCellValue(value, "datetime");
+
+      // ASSERT
+      expect(actual).toBe(expected);
+    },
+  );
+
+  test.each([
+    { value: new Date(2025, 3, 11, 15, 42), expected: "3:42 PM" },
+    { value: new Date(2025, 3, 11, 15, 42).toISOString(), expected: "3:42 PM" },
+    { value: new Date(2025, 3, 11, 15, 42).getTime(), expected: "3:42 PM" },
+    { value: BigInt(new Date(2025, 3, 11, 15, 42).getTime()), expected: "3:42 PM" },
+    ...DATE_INVALID_TEST_CASES,
+  ])("should format cell value $value to $expected with time renderer", ({ value, expected }) => {
+    // ACT
+    const actual = getRendererCellValue(value, "time");
+
+    // ASSERT
+    expect(actual).toBe(expected);
+  });
+
+  test.each([
+    { value: new Date(2025, 3, 11, 15, 42, 27), expected: "04/11/2025, 03:42:27 PM GMT" },
+    {
+      value: new Date(2025, 3, 11, 15, 42, 27).toISOString(),
+      expected: "04/11/2025, 03:42:27 PM GMT",
+    },
+    { value: new Date(2025, 3, 11, 15, 42, 27).getTime(), expected: "04/11/2025, 03:42:27 PM GMT" },
+    {
+      value: BigInt(new Date(2025, 3, 11, 15, 42, 27).getTime()),
+      expected: "04/11/2025, 03:42:27 PM GMT",
+    },
+    ...DATE_INVALID_TEST_CASES,
+  ])(
+    "should format cell value $value to $expected with timestamp renderer",
+    ({ value, expected }) => {
+      // ACT
+      const actual = getRendererCellValue(value, "timestamp");
+
+      // ASSERT
+      expect(actual).toBe(expected);
+    },
+  );
 });
+
+function getRendererCellValue(value: unknown, type?: DefaultSupportedTypes) {
+  const renderer = createRenderer([]);
+  return renderer
+    .getFor("cell", type)
+    .component({ modelValue: value, row: { id: 1 } }, { attrs: {}, slots: {}, emit: () => ({}) });
+}

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/renderers.spec.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/renderers.spec.ts
@@ -61,7 +61,7 @@ describe("renderers", () => {
    */
   const DATE_TEST_CASES = {
     date: "Mar 11, 2025",
-    datetime: "Mar 11, 2025, 9:51 AM",
+    "datetime-local": "Mar 11, 2025, 9:51 AM",
     time: "9:51 AM",
     timestamp: "03/11/2025, 09:51:27 AM GMT",
   } as const satisfies Partial<Record<DefaultSupportedTypes, string>>;


### PR DESCRIPTION
Relates to #2815

Support new default supported data grid column types:

| Type      | Example output              |
| --------- | --------------------------- |
| date      | Mar 11, 2025                |
| datetime  | Mar 11, 2025, 9:51 AM       |
| time      | 9:51 AM                     |
| timestamp | 03/11/2025, 09:51:27 AM GMT |


## Checklist

<!-- If bullet points below do not apply to your changes (e.g. no documentation needed), just remove it. -->

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) or functional test is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
