### PR TITLE
chore: update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.yml
@@ -2,6 +2,8 @@ name: Report a bug 🐞
 description: You found a bug in onyx? You can report it with the form below.
 title: "[Bug]: "
 type: Bug
+labels: "needs-triage"
+projects: ["SchwarzIT/5"]
 
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/01-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.yml
@@ -3,7 +3,7 @@ description: You found a bug in onyx? You can report it with the form below.
 title: "[Bug]: "
 type: Bug
 labels: "needs-triage"
-projects: ["SchwarzIT/5"]
+projects: "SchwarzIT/5"
 
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/02-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature_request.yml
@@ -4,8 +4,10 @@ description: >-
   with the form below.
 title: "[Feature request]: "
 type: Feature
+projects: "SchwarzIT/5"
 labels:
   - enhancement
+  - "needs-triage"
 
 body:
   - type: textarea


### PR DESCRIPTION
I updated the issue template, so that
- now it's automatically also added to our project and it's backlog
- the issues are labeled with `needs-triage`, so that we know that it is an external request and we need to analyze it