### PR TITLE
fix(OnyxColorSchemeMenuItem): fix not opening OnyxColorSchemeDialog on click

### DIFF
--- a/.changeset/silent-bags-sing.md
+++ b/.changeset/silent-bags-sing.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxColorSchemeMenuItem): fix not opening OnyxColorSchemeDialog on click

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/filtering/filtering.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/filtering/filtering.ts
@@ -84,6 +84,7 @@ export const useFiltering = createFeature(
         class: "onyx-filter-search",
         placeholder: t.value(`dataGrid.head.filtering.menu.placeholder`),
         modelValue: inputValue,
+        // TODO: check after https://github.com/SchwarzIT/onyx/issues/2982 is closed -- `autofocus` doesn't have an effect currently
         autofocus: true,
         "onUpdate:modelValue": (value?: string) => {
           inputValue = value || "";

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.ct.tsx
@@ -38,6 +38,12 @@ test("check custom interactivity", async ({ page, mount }) => {
   for (const item of await menuItems.all()) {
     await expect(item).toBeEnabled();
   }
+
+  // ACT
+  await page.getByRole("menuitem", { name: "Appearance" }).click();
+
+  // ASSERT
+  await expect(page.getByRole("dialog", { name: "Change appearance" })).toBeVisible();
 });
 
 test("should open on click", async ({ page, mount }) => {

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
@@ -49,10 +49,10 @@ const {
 <template>
   <div class="onyx-component onyx-flyout-menu" v-bind="root">
     <slot name="button" :trigger="button"></slot>
-
-    <!-- isExpanded is in v-if to ensure autofocus is working -->
+    <!-- `v-show` instead of `v-if` is necessary, so that we can allow (teleported) dialogs to be shown -->
     <div
-      v-if="(slots.options || slots.header || slots.footer) && isExpanded"
+      v-if="slots.options || slots.header || slots.footer"
+      v-show="isExpanded"
       :aria-label="props.label"
       class="onyx-flyout-menu__list"
     >

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/TestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/TestWrapper.ct.vue
@@ -1,5 +1,6 @@
 <!-- Currently slot props are not supported by Playwright, so we need to provide a custom wrapper. See issue: https://github.com/microsoft/playwright/issues/18758 -->
 <script lang="ts" setup>
+import OnyxColorSchemeMenuItem from "../OnyxColorSchemeMenuItem/OnyxColorSchemeMenuItem.vue";
 import OnyxMenuItem from "../OnyxMenuItem/OnyxMenuItem.vue";
 import OnyxFlyoutMenu from "./OnyxFlyoutMenu.vue";
 import type { OnyxFlyoutMenuProps } from "./types";
@@ -20,6 +21,7 @@ defineSlots<{
       <OnyxMenuItem active>English</OnyxMenuItem>
       <OnyxMenuItem>German</OnyxMenuItem>
       <OnyxMenuItem>Spanish</OnyxMenuItem>
+      <OnyxColorSchemeMenuItem model-value="auto" />
     </template>
   </OnyxFlyoutMenu>
 </template>


### PR DESCRIPTION
Closes #2888 

### Cause:

- `OnyxColorSchemeDialog` is a child element of `OnyxColorSchemeMenuItem`, which is teleported to the body
- `OnyxFlyoutMenu` renders `menuitem`s when it's opened (e.g. by hovering its button)
  - Clicking a `menuitem` closes the `OnyxFlyoutMenu` and unmounts its `menuitem`s
  - This way the parent of `OnyxColorSchemeDialog` was unmounted and therefore the dialog was unmounted, too.

### Fix:

- Replace `v-if` with `v-show` for the `menuitems` in the `OnyxFlyoutMenu`, so that `OnyxColorSchemeMenuItem` is only visually hidden and not unmounted
- This way `OnyxColorSchemeDialog` will be shown, because its parent still exists
- This has the unfortunate side-effect, that the `autofocus` inside of the flyout will not work (it only works on inital render)
  - This affects the FlyoutMenu inside the `OnyxDataGrid`
  - Will be solved through #2982 


