### PR TITLE
fix(OnyxSelect): accept `:multiple="false"` without type errors

### DIFF
--- a/.changeset/real-garlics-return.md
+++ b/.changeset/real-garlics-return.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxSelect): accept `:multiple="false"` without type errors

--- a/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
+++ b/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
@@ -3,7 +3,7 @@
   setup
   generic="
     TModelValue extends SelectOptionValue | SelectOptionValue[],
-    TMultiple extends TModelValue extends any[] ? true : undefined,
+    TMultiple extends TModelValue extends any[] ? true : false | undefined,
     TValue extends TModelValue extends (infer TInner)[] ? TInner : TModelValue
   "
 >


### PR DESCRIPTION
Currently when passing `<OnyxSelect :multiple="false" />` a type error is throwns because only true and undefined are accepted.

![image](https://github.com/user-attachments/assets/65e9b753-87e9-479d-a8cb-0ae6b380ba6d)


## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
