### PR TITLE
fix(OnyxDataGrid): fix sorting buttons of `useSorting` feature using column key instead of label 

### DIFF
--- a/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.stories.ts
@@ -15,11 +15,12 @@ const meta: Meta<typeof OnyxDataGrid> = {
 export default meta;
 type Story = StoryObj<typeof OnyxDataGrid>;
 
-export const Default = createAdvancedStoryExample("OnyxDataGrid", "DefaultExample");
+export const Default = createAdvancedStoryExample("OnyxDataGrid", "DefaultExample") satisfies Story;
 
-export const CustomFeature = {
-  ...createAdvancedStoryExample("OnyxDataGrid", "CustomFeatureExample"),
-} satisfies Story;
+export const CustomFeature = createAdvancedStoryExample(
+  "OnyxDataGrid",
+  "CustomFeatureExample",
+) satisfies Story;
 
 export const CustomColumnTypes = {
   tags: ["new:feature"],

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/hideColumns/hideColumns.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/hideColumns/hideColumns.ts
@@ -104,7 +104,7 @@ export const useHideColumns = createFeature(
           });
 
           return hiddenColumns.value.length > 0
-            ? [...filteredColumns, { key: HIDDEN_COLUMN, type: HIDDEN_COLUMN }]
+            ? [...filteredColumns, { key: HIDDEN_COLUMN, type: HIDDEN_COLUMN, label: "" }]
             : filteredColumns;
         },
       } satisfies ModifyColumns<TEntry>,

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
@@ -80,7 +80,7 @@ export type InternalColumnConfig<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TColumnGroup extends ColumnGroupConfig = any,
   TTypes extends PropertyKey = PropertyKey,
-> = {
+> = PublicNormalizedColumnConfig<TEntry, TColumnGroup, TTypes> & {
   /**
    * Attributes that should be set on all `td` elements
    */
@@ -89,7 +89,8 @@ export type InternalColumnConfig<
    * Attributes that should be set on all `th` elements
    */
   thAttributes?: ThHTMLAttributes;
-} & PublicNormalizedColumnConfig<TEntry, TColumnGroup, TTypes>;
+  label: string;
+};
 
 /**
  * Normalized column config for public/external usage.
@@ -182,7 +183,7 @@ export type DataGridFeature<
      * `iconComponent` of an action is shown after the header label.
      * The components must be ARIA-conform buttons.
      */
