### PR TITLE
refactor(i18n): create reusable date and number formats

### DIFF
--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
@@ -13,6 +13,7 @@ import {
 } from "vue";
 import type { ComponentSlots } from "vue-component-type-helpers";
 import { type OnyxI18n } from "../../../i18n";
+import type { DatetimeFormat } from "../../../i18n/datetime-formats";
 import { mergeVueProps } from "../../../utils/attrs";
 import type { OnyxMenuItem } from "../../OnyxNavBar/modules";
 import OnyxFlyoutMenu from "../../OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue";
@@ -59,13 +60,7 @@ export type ColumnConfig<
   TTypes,
 > = keyof TEntry | PublicNormalizedColumnConfig<TEntry, TColumnGroup, TTypes>;
 
-export type DefaultSupportedTypes =
-  | "string"
-  | "number"
-  | "date"
-  | "datetime-local"
-  | "time"
-  | "timestamp";
+export type DefaultSupportedTypes = "string" | "number" | DatetimeFormat;
 
 /**
  * Configuration for the column groupings.

--- a/packages/sit-onyx/src/i18n/datetime-formats.ts
+++ b/packages/sit-onyx/src/i18n/datetime-formats.ts
@@ -1,0 +1,16 @@
+export const DATETIME_FORMATS = {
+  date: { dateStyle: "medium" },
+  "datetime-local": { dateStyle: "medium", timeStyle: "short" },
+  time: { timeStyle: "short" },
+  timestamp: {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "shortOffset",
+  },
+} satisfies Record<string, Intl.DateTimeFormatOptions>;
+
+export type DatetimeFormat = keyof typeof DATETIME_FORMATS;

--- a/packages/sit-onyx/src/i18n/index.spec.ts
+++ b/packages/sit-onyx/src/i18n/index.spec.ts
@@ -5,6 +5,8 @@ import * as vue from "vue";
 import { createI18n as createVueI18n } from "vue-i18n";
 import { injectI18n, provideI18n, type OnyxTranslations, type ProvideI18nOptions } from ".";
 import type { FlattenedKeysOf, TranslationValue } from "../types";
+import type { DatetimeFormat } from "./datetime-formats";
+import type { NumberFormat } from "./number-formats";
 
 // keep track of provide/inject because they need to be mocked
 let provided = new Map();
@@ -265,6 +267,39 @@ test.each(LOCALES.map((locale) => ({ locale })))(
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   },
 );
+
+test.each<{ format: DatetimeFormat; expected: string }>([
+  { format: "date", expected: "Mar 11, 2025" },
+  { format: "datetime-local", expected: "Mar 11, 2025, 9:51 AM" },
+  { format: "time", expected: "9:51 AM" },
+  { format: "timestamp", expected: "03/11/2025, 09:51:27 AM GMT" },
+])("should format date with format $format as $expected", ({ format, expected }) => {
+  // ARRANGE
+  provideI18n(app, { locale: "en-US" });
+
+  const { d } = injectI18n();
+
+  const date = new Date(2025, 2, 11, 9, 51, 27);
+
+  // ASSERT
+  expect(d.value(date, format)).toBe(expected);
+});
+
+test.each<{ format: NumberFormat; value: number; expected: string }>([
+  { format: "decimal", value: 42, expected: "42" },
+  { format: "decimal", value: -42, expected: "-42" },
+  { format: "decimal", value: 42.123, expected: "42.123" },
+  { format: "decimal", value: 42.1238, expected: "42.124" },
+  { format: "decimal", value: 0.123, expected: "0.123" },
+])("should format date with format $format as $expected", ({ format, value, expected }) => {
+  // ARRANGE
+  provideI18n(app, { locale: "en-US" });
+
+  const { n } = injectI18n();
+
+  // ASSERT
+  expect(n.value(value, format)).toBe(expected);
+});
 
 /**
  * Gets all nested keys of the given translation entry as a flattened array.

--- a/packages/sit-onyx/src/i18n/number-formats.ts
+++ b/packages/sit-onyx/src/i18n/number-formats.ts
@@ -1,0 +1,5 @@
+export const NUMBER_FORMATS = {
+  decimal: { style: "decimal" },
+} satisfies Record<string, Intl.NumberFormatOptions>;
+
+export type NumberFormat = keyof typeof NUMBER_FORMATS;


### PR DESCRIPTION
Support unified date and number formats so they can be reused across all components.
This is extracted from #2960.

The API is aligned with [vue-i18n](https://vue-i18n.intlify.dev/guide/essentials/datetime.html)

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
