### PR TITLE
chore: refactor base Playwright config

### DIFF
--- a/apps/docs/playwright.config.ts
+++ b/apps/docs/playwright.config.ts
@@ -1,13 +1,11 @@
-import { defineConfig } from "@playwright/test";
-import { PLAYWRIGHT_BASE_CONFIG } from "@sit-onyx/shared/playwright.config.base";
+import { defineOnyxPlaywrightConfig } from "@sit-onyx/shared/playwright.config.base";
 
 // NOTE: You need to run "pnpm build" before running the tests
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-export default defineConfig({
-  ...PLAYWRIGHT_BASE_CONFIG,
+export default defineOnyxPlaywrightConfig({
   testDir: "./tests",
   testMatch: `**/*.ct.{ts,tsx}`,
   expect: { toHaveScreenshot: { maxDiffPixelRatio: 0.01 } },

--- a/apps/playground/playwright.config.ts
+++ b/apps/playground/playwright.config.ts
@@ -1,13 +1,11 @@
-import { defineConfig } from "@playwright/test";
-import { PLAYWRIGHT_BASE_CONFIG } from "@sit-onyx/shared/playwright.config.base";
+import { defineOnyxPlaywrightConfig } from "@sit-onyx/shared/playwright.config.base";
 
 // NOTE: You need to run "pnpm build" before running the tests
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-export default defineConfig({
-  ...PLAYWRIGHT_BASE_CONFIG,
+export default defineOnyxPlaywrightConfig({
   testDir: "./tests",
   fullyParallel: true,
   /* Run your local dev server before starting the tests */

--- a/packages/chartjs-plugin/playwright.config.ts
+++ b/packages/chartjs-plugin/playwright.config.ts
@@ -1,11 +1,10 @@
-import { defineConfig, devices } from "@playwright/experimental-ct-vue";
-import { PLAYWRIGHT_BASE_CONFIG } from "@sit-onyx/shared/playwright.config.base";
+import { devices } from "@playwright/experimental-ct-vue";
+import { defineOnyxPlaywrightConfig } from "@sit-onyx/shared/playwright.config.base";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-export default defineConfig({
-  ...PLAYWRIGHT_BASE_CONFIG,
+export default defineOnyxPlaywrightConfig({
   testDir: "./src",
   testMatch: `**/*.ct.tsx`,
   expect: { toHaveScreenshot: { maxDiffPixelRatio: 0.01 } },

--- a/packages/headless/playwright.config.ts
+++ b/packages/headless/playwright.config.ts
@@ -1,11 +1,9 @@
-import { defineConfig } from "@playwright/experimental-ct-vue";
-import { PLAYWRIGHT_BASE_CONFIG } from "@sit-onyx/shared/playwright.config.base";
+import { defineOnyxPlaywrightConfig } from "@sit-onyx/shared/playwright.config.base";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-export default defineConfig({
-  ...PLAYWRIGHT_BASE_CONFIG,
+export default defineOnyxPlaywrightConfig({
   testDir: "./",
   testMatch: `**/*.ct.tsx`,
 });

--- a/packages/nuxt-docs/playground/playwright.config.ts
+++ b/packages/nuxt-docs/playground/playwright.config.ts
@@ -1,6 +1,6 @@
 import type { ConfigOptions } from "@nuxt/test-utils/playwright";
-import { defineConfig, devices } from "@playwright/test";
-import { PLAYWRIGHT_BASE_CONFIG } from "@sit-onyx/shared/playwright.config.base";
+import { devices } from "@playwright/test";
+import { defineOnyxPlaywrightConfig } from "@sit-onyx/shared/playwright.config.base";
 import { fileURLToPath } from "node:url";
 
 /**
@@ -8,12 +8,10 @@ import { fileURLToPath } from "node:url";
  *
  * @see https://playwright.dev/docs/test-configuration.
  */
-export default defineConfig<ConfigOptions>({
-  ...PLAYWRIGHT_BASE_CONFIG,
+export default defineOnyxPlaywrightConfig<ConfigOptions>({
   testDir: "./tests/playwright",
   timeout: 30 * 1000,
   use: {
-    ...PLAYWRIGHT_BASE_CONFIG.use,
     nuxt: {
       rootDir: fileURLToPath(new URL(".", import.meta.url)),
     },

--- a/packages/shared/src/playwright.config.base.ts
+++ b/packages/shared/src/playwright.config.base.ts
@@ -1,4 +1,4 @@
-import { devices, type PlaywrightTestConfig } from "@playwright/experimental-ct-vue";
+import { defineConfig, devices, type PlaywrightTestConfig } from "@playwright/experimental-ct-vue";
 import vue, { type Options } from "@vitejs/plugin-vue";
 
 export const vuePluginOptions: Options = {
@@ -12,73 +12,78 @@ export const vuePluginOptions: Options = {
 };
 
 /**
- * Basic, shared playwright configuration
+ * Creates a basic, shared playwright configuration for onyx.
  *
- * See https://playwright.dev/docs/test-configuration
+ * @param overrides - Optional config overrides. Will be merged with the default config
+ * @see https://playwright.dev/docs/test-configuration
  */
-export const PLAYWRIGHT_BASE_CONFIG = {
-  /**
-   * SCREENSHOTS
-   *
-   * See: https://playwright.dev/docs/screenshots
-   */
-  snapshotDir: "./playwright/snapshots",
-  // custom snapshotPathTemplate to remove the testFileName folder that we don't want
-  snapshotPathTemplate: "{snapshotDir}/{testFileDir}/{arg}-{projectName}-{platform}{ext}",
-  // we don't want to update snapshots on the local machine of each developer.
-  // if you want to update snapshots for your branch, use the corresponding GitHub action:
-  // https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml
-  ignoreSnapshots: !process.env.CI,
-  updateSnapshots: process.env.PW_UPDATE_SNAPSHOTS === "true" ? "changed" : "none",
+export const defineOnyxPlaywrightConfig = <T>(overrides: PlaywrightTestConfig<T> = {}) => {
+  const defaultConfig: PlaywrightTestConfig = {
+    /**
+     * SCREENSHOTS
+     *
+     * @see https://playwright.dev/docs/screenshots
+     */
+    snapshotDir: "./playwright/snapshots",
+    // custom snapshotPathTemplate to remove the testFileName folder that we don't want
+    snapshotPathTemplate: "{snapshotDir}/{testFileDir}/{arg}-{projectName}-{platform}{ext}",
+    // we don't want to update snapshots on the local machine of each developer.
+    // if you want to update snapshots for your branch, use the corresponding GitHub action:
+    // https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml
+    ignoreSnapshots: !process.env.CI,
+    updateSnapshots: process.env.PW_UPDATE_SNAPSHOTS === "true" ? "changed" : "none",
 
-  /**
-   * SHARDING
-   *
-   * See: https://playwright.dev/docs/test-sharding
-   */
-  fullyParallel: true,
-  // when (in the pipeline) the sharding environment variables are set, sharding is enabled
-  shard:
-    process.env.CI && process.env.PW_SHARD && process.env.PW_TOTAL_SHARDS
-      ? {
-          current: +process.env.PW_SHARD,
-          total: +process.env.PW_TOTAL_SHARDS,
-        }
-      : null,
+    /**
+     * SHARDING
+     *
+     * @see https://playwright.dev/docs/test-sharding
+     */
+    fullyParallel: true,
+    // when (in the pipeline) the sharding environment variables are set, sharding is enabled
+    shard:
+      process.env.CI && process.env.PW_SHARD && process.env.PW_TOTAL_SHARDS
+        ? {
+            current: +process.env.PW_SHARD,
+            total: +process.env.PW_TOTAL_SHARDS,
+          }
+        : null,
 
-  /**
-   * FAILURE HANDLING
-   *
-   * See: https://playwright.dev/docs/test-retries
-   */
-  timeout: 20 * 1000,
-  forbidOnly: !!process.env.CI, // fail build on CI if we left test.only in the source code
-  retries: process.env.CI ? 1 : 0, // retry on CI only
+    /**
+     * FAILURE HANDLING
+     *
+     * @see https://playwright.dev/docs/test-retries
+     */
+    timeout: 20 * 1000,
+    forbidOnly: !!process.env.CI, // fail build on CI if we left test.only in the source code
+    retries: process.env.CI ? 1 : 0, // retry on CI only
 
-  /**
-   * REPORTERS
-   *
-   * See: https://playwright.dev/docs/test-reporters
-   */
-  /* In the CI pipeline it generates dot (for the stdout) and blob reports, locally only a html report is generated */
-  reporter: process.env.CI ? [["dot"], ["blob"]] : [["html", { open: "never" }]],
-  use: {
-    trace: process.env.CI ? "retain-on-failure" : "off",
-    video: process.env.CI ? "retain-on-failure" : "off",
-    ctPort: 3100,
-    ctViteConfig: {
-      plugins: [vue(vuePluginOptions)],
+    /**
+     * REPORTERS
+     *
+     * @see https://playwright.dev/docs/test-reporters
+     */
+    /* In the CI pipeline it generates dot (for the stdout) and blob reports, locally only a html report is generated */
+    reporter: process.env.CI ? [["dot"], ["blob"]] : [["html", { open: "never" }]],
+    use: {
+      trace: process.env.CI ? "retain-on-failure" : "off",
+      video: process.env.CI ? "retain-on-failure" : "off",
+      ctPort: 3100,
+      ctViteConfig: {
+        plugins: [vue(vuePluginOptions)],
+      },
     },
-  },
 
-  /**
-   * BROWSERS
-   *
-   * See: https://playwright.dev/docs/test-projects
-   */
-  projects: [
-    { name: "edge", use: { ...devices["Desktop Edge"], channel: "msedge" } },
-    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
-    { name: "webkit", use: { ...devices["Desktop Safari"] } },
-  ],
-} as const satisfies PlaywrightTestConfig;
+    /**
+     * BROWSERS
+     *
+     * @see https://playwright.dev/docs/test-projects
+     */
+    projects: [
+      { name: "edge", use: { ...devices["Desktop Edge"], channel: "msedge" } },
+      { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+      { name: "webkit", use: { ...devices["Desktop Safari"] } },
+    ],
+  };
+
+  return defineConfig<T>(defaultConfig as PlaywrightTestConfig<T>, overrides);
+};

--- a/packages/sit-onyx/playwright.config.ts
+++ b/packages/sit-onyx/playwright.config.ts
@@ -1,22 +1,9 @@
-import { defineConfig } from "@playwright/experimental-ct-vue";
-import { PLAYWRIGHT_BASE_CONFIG } from "@sit-onyx/shared/playwright.config.base";
-import { Options } from "@vitejs/plugin-vue";
-
-export const vuePluginOptions: Options = {
-  template: {
-    compilerOptions: {
-      // comments can cause issues for components where classes
-      // are not merged correctly, e.g. when using `<OnyxIcon class="custom-class" />`
-      comments: false,
-    },
-  },
-};
+import { defineOnyxPlaywrightConfig } from "@sit-onyx/shared/playwright.config.base";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-export default defineConfig({
-  ...PLAYWRIGHT_BASE_CONFIG,
+export default defineOnyxPlaywrightConfig({
   testDir: "./src",
   testMatch: `**/*.ct.tsx`,
 });

--- a/packages/sit-onyx/vite.config.ts
+++ b/packages/sit-onyx/vite.config.ts
@@ -1,10 +1,10 @@
 /// <reference types="vitest" />
+import { vuePluginOptions } from "@sit-onyx/shared/playwright.config.base";
 import { VITE_BASE_CONFIG } from "@sit-onyx/shared/vite.config.base";
 import vue from "@vitejs/plugin-vue";
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vite";
 import packageJson from "./package.json";
-import { vuePluginOptions } from "./playwright.config";
 
 // https://vitejs.dev/config
 export default defineConfig({


### PR DESCRIPTION
Refactor our base Playwright config to use native `defineConfig` for merging

## Checklist

<!-- If bullet points below do not apply to your changes (e.g. no documentation needed), just remove it. -->

- [ ] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [ ] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) or functional test is added
- [ ] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [ ] I have performed a self review of my code ("Files changed" tab in the pull request)
- [ ] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