-    actions?: (column: PublicNormalizedColumnConfig<TEntry>) => {
+    actions?: (column: InternalColumnConfig<TEntry>) => {
       iconComponent?:
         | Component
         | {
@@ -350,9 +351,11 @@ export const useDataGridFeatures = <
   { i18n, columnConfig, columnGroups }: UseDataGridFeaturesOptions<TEntry, TColumnGroup>,
 ) => {
   const columns = computed(() => {
-    const normalized = toValue(columnConfig).map<InternalColumnConfig<TEntry>>((c) =>
-      typeof c !== "object" ? { key: c } : c,
-    );
+    const normalized = toValue(columnConfig).map((c) => {
+      const obj = typeof c !== "object" ? { key: c } : c;
+      obj.label ??= String(obj.key);
+      return obj as InternalColumnConfig<TEntry>;
+    });
     return features
       .flatMap(({ modifyColumns }) => modifyColumns)
       .reduce((last, m) => (m?.func ? m.func(last) : last), normalized);
@@ -380,7 +383,6 @@ export const useDataGridFeatures = <
     return columns.value.map<DataGridRendererColumn<TEntry>>((column) => {
       const actions = headerActions.flatMap((actionFactory) => actionFactory(column));
       const header = renderer.value.getFor("header", column.type);
-      const label = column.label?.trim() ?? String(column.key);
 
       const menuItems = actions.map(({ menuItems }) => menuItems).filter((item) => !!item);
       const iconComponent = actions.map(({ iconComponent }) => iconComponent);
@@ -388,7 +390,7 @@ export const useDataGridFeatures = <
       const flyoutMenu = h(
         OnyxFlyoutMenu,
         {
-          label: i18n.t.value("navigation.moreActionsFlyout", { column: label }),
+          label: i18n.t.value("navigation.moreActionsFlyout", { column: column.label }),
           trigger: "click",
         },
         {
@@ -445,7 +447,7 @@ export const useDataGridFeatures = <
         (acc, component) => {
           return h(component(column), acc);
         },
-        (props) => h(header.component, { label, ...props }, actionsSlot),
+        (props) => h(header.component, { label: column.label, ...props }, actionsSlot),
       );
       return {
         thAttributes: mergeVueProps(header.thAttributes, column.thAttributes),

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
@@ -89,6 +89,9 @@ export type InternalColumnConfig<
    * Attributes that should be set on all `th` elements
    */
   thAttributes?: ThHTMLAttributes;
+  /**
+   * After normalization the label is always defined.
+   */
   label: string;
 };
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
@@ -196,7 +196,7 @@ export type DataGridFeature<
       menuItems?: Component<typeof OnyxMenuItem>[];
       showFlyoutMenu?: boolean;
     }[];
-    wrapper?: (column: PublicNormalizedColumnConfig<TEntry>) => Component;
+    wrapper?: (column: InternalColumnConfig<TEntry>) => Component;
   };
   scrollContainerAttributes?: () => HTMLAttributes;
 };

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/selection/selection.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/selection/selection.ts
@@ -62,7 +62,7 @@ export const useSelection = createFeature(
         func: (columnConfig) =>
           disabled.value
             ? [...columnConfig]
-            : [{ key: SELECTION_COLUMN, type: SELECTION_COLUMN }, ...columnConfig],
+            : [{ key: SELECTION_COLUMN, type: SELECTION_COLUMN, label: "" }, ...columnConfig],
       } satisfies ModifyColumns<TEntry>,
       mutation: {
         func: (rows) => {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/sorting.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/sorting.ts
@@ -107,7 +107,7 @@ export const useSorting = createFeature(
           return [
             {
               iconComponent: h(SortAction, {
-                columnLabel: String(column),
+                columnLabel: label,
                 sortDirection:
                   sortState.value.column === column ? sortState.value.direction : undefined,
                 onClick: () => handleClick(column),

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/sorting.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/sorting.ts
@@ -102,7 +102,7 @@ export const useSorting = createFeature(
         func: sortData,
       },
       header: {
-        actions: ({ key: column }) => {
+        actions: ({ key: column, label }) => {
           if (!isEnabled.value(column)) return [];
           return [
             {
@@ -124,7 +124,7 @@ export const useSorting = createFeature(
               ? {
                   iconComponent: {
                     iconComponent: h(SortAction, {
-                      columnLabel: String(column),
+                      columnLabel: label,
                       sortDirection:
                         sortState.value.column === column ? sortState.value.direction : undefined,
                       onClick: () => handleClick(column, true),

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/stickyColumns.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/stickyColumns.ts
@@ -17,7 +17,7 @@ export const useStickyColumns = createFeature(
     const isScrolled = ref(false);
 
     const createStickyPositionCssVar = (key: PropertyKey) =>
-      `--onyx-data-grid-sticky-column-position-${stickyId}-${String(key)}`;
+      `--onyx-data-grid-sticky-column-position-${stickyId}-${CSS.escape(String(key))}`;
 
     const resizeObserver = new ResizeObserver(() => {
       Object.entries(elementsToStyle.value).forEach(

--- a/packages/sit-onyx/src/utils/storybook.ts
+++ b/packages/sit-onyx/src/utils/storybook.ts
@@ -63,7 +63,7 @@ export const textColorDecorator: Decorator = (story) => ({
  * Make sure to import all onyx components, types etc. from the index file "../../../" so its replaced correctly in the code snippet.
  * Will also make the OnyxToast available to be used inside the example.
  *
- * **Note** The "Controls" and "Actions" panel/tab will be disable for this story since they will probably be mostly unusable due to the custom example.
+ * **Note** The "Controls" and "Actions" panel/tab will be disabled for this story since they will probably be mostly unusable due to the custom example.
  */
 export function createAdvancedStoryExample(componentName: string, exampleName: string) {
   const allExamples: Record<string, DefineComponent> = import.meta.glob(


### PR DESCRIPTION
some minor changes:
- column `label` is now resolved as part of the normalization
- `header.actions` now uses the available `InternalColumnConfig` type instead of the less accurate `PublicNormalizedColumnConfig`
- OnyxDataGrid: The column label is now used instead of the key for the sorting buttons