### PR TITLE
fix(OnyxFlyoutMenu): fix max-height and scrollable behavior for OnyxFlyoutMenu

### DIFF
--- a/.changeset/rude-bikes-strive.md
+++ b/.changeset/rude-bikes-strive.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxFlyoutMenu, OnyxUserMenu): fix unlimited height and scroll-behavior

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.ct.tsx
@@ -110,6 +110,10 @@ test("should display correctly and allow scrolling for many options", async ({ p
 
   // ACT
   await component.click();
+  // Only in Firefox and in the test: There is a weird bug where the menu doesn't initially have the correct height
+  // TODO: check if this "fix" is still necessary in later versions
+  await component.click();
+  await component.click();
 
   // ASSERT
   await expect(menu).toBeInViewport();

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.ct.tsx
@@ -1,6 +1,7 @@
 import { menuButtonTesting } from "@sit-onyx/headless/playwright";
 import { expect, test } from "../../../../playwright/a11y";
 import TestWrapperCt from "./TestWrapper.ct.vue";
+import TestWrapperManyCt from "./TestWrapperMany.ct.vue";
 
 test("check accessibility", async ({ page, mount, makeAxeBuilder }) => {
   await mount(TestWrapperCt, {
@@ -64,4 +65,64 @@ test("should open on click", async ({ page, mount }) => {
   for (const item of await menuItems.all()) {
     await expect(item).toBeEnabled();
   }
+});
+
+test("should open on hover", async ({ page, mount }) => {
+  // ARRANGE
+  const component = await mount(TestWrapperCt, {
+    props: { label: "Choose application language", trigger: "hover" },
+  });
+  const menu = page.locator("ul");
+
+  // ASSERT
+  await expect(menu).toBeHidden();
+
+  // ACT
+  await component.hover();
+
+  // ASSERT
+  await expect(menu).toBeVisible();
+
+  // ACT
+  await component.click();
+
+  // ASSERT
+  await expect(menu).toBeVisible();
+
+  // ACT
+  await page.locator("body").hover();
+
+  // ASSERT
+  await expect(menu).toBeHidden();
+});
+
+test("should display correctly and allow scrolling for many options", async ({ page, mount }) => {
+  // ARRANGE
+  const component = await mount(TestWrapperManyCt);
+  const menu = page.locator("ul");
+  const footer = page.getByTestId("footer-content");
+  const header = page.getByTestId("header-content");
+
+  // ASSERT
+  await expect(menu).toBeHidden();
+  await expect(footer).toBeHidden();
+  await expect(header).toBeHidden();
+
+  // ACT
+  await component.click();
+
+  // ASSERT
+  await expect(menu).toBeInViewport();
+  await expect(footer).toBeInViewport();
+  await expect(header).toBeInViewport();
+  await expect(menu.getByRole("menuitem", { name: "Option 8" })).toBeInViewport();
+  await expect(menu.getByRole("menuitem", { name: "Option 9" })).not.toBeInViewport();
+
+  // ACT
+  await menu.getByRole("menuitem", { name: "Option 10" }).scrollIntoViewIfNeeded();
+
+  // ASSERT
+  await expect(menu.getByRole("menuitem", { name: "Option 10" })).toBeInViewport();
+  await expect(footer).toBeInViewport();
+  await expect(header).toBeInViewport();
 });

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.ct.tsx
@@ -72,7 +72,7 @@ test("should open on hover", async ({ page, mount }) => {
   const component = await mount(TestWrapperCt, {
     props: { label: "Choose application language", trigger: "hover" },
   });
-  const menu = page.locator("ul");
+  const menu = page.getByLabel("Choose application language");
 
   // ASSERT
   await expect(menu).toBeHidden();

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
@@ -120,8 +120,14 @@ const {
 
     &__wrapper {
       padding: 0;
-      /** 8 * OnyxListItem, where OnyxListItem => 2 * padding + line-height of OnyxListItem */
-      max-height: calc(8 * (2 * var(--onyx-density-xs) + 1.5rem));
+      /**
+       * The last option should only be half visible:
+       * 7.5 * OnyxListItem, where OnyxListItem => 2 * padding + line-height of OnyxListItem 
+       */
+      max-height: calc(
+        (var(--onyx-flyout-menu-visible-item-count, 7) + 0.5) *
+          (2 * var(--onyx-density-xs) + 1.5rem)
+      );
       overflow: scroll;
     }
   }

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
@@ -56,6 +56,7 @@ const {
       :aria-label="props.label"
       class="onyx-flyout-menu__list"
     >
+      <!-- We always want to render the header so that we can render the padding here -->
       <div class="onyx-flyout-menu__list-header">
         <slot name="header"></slot>
       </div>
@@ -68,6 +69,7 @@ const {
         <slot name="options"></slot>
       </ul>
 
+      <!-- We always want to render the footer so that we can render the padding here -->
       <div class="onyx-flyout-menu__list-footer">
         <slot name="footer"></slot>
       </div>
@@ -102,19 +104,13 @@ const {
       &-header {
         position: sticky;
         top: 0;
-
-        &:empty {
-          padding-top: var(--onyx-spacing-2xs);
-        }
+        min-height: var(--onyx-spacing-2xs);
       }
 
       &-footer {
         position: sticky;
         bottom: 0;
-
-        &:empty {
-          padding-bottom: var(--onyx-spacing-2xs);
-        }
+        min-height: var(--onyx-spacing-2xs);
       }
     }
 
@@ -125,8 +121,7 @@ const {
        * 7.5 * OnyxListItem, where OnyxListItem => 2 * padding + line-height of OnyxListItem 
        */
       max-height: calc(
-        (var(--onyx-flyout-menu-visible-item-count, 7) + 0.5) *
-          (2 * var(--onyx-density-xs) + 1.5rem)
+        (var(--onyx-flyout-menu-visible-item-count, 7) + 0.5) * (2 * var(--onyx-density-xs) + 1lh)
       );
       overflow: scroll;
     }

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
@@ -54,13 +54,11 @@ const {
     <div
       v-if="(slots.options || slots.header || slots.footer) && isExpanded"
       :aria-label="props.label"
-      :class="{
-        'onyx-flyout-menu__list--with-header': !!slots.header,
-        'onyx-flyout-menu__list--with-footer': !!slots.footer,
-        'onyx-flyout-menu__list': true,
-      }"
+      class="onyx-flyout-menu__list"
     >
-      <slot name="header"></slot>
+      <div class="onyx-flyout-menu__list-header">
+        <slot name="header"></slot>
+      </div>
 
       <ul
         v-if="slots.options"
@@ -70,7 +68,9 @@ const {
         <slot name="options"></slot>
       </ul>
 
-      <slot name="footer"></slot>
+      <div class="onyx-flyout-menu__list-footer">
+        <slot name="footer"></slot>
+      </div>
     </div>
   </div>
 </template>
@@ -90,7 +90,7 @@ const {
       top: calc(100% + var(--onyx-flyout-menu-gap));
       border-radius: var(--onyx-radius-md);
       background-color: var(--onyx-color-base-background-blank);
-      padding: var(--onyx-spacing-2xs) 0;
+      padding: 0;
       box-shadow: var(--onyx-shadow-medium-bottom);
       box-sizing: border-box;
       width: max-content;
@@ -99,17 +99,30 @@ const {
       font-family: var(--onyx-font-family);
       z-index: var(--onyx-z-index-flyout);
 
-      &--with-header {
-        padding-top: 0;
+      &-header {
+        position: sticky;
+        top: 0;
+
+        &:empty {
+          padding-top: var(--onyx-spacing-2xs);
+        }
       }
 
-      &--with-footer {
-        padding-bottom: 0;
+      &-footer {
+        position: sticky;
+        bottom: 0;
+
+        &:empty {
+          padding-bottom: var(--onyx-spacing-2xs);
+        }
       }
     }
 
     &__wrapper {
       padding: 0;
+      /** 8 * OnyxListItem, where OnyxListItem => 2 * padding + line-height of OnyxListItem */
+      max-height: calc(8 * (2 * var(--onyx-density-xs) + 1.5rem));
+      overflow: scroll;
     }
   }
 }

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/TestWrapperMany.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/TestWrapperMany.ct.vue
@@ -1,0 +1,22 @@
+<!-- Currently slot props are not supported by Playwright, so we need to provide a custom wrapper. See issue: https://github.com/microsoft/playwright/issues/18758 -->
+<script lang="ts" setup>
+import OnyxMenuItem from "../OnyxMenuItem/OnyxMenuItem.vue";
+import OnyxFlyoutMenu from "./OnyxFlyoutMenu.vue";
+</script>
+
+<template>
+  <OnyxFlyoutMenu label="test" trigger="click">
+    <template #button="{ trigger }">
+      <button type="button" v-bind="trigger">button label</button>
+    </template>
+    <template #header>
+      <div data-testid="header-content">header-content</div>
+    </template>
+    <template #footer>
+      <div data-testid="footer-content">footer-content</div>
+    </template>
+    <template #options>
+      <OnyxMenuItem v-for="i in 10" :key="i">Option {{ i }}</OnyxMenuItem>
+    </template>
+  </OnyxFlyoutMenu>
+</template>


### PR DESCRIPTION
Relates to #2890 

- Limites the mumber of visible menu items in the `OnyxFlyoutMenu` to 8, as defined in Figma.
  - added tests for this behavior
- added test for hover behavior 

