### PR TITLE
feat(nuxt): re-enable cssnano calc after dependency was fixed

### DIFF
--- a/.changeset/shy-feet-smell.md
+++ b/.changeset/shy-feet-smell.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt": patch
+---
+
+Re-enable cssnano extension "calc" to optimize css calc expressions during build. This had to be disabled until now because of a bug in the extension. (See: https://github.com/postcss/postcss-calc/issues/210)

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -48,13 +48,6 @@ export default defineNuxtModule<ModuleOptions>({
     const logger = useLogger("@sit-onyx/nuxt");
     const { resolve } = createResolver(import.meta.url);
 
-    /**
-     * The calc plugin of cssnano doesn't work with calc constants (https://developer.mozilla.org/en-US/docs/Web/CSS/calc-constant) used within onyx.
-     * Therefor it needs to be disabled temporarily until they are either no longer used inside onyx or the calc plugin is fixed.
-     * An issue was raised for inside the calc plugin: https://github.com/postcss/postcss-calc/issues/210
-     */
-    nuxt.options.postcss.plugins.cssnano = { preset: ["default", { calc: false }] };
-
     nuxt.options.css.push("sit-onyx/style.css");
 
     if (options.theme !== "onyx") {


### PR DESCRIPTION
<!-- Briefly describe the changes of this PR. -->
In the beginning we had to add a little workaround to the nuxt module as one of the underlying dependencies for css bundling had a bug. This bug was fixed here: https://github.com/postcss/postcss-calc/issues/210 and the update by now made it into the current version of nuxt so we can safely remove the workaround.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
