### PR TITLE
internal: update `mergeVueProps` to support merging of vnode refs

### DIFF
--- a/packages/sit-onyx/src/utils/attrs.spec.ts
+++ b/packages/sit-onyx/src/utils/attrs.spec.ts
@@ -66,4 +66,19 @@ describe("mergeVueProps", () => {
     const result = mergeVueProps(...args);
     expect(result).toMatchObject(expected);
   });
+
+  test("should be able to merge refs", async () => {
+    const newValue = "new-value";
+    const ref1 = vue.ref();
+    const ref2 = vue.ref();
+    const fnRef = vi.fn();
+    const result = mergeVueProps({}, { ref: ref1 }, { ref: ref2 }, {}, { ref: fnRef }, {});
+
+    const targetRef = result.ref as vue.Ref;
+    targetRef.value = newValue;
+    expect(targetRef.value).toBe(newValue);
+    expect(ref1.value).toBe(newValue);
+    expect(ref2.value).toBe(newValue);
+    expect(fnRef).toHaveBeenCalledWith(newValue, []);
+  });
 });

--- a/packages/sit-onyx/src/utils/attrs.ts
+++ b/packages/sit-onyx/src/utils/attrs.ts
@@ -1,4 +1,14 @@
-import { computed, mergeProps, useAttrs, type HTMLAttributes } from "vue";
+import {
+  computed,
+  mergeProps,
+  ref,
+  useAttrs,
+  watch,
+  type HTMLAttributes,
+  type Ref,
+  type VNodeProps,
+  type VNodeRef,
+} from "vue";
 
 // region docs
 /**
@@ -51,8 +61,81 @@ export const useRootAttrs = <T extends HTMLAttributes = HTMLAttributes>() => {
   };
 };
 
+const MERGED_REFS_SYMBOL = Symbol("MERGED_REFS");
+
+type MergedRef = Ref & {
+  /**
+   * In this array we store the refs that we want to keep in sync.
+   */
+  [MERGED_REFS_SYMBOL]: VNodeRef[];
+};
+
 /**
- * Extends the Vue's `mergeProp` functionality and typing to be easier to work with.
+ * Creates a new `ref` that syncs the `toMerge` refs uni-directional.
+ * Only intended to be used for template/vnode refs.
  */
-export const mergeVueProps = <T extends object | null | undefined>(...args: T[]) =>
-  mergeProps(...args.map((e) => e ?? {})) as NonNullable<T>;
+const createMergedRef = (...toMerge: VNodeRef[]) => {
+  const _ref = ref() as MergedRef;
+  _ref[MERGED_REFS_SYMBOL] = toMerge ?? [];
+
+  watch(
+    _ref,
+    (newValue) =>
+      _ref[MERGED_REFS_SYMBOL].forEach((r) => {
+        switch (typeof r) {
+          case "function":
+            r(newValue, []);
+            break;
+          case "object":
+            r.value = newValue;
+            break;
+          default:
+            import.meta.env.DEV &&
+              // eslint-disable-next-line no-console -- show console error in dev mode
+              console.error(
+                `Template Ref of type "${typeof r}" is not supported and cannot be merged!`,
+              );
+        }
+      }),
+    {
+      // we want to update the merged refs immediately when the proxy ref is updated
+      // so that their effect can be applied in the current tick
+      flush: "sync",
+    },
+  );
+  return _ref;
+};
+
+const isMergedRef = (_ref: unknown): _ref is MergedRef =>
+  !!_ref && typeof _ref === "object" && MERGED_REFS_SYMBOL in _ref;
+
+type VProps = object & VNodeProps;
+
+/**
+ * Extends the Vue's `mergeProp` function, so that it
+ *   - doesn't complain about nullish parameters
+ *   - is also able to merge `ref` properties
+ */
+export const mergeVueProps = <T extends VProps | null | undefined>(...args: T[]) =>
+  args.reduce((prev, curr) => {
+    const merged = mergeProps(prev, (curr ?? {}) as VProps);
+
+    // when there is only a single or no ref defined, we can rely on the default merge logic
+    if (!prev?.ref || !curr?.ref) {
+      return merged;
+    }
+
+    let mergedRef: MergedRef;
+    // use existing merged ref, otherwise create a new one
+    if (isMergedRef(prev?.ref)) {
+      prev.ref[MERGED_REFS_SYMBOL].push(curr?.ref);
+      mergedRef = prev.ref;
+    } else if (isMergedRef(curr?.ref)) {
+      curr.ref[MERGED_REFS_SYMBOL].push(prev?.ref);
+      mergedRef = curr.ref;
+    } else {
+      mergedRef = createMergedRef(prev.ref, curr?.ref);
+    }
+    merged.ref = mergedRef;
+    return merged;
+  }, {} as VProps) as NonNullable<T>;


### PR DESCRIPTION
This addresses the issue of refs to from an element being needed by multiple `v-bind` attributes sources.
The default `mergeProps` behaviour will just overwrite the `ref` if it is defined multiple times.
This also the case when using `ref` on a an elment and a ref defined via v-bind: [Playground example](https://play.vuejs.org/#eNp9UrFuwjAU/BXLCyDRMLQTDUhtxdAObUU7egnhJYQ6tmW/BKQo/95np0mDhNjsu3v37mQ3/MmYqK6AL3nsUlsYZA6wMmuhitJoi6xhpwTTwybLIEXWsszqkk1oZPI40ljILjihhEq1csgQSiMThC0pVl43nfXUrlD7K3CCaB2BwXU5qFrvOcoync7Yas38jJYQSZ1PR7uiOpEVzPvp7jqjHfGi60kN6dJP0I2xuFCmQr91JfjIS3BW33kjgkM4AhbreGfD1Ei4ZE1zUbhtWS/7CxIkQ6WejhejIHzO0VGtrMijo9OK3qbxDoKnujSFBPthsKDagpObZzyXSKlPbwFDS817PD1A+nMFP7qzxwT/tODA1iD4wGFic8CO3ny9w5nOA1nqfSVJfYPcAj1J5TN2sudK7Sn2SBfSvobfU6j8223OCMr1pXxQr2yDXnD6US83qv/HvY8ewpxQLW9/AfZG+Gc=)