### PR TITLE
refactor(OnyxDataGrid): align enabled options for useResizing

### DIFF
--- a/.changeset/lazy-pianos-flash.md
+++ b/.changeset/lazy-pianos-flash.md
@@ -3,3 +3,24 @@
 ---
 
 refactor(OnyxDataGrid): align enabled options for useResizing
+
+The options for enabling the `useResizing` feature of the OnyxDataGrid has been changed to be aligned with all other features.
+Also if no options are passed, the feature is now enabled for all columns instead of being disabled.
+
+**Old**:
+
+```ts
+
+```
+
+**New**:
+
+```ts
+const withResizing = DataGridFeatures.useResizing<TEntry>({
+  columns: {
+    age: {
+      enabled: false,
+    },
+  },
+});
+```

--- a/.changeset/lazy-pianos-flash.md
+++ b/.changeset/lazy-pianos-flash.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": major
+---
+
+refactor(OnyxDataGrid): align enabled options for useResizing

--- a/.changeset/lazy-pianos-flash.md
+++ b/.changeset/lazy-pianos-flash.md
@@ -10,7 +10,10 @@ Also if no options are passed, the feature is now enabled for all columns instea
 **Old**:
 
 ```ts
-
+const withResizing = DataGridFeatures.useResizing<TEntry>({
+  columnResizing: true,
+  disabledColumns: ["age"],
+});
 ```
 
 **New**:

--- a/apps/demo-app/src/views/DataGridView.vue
+++ b/apps/demo-app/src/views/DataGridView.vue
@@ -34,6 +34,7 @@ const enabledFeatures = ref({
   moreActions: false,
   hideColumns: false,
   stickyColumns: false,
+  resize: false,
 });
 
 const data: Entry[] = [
@@ -141,6 +142,9 @@ const dataFeatures = computed(() => {
   }
   if (enabledFeatures.value.stickyColumns) {
     enabled.push(DataGridFeatures.useStickyColumns<Entry>({ columns: ["name"] }));
+  }
+  if (enabledFeatures.value.resize) {
+    enabled.push(DataGridFeatures.useResizing<Entry>());
   }
   if (enabledFeatures.value.moreActions) {
     enabled.push(dummyFeature());

--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/ResizingExample.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/ResizingExample.vue
@@ -28,9 +28,7 @@ const columns: ColumnConfig<TEntry, ColumnGroupConfig, never>[] = [
   { key: "birthday", label: "Birthday", type: "date" },
 ];
 
-const withResizing = DataGridFeatures.useResizing<TEntry>({
-  columnResizing: true,
-});
+const withResizing = DataGridFeatures.useResizing<TEntry>();
 
 const features = [withResizing];
 </script>

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/resizing/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/resizing/types.ts
@@ -1,16 +1,12 @@
+import { type DataGridFeatureOptions } from "..";
 import type { DataGridEntry } from "../../types";
+
 /**
  * The configuration options for the resizing feature in the OnyxDataGrid component.
  * Includes settings for the individual columns and general resizing behavior.
  */
-export type ResizingOptions<TEntry extends DataGridEntry> = {
-  /**
-   * Defines the columns for which the resizing behavior is disabled.
-   */
-  disabledColumns?: (keyof TEntry)[];
-  /**
-   * Whether column resizing is enabled. This setting applies for every column.
-   * If undefined, resizing will be disabled.
-   */
-  columnResizing?: boolean;
-};
+export type ResizingOptions<TEntry extends DataGridEntry> = DataGridFeatureOptions<
+  TEntry,
+  object,
+  object
+>;


### PR DESCRIPTION
Relates to #2502, https://github.com/SchwarzIT/onyx/issues/2502#issuecomment-2732071767

Align the enabled API with all other data grid features

## Checklist

<!-- If bullet points below do not apply to your changes (e.g. no documentation needed), just remove it. -->

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
