### PR TITLE
chore(eslint): enable new rule @eslint-community/eslint-comments

### DIFF
--- a/apps/demo-app/src/views/DataGridView.vue
+++ b/apps/demo-app/src/views/DataGridView.vue
@@ -12,7 +12,6 @@ import {
   type ColumnConfig,
   type ColumnGroupConfig,
   type DataGridFeature,
-  type TypeRenderMap,
 } from "sit-onyx";
 import { computed, h, ref } from "vue";
 
@@ -126,8 +125,7 @@ const dummyFeature = createFeature(() => ({
 }));
 
 const dataFeatures = computed(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const enabled: DataGridFeature<Entry, TypeRenderMap<any>, any>[] = [];
+  const enabled: DataGridFeature<Entry>[] = [];
   if (enabledFeatures.value.filtering) {
     enabled.push(DataGridFeatures.useFiltering());
   }

--- a/apps/docs/src/cached.ts
+++ b/apps/docs/src/cached.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console -- we want to be able to log output to the console */
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { resolve } from "path";
 
@@ -72,3 +72,5 @@ export const cached = async <T>(url: URL, fetch: () => Promise<T>): Promise<T> =
   }
   throw new Error(`Failed to fetch and load from cache for ${url}!`);
 };
+
+/* eslint-enable */

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,9 @@
+import comments from "@eslint-community/eslint-plugin-eslint-comments/configs";
 import { includeIgnoreFile } from "@eslint/compat";
 import eslint from "@eslint/js";
 import pluginVitest from "@vitest/eslint-plugin";
 import skipFormattingConfig from "@vue/eslint-config-prettier/skip-formatting";
-import vueTsEslintConfig from "@vue/eslint-config-typescript";
+import { defineConfigWithVueTs, vueTsConfigs } from "@vue/eslint-config-typescript";
 import compat from "eslint-plugin-compat";
 import playwrightEslintConfig from "eslint-plugin-playwright";
 import vue from "eslint-plugin-vue";
@@ -21,9 +22,8 @@ const generalVueTsConfig = {
   name: "general-vue-ts",
   files: ["**/*.{js,jsx,ts,tsx,vue}"],
   extends: [
-    ...vue.configs["flat/recommended"],
+    ...defineConfigWithVueTs(vue.configs["flat/recommended"], vueTsConfigs.recommended),
     ...vueA11y.configs["flat/recommended"],
-    ...vueTsEslintConfig({ extends: ["recommended"] }),
   ],
   rules: {
     "vue/html-self-closing": [
@@ -114,6 +114,7 @@ const playwrightConfig = {
           "menuButtonTesting",
           "navigationTesting",
           "listboxTesting",
+          "tabsTesting",
           "comboboxTesting",
           "comboboxSelectOnlyTesting",
         ],
@@ -151,7 +152,7 @@ const sitOnyxConfig = {
   files: ["**/packages/sit-onyx/**/*"],
   extends: [
     compat.configs["flat/recommended"],
-    ...vueTsEslintConfig({ extends: ["recommendedTypeChecked"] }),
+    ...defineConfigWithVueTs(vue.configs["flat/recommended"], vueTsConfigs.recommendedTypeChecked),
     ...vueScopedCss.configs["flat/recommended"],
   ],
   languageOptions: {
@@ -198,8 +199,20 @@ const nuxtConfig = {
   },
 };
 
+const eslintCommentsConfig = {
+  name: "onyx-eslint-comments",
+  extends: [comments.recommended],
+  rules: {
+    "@eslint-community/eslint-comments/require-description": [
+      "error",
+      { ignore: ["eslint-enable"] },
+    ],
+  },
+};
+
 export default tsEslint.config(
   eslint.configs.recommended,
+  eslintCommentsConfig,
   generalVueTsConfig,
   playwrightConfig,
   vitestConfig,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.1",
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
     "@eslint-community/eslint-utils": "^4.6.0",
     "@eslint/compat": "^1.2.8",
     "@eslint/js": "^9.24.0",

--- a/packages/headless/src/composables/tabs/TestTabs.ct.tsx
+++ b/packages/headless/src/composables/tabs/TestTabs.ct.tsx
@@ -2,7 +2,6 @@ import { test } from "@playwright/experimental-ct-vue";
 import TestTabs from "./TestTabs.vue";
 import { tabsTesting } from "./createTabs.testing";
 
-// eslint-disable-next-line playwright/expect-expect
 test("tabs", async ({ mount, page }) => {
   const component = await mount(<TestTabs />);
 

--- a/packages/headless/src/utils/builder.ts
+++ b/packages/headless/src/utils/builder.ts
@@ -29,7 +29,7 @@ export type IteratedHeadlessElementFunc<
 
 export type HeadlessElementAttributes<A extends HTMLAttributes> =
   | VBindAttributes<A>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- the specific type doesn't matter here
   | IteratedHeadlessElementFunc<A, any>;
 
 export type HeadlessElements = Record<string, MaybeRef<HeadlessElementAttributes<HTMLAttributes>>>;

--- a/packages/nuxt-docs/components/NavItem.vue
+++ b/packages/nuxt-docs/components/NavItem.vue
@@ -7,8 +7,7 @@ const props = defineProps<NavItem>();
  * Same as `props` but without the `children` property to prevent console warnings when using `v-bind`.
  */
 const navItemProps = computed(() => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { children, ...rest } = props;
+  const { children: _, ...rest } = props;
   return rest;
 });
 </script>

--- a/packages/sit-onyx/src/components/OnyxBottomBar/OnyxBottomBar.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxBottomBar/OnyxBottomBar.ct.tsx
@@ -64,17 +64,16 @@ Object.entries(ONYX_BREAKPOINTS).forEach(([breakpoint, width]) => {
 
     await expect(page).toHaveScreenshot(`grid-default-${breakpoint}.png`);
 
-    // eslint-disable-next-line playwright/no-conditional-in-test -- prevent useless screenshots for breakpoints that don't have a max width
+    /* eslint-disable playwright/no-conditional-in-test, playwright/no-conditional-expect -- prevent useless screenshots for breakpoints that don't have a max width */
     if (width > ONYX_BREAKPOINTS.md) {
       const app = page.locator(".onyx-app");
 
       await app.evaluate((element) => element.classList.add("onyx-grid-max-md"));
-      // eslint-disable-next-line playwright/no-conditional-expect
       await expect(page).toHaveScreenshot(`grid-max-width-${breakpoint}.png`);
 
       await app.evaluate((element) => element.classList.add("onyx-grid-center"));
-      // eslint-disable-next-line playwright/no-conditional-expect
       await expect(page).toHaveScreenshot(`grid-max-center-${breakpoint}.png`);
     }
+    /* eslint-enable */
   });
 });

--- a/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.ct.tsx
@@ -123,7 +123,7 @@ test.describe("Screenshot tests", () => {
 
         // wait for the tooltip to show up reliably
         if (["focus-visible", "hover"].includes(row) && column !== "disabled") {
-          // eslint-disable-next-line playwright/no-standalone-expect
+          // eslint-disable-next-line playwright/no-standalone-expect -- is called by the test in executeMatrixScreenshotTest
           await expect(
             component.getByRole("tooltip"),
             `should show error tooltip for ${row} and ${column}`,

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/filtering/TestCase.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/filtering/TestCase.vue
@@ -5,7 +5,7 @@ import { DataGridFeatures, OnyxDataGrid } from "../../../..";
 import type { FilterOptions } from "./types";
 
 const { columns, data, filterOptions } = defineProps<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
   Pick<OnyxDataGridProps<any, any, any, any, any>, "columns" | "data"> & {
     /**
      * config

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/filtering/filtering.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/filtering/filtering.ct.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable playwright/expect-expect -- expect is done by "expectRowCount" utility */
+/* eslint playwright/expect-expect: ["error", { "assertFunctionNames": ["expectRowCount"] }] -- We have some assertions in extra functions */
 import type { Locator } from "@playwright/test";
 import { expect, test } from "../../../../playwright/a11y";
 import type { DataGridEntry } from "../../types";

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/hideColumns/TestCase.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/hideColumns/TestCase.vue
@@ -5,7 +5,7 @@ import { DataGridFeatures, OnyxDataGrid } from "../../../..";
 import type { HideColumnsOptions } from "./types";
 
 const { columns, data, hideColumnsOptions } = defineProps<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
   Pick<OnyxDataGridProps<TEntry, any, any, any, any>, "columns" | "data"> & {
     /**
      * config

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
@@ -77,7 +77,7 @@ export type ColumnGroupConfig = Record<
  */
 export type InternalColumnConfig<
   TEntry extends DataGridEntry,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- we use any for type inference
   TColumnGroup extends ColumnGroupConfig = any,
   TTypes extends PropertyKey = PropertyKey,
 > = PublicNormalizedColumnConfig<TEntry, TColumnGroup, TTypes> & {
@@ -100,7 +100,7 @@ export type InternalColumnConfig<
  */
 export type PublicNormalizedColumnConfig<
   TEntry extends DataGridEntry,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- we use any for type inference
   TColumnGroup extends ColumnGroupConfig = any,
   TTypes = PropertyKey,
 > = Pick<DataGridRendererColumn<TEntry>, "width" | "key"> & {
@@ -256,10 +256,9 @@ export type DataGridFeatureOptions<
  * ```
  */
 export function createFeature<
-  // any must be used here, otherwise the type inference breaks
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- any must be used here, otherwise the type inference breaks
   TArgs extends any[],
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- we use any for simplicity
   TFeature extends DataGridFeature<any, any, any>,
   T extends (...args: TArgs) => CheckDataGridFeature<TFeature>,
 >(featureDefinition: T) {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
@@ -129,8 +129,8 @@ export type PublicNormalizedColumnConfig<
  */
 export type DataGridFeature<
   TEntry extends DataGridEntry,
-  TTypeRenderer extends TypeRenderMap<TEntry>,
-  TFeatureName extends symbol,
+  TTypeRenderer extends TypeRenderMap<TEntry> = TypeRenderMap<TEntry>,
+  TFeatureName extends symbol = symbol,
 > = {
   /**
    * Unique name and identifier of the datagrid feature

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/resizing/TestCase.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/resizing/TestCase.vue
@@ -5,7 +5,7 @@ import { DataGridFeatures, OnyxDataGrid } from "../../../..";
 import type { ResizingOptions } from "./types";
 
 const { columns, data, resizingOptions } = defineProps<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
   Pick<OnyxDataGridProps<any, any, any, any, any>, "columns" | "data"> & {
     /**
      * config

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/selection/TestCase.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/selection/TestCase.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { computed, ref, toValue, watch } from "vue";
 import type { OnyxDataGridProps } from "../../../..";
 import { DataGridFeatures, OnyxDataGrid } from "../../../..";
@@ -14,7 +12,7 @@ const { dataGrid, selectionOption } = defineProps<{
   /**
    * props passed through to DataGrid
    */
-  dataGrid: Pick<OnyxDataGridProps<any, any, any, any, any>, "columns" | "data">;
+  dataGrid: Pick<OnyxDataGridProps<any, any, any, any, any>, "columns" | "data">; // eslint-disable-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
   /**
    * props passed through to the feature
    */

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/TestCase.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/TestCase.vue
@@ -4,7 +4,7 @@ import type { DataGridEntry, OnyxDataGridProps } from "../../../..";
 import { DataGridFeatures, OnyxDataGrid } from "../../../..";
 
 const { columns, data } =
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
   defineProps<Pick<OnyxDataGridProps<any, any, any, any, any>, "columns" | "data">>();
 
 const emit = defineEmits<{

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/TestCase.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/TestCase.vue
@@ -5,7 +5,7 @@ import { DataGridFeatures, OnyxDataGrid } from "../../../..";
 import type { StickyColumnsOptions } from "./types";
 
 const { columns, data, stickyColumnsOptions } = defineProps<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
   Pick<OnyxDataGridProps<any, any, any, any, any>, "columns" | "data"> & {
     /**
      * config

--- a/packages/sit-onyx/src/components/OnyxDataGrid/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/types.ts
@@ -6,7 +6,7 @@ export type DataGridMetadata = Record<string, unknown>;
 /**
  * Unwraps the defined typeRenderers
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- we use any for simplicity
 export type RenderTypesFromFeature<TFeatures extends DataGridFeature<any, any, any>[]> =
   // Only expose named types, symbols are intended for internal types
   Exclude<

--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.ts
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.ts
@@ -96,7 +96,7 @@ const createCompute = <TKey extends keyof FormProps>(
       return formProps?.value[key] ?? defaultValue;
     }
     if (import.meta.env.DEV && prop != undefined) {
-      // eslint-disable-next-line no-console
+      // eslint-disable-next-line no-console -- we only log the error in dev mode
       console.error(
         `The %s prop is an unrecognized symbol: %o which is not identical to the expected symbol %o.`,
         key,

--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.ct.tsx
@@ -52,7 +52,7 @@ test("OnyxForm should inject disabled state", async ({ mount, page }) => {
   const expectForAll = async (expectation: (locator: Locator) => Promise<unknown>) => {
     for (const { props, delegate } of allFormElements) {
       const getInputByLabel = page.getByLabel(props.label, { exact: true });
-      // eslint-disable-next-line playwright/no-conditional-in-test
+      // eslint-disable-next-line playwright/no-conditional-in-test -- its easier to have some simple dynamic checks in the test
       const element = delegate || getInputByLabel;
       expect(element).toBeDefined();
       await expectation(element);
@@ -68,10 +68,6 @@ test("OnyxForm should inject disabled state", async ({ mount, page }) => {
 
   // ASSERT
   await expectForAll(async (element) => {
-    if ((await element.textContent())?.includes("OnyxButton")) {
-      // eslint-disable-next-line playwright/no-conditional-expect
-      return expect(element).toBeEnabled();
-    }
     return Promise.all([expect(element).toBeEnabled(), expect(element).toBeEditable()]);
   });
 

--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.ct.tsx
@@ -68,6 +68,10 @@ test("OnyxForm should inject disabled state", async ({ mount, page }) => {
 
   // ASSERT
   await expectForAll(async (element) => {
+    if ((await element.textContent())?.includes("OnyxButton")) {
+      // eslint-disable-next-line playwright/no-conditional-expect -- its easier to have some simple dynamic checks in the test
+      return expect(element).toBeEnabled();
+    }
     return Promise.all([expect(element).toBeEnabled(), expect(element).toBeEditable()]);
   });
 

--- a/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxHeadline/OnyxHeadline.ct.tsx
@@ -49,7 +49,7 @@ test.describe("Screenshot tests (hash)", () => {
 });
 
 test("should copy hash", async ({ mount, page, context, browserName }) => {
-  // eslint-disable-next-line playwright/no-skipped-test
+  // eslint-disable-next-line playwright/no-skipped-test -- clipboard permission granting is only supported in chromium
   test.skip(
     browserName !== "chromium",
     "clipboard permission granting is only supported in chromium",

--- a/packages/sit-onyx/src/components/OnyxIconButton/OnyxIconButton.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxIconButton/OnyxIconButton.ct.tsx
@@ -33,7 +33,7 @@ test("should behave correctly", async ({ page, mount }) => {
     // ARRANGE
     await component.update({ ...setup, props: { disabled: true } }); // ACT
     // ACT
-    // eslint-disable-next-line playwright/no-force-option
+    // eslint-disable-next-line playwright/no-force-option -- we want to check that a disabled button behaves as expected
     await buttonElement.click({ force: true });
     // ASSERT
     await expect(buttonElement).toBeDisabled();

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
@@ -333,18 +333,17 @@ Object.entries(ONYX_BREAKPOINTS).forEach(([breakpoint, width]) => {
 
     await expect(page).toHaveScreenshot(`grid-default-${breakpoint}.png`);
 
-    // eslint-disable-next-line playwright/no-conditional-in-test -- prevent useless screenshots for breakpoints that don't have a max width
+    /* eslint-disable playwright/no-conditional-in-test, playwright/no-conditional-expect -- prevent useless screenshots for breakpoints that don't have a max width */
     if (width > ONYX_BREAKPOINTS.md) {
       const app = page.locator(".onyx-app");
 
       await app.evaluate((element) => element.classList.add("onyx-grid-max-md"));
-      // eslint-disable-next-line playwright/no-conditional-expect
       await expect(page).toHaveScreenshot(`grid-max-width-${breakpoint}.png`);
 
       await app.evaluate((element) => element.classList.add("onyx-grid-center"));
-      // eslint-disable-next-line playwright/no-conditional-expect
       await expect(page).toHaveScreenshot(`grid-max-center-${breakpoint}.png`);
     }
+    /* eslint-enable */
   });
 });
 

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/ComponentTestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/ComponentTestWrapper.ct.vue
@@ -33,7 +33,7 @@ provide(
   computed(() => props.mobile),
 );
 
-// eslint-disable-next-line vue/no-setup-props-reactivity-loss
+// eslint-disable-next-line vue/no-setup-props-reactivity-loss -- wont change at runtime
 provide(NAV_BAR_IS_TOP_LEVEL_INJECTION_KEY, props.topLeveL);
 </script>
 

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/UserMenuLayout.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/UserMenuLayout.vue
@@ -18,7 +18,7 @@ const props = withDefaults(
      */
     flyoutOpen?: Nullable<boolean>;
   }>(),
-  // eslint-disable-next-line vue/no-boolean-default
+  // eslint-disable-next-line vue/no-boolean-default -- to support 'useVModel' we need to know if a value was set or not
   { flyoutOpen: undefined },
 );
 

--- a/packages/sit-onyx/src/components/OnyxNotifications/useNotification.ts
+++ b/packages/sit-onyx/src/components/OnyxNotifications/useNotification.ts
@@ -89,7 +89,7 @@ export const createNotificationsProvider = (): NotificationsProvider => {
  */
 export const useNotification = () => {
   const logWarning = () => {
-    // eslint-disable-next-line no-console
+    // eslint-disable-next-line no-console -- we want to inform devs about incorrect usage
     console.warn(
       'Trying to use "useNotification()" before the notifications provider has been provided. Make sure to "provide" it first.',
     );

--- a/packages/sit-onyx/src/components/OnyxRouterLink/OnyxRouterLink.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxRouterLink/OnyxRouterLink.ct.tsx
@@ -85,7 +85,7 @@ for (const modifier of ["Alt", "ControlOrMeta", "Shift"] as const) {
     mount,
     browserName,
   }) => {
-    // eslint-disable-next-line playwright/no-skipped-test
+    // eslint-disable-next-line playwright/no-skipped-test -- Alt does not work in safari
     test.skip(browserName === "webkit" && modifier === "Alt", "Alt does not work in safari");
 
     // ARRANGE

--- a/packages/sit-onyx/src/components/OnyxToast/useToast.ts
+++ b/packages/sit-onyx/src/components/OnyxToast/useToast.ts
@@ -79,7 +79,7 @@ export const createToastProvider = (): ToastProvider => {
  */
 export const useToast = () => {
   const logWarning = () => {
-    // eslint-disable-next-line no-console
+    // eslint-disable-next-line no-console -- we want to inform devs about incorrect usage
     console.warn(
       'Trying to use "useToast()" before the toast provider has been provided. Make sure to "provide" it first.',
     );

--- a/packages/sit-onyx/src/components/OnyxTooltip/OnyxTooltip.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxTooltip/OnyxTooltip.stories.ts
@@ -43,9 +43,7 @@ type Story = StoryObj<typeof OnyxTooltip>;
 export const Default = {
   args: {
     text: "Tooltip text",
-    default: ({ trigger }) =>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      h(OnyxButton, { label: "Slot content goes here", ...(trigger as any) }),
+    default: ({ trigger }) => h(OnyxButton, { label: "Slot content goes here", ...trigger }),
     icon: circleInformation,
     open: true,
   },
@@ -86,8 +84,7 @@ export const Click = {
   args: {
     ...Default.args,
     text: "Storybook is a frontend workshop for building UI components and pages in isolation.",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    default: ({ trigger }) => h(OnyxButton, { label: "Info", ...(trigger as any) }),
+    default: ({ trigger }) => h(OnyxButton, { label: "Info", ...trigger }),
     open: "click",
   },
 } satisfies Story;
@@ -110,8 +107,7 @@ export const Danger = {
     ...Default.args,
     open: "hover",
     text: "Clicking this button will delete the internet!",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    default: ({ trigger }) => h(OnyxButton, { label: "Delete", ...(trigger as any) }),
+    default: ({ trigger }) => h(OnyxButton, { label: "Delete", ...trigger }),
     color: "danger",
   },
 } satisfies Story;

--- a/packages/sit-onyx/src/composables/animation.ts
+++ b/packages/sit-onyx/src/composables/animation.ts
@@ -15,7 +15,7 @@ const IDLE_TIMEOUT = 200;
  */
 const onIdleCallback =
   globalThis.window && "requestIdleCallback" in globalThis.window
-    ? globalThis.window.requestIdleCallback // eslint-disable-line compat/compat
+    ? globalThis.window.requestIdleCallback // eslint-disable-line compat/compat -- we monkey patch requestIdleCallback for compatibility using `setTimeout`
     : (cb: () => void, _: IdleRequestOptions) => setTimeout(cb, 0);
 
 const syncAnimations = (animationName: string) => {

--- a/packages/sit-onyx/src/composables/useSkeletonState.ts
+++ b/packages/sit-onyx/src/composables/useSkeletonState.ts
@@ -59,7 +59,7 @@ const createSkeletonInjectionContext =
         return parentElementProps?.skeleton === true ? 3 : false;
       }
       if (import.meta.env.DEV) {
-        // eslint-disable-next-line no-console
+        // eslint-disable-next-line no-console -- we only log the error in dev mode
         console.error(
           `skeleton prop is an recognized symbol: %o which is not identical to the symbol %o.`,
           props.skeleton,

--- a/packages/sit-onyx/src/styles/grid.ct.tsx
+++ b/packages/sit-onyx/src/styles/grid.ct.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable playwright/expect-expect */
+/* eslint playwright/expect-expect: ["error", { "assertFunctionNames": ["expectComputedGridSpan", "expectComputedColumnCount"] }] -- We have some assertions in extra functions */
 import type { Locator, Page } from "@playwright/test";
 import {
   ONYX_BREAKPOINTS,

--- a/packages/sit-onyx/src/utils/attrs.ts
+++ b/packages/sit-onyx/src/utils/attrs.ts
@@ -5,6 +5,7 @@ import {
   mergeProps,
   toRaw,
   useAttrs,
+  type ComponentPublicInstance,
   type HTMLAttributes,
   type Ref,
   type VNodeProps,
@@ -90,8 +91,7 @@ const createMergedRef = <T>(...toMerge: VNodeRef[]) => {
         _ref[MERGED_REFS_SYMBOL].forEach((r) => {
           switch (typeof r) {
             case "function":
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              r(value as any, []);
+              r(value as VRef, []);
               break;
             case "object":
               r.value = value;
@@ -115,8 +115,9 @@ const createMergedRef = <T>(...toMerge: VNodeRef[]) => {
 const isMergedRef = (_ref: unknown): _ref is MergedRef =>
   !!_ref && typeof _ref === "object" && MERGED_REFS_SYMBOL in _ref;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- we want to allow any kind of props
 type VProps = Data<any> & VNodeProps;
+type VRef = Element | ComponentPublicInstance | null;
 
 /**
  * Extends the Vue's `mergeProp` function, so that it

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   default:
-    chart.js:
-      specifier: ^4.4.9
-      version: 4.4.9
     typescript:
       specifier: 5.8.3
       version: 5.8.3
@@ -30,6 +27,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.1
         version: 2.29.1
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.5.0
+        version: 4.5.0(eslint@9.24.0(jiti@2.4.2))
       '@eslint-community/eslint-utils':
         specifier: ^4.6.0
         version: 4.6.0(eslint@9.24.0(jiti@2.4.2))
@@ -1050,6 +1050,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.5.0':
+    resolution: {integrity: sha512-MAhuTKlr4y/CE3WYX26raZjy+I/kS2PLKSzvfmDCGrBLTFHOYwqROZdr4XwPgXwX3K9rjzMr4pSmUWGnzsUyMg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
   '@eslint-community/eslint-utils@4.6.0':
     resolution: {integrity: sha512-WhCn7Z7TauhBtmzhvKpoQs0Wwb/kBcy4CwpuI0/eEIr2Lx2auxmulAzLr91wVZJaz47iUZdkXOK7WlAfxGKCnA==}
@@ -6956,6 +6962,9 @@ packages:
       typescript:
         optional: true
 
+  vue-component-type-helpers@2.2.10:
+    resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
+
   vue-component-type-helpers@2.2.8:
     resolution: {integrity: sha512-4bjIsC284coDO9om4HPA62M7wfsTvcmZyzdfR0aUlFXqq4tXxM1APyXpNVxPC8QazKw9OhmZNHBVDA6ODaZsrA==}
 
@@ -7803,6 +7812,12 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.2':
     optional: true
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.24.0(jiti@2.4.2))':
+    dependencies:
+      escape-string-regexp: 4.0.0
+      eslint: 9.24.0(jiti@2.4.2)
+      ignore: 5.3.2
 
   '@eslint-community/eslint-utils@4.6.0(eslint@8.57.1)':
     dependencies:
@@ -9393,7 +9408,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.8.3)
-      vue-component-type-helpers: 2.2.8
+      vue-component-type-helpers: 2.2.10
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -15283,6 +15298,8 @@ snapshots:
       vue-component-type-helpers: 2.2.8
     optionalDependencies:
       typescript: 5.8.3
+
+  vue-component-type-helpers@2.2.10: {}
 
   vue-component-type-helpers@2.2.8: {}
 


### PR DESCRIPTION
- enable new rule `@eslint-community/eslint-comments`
- fixed exisiting linting issues
- replaced deprecated import `vueTsEslintConfig` with new `defineConfigWithVueTs` - shouldn't change any existing lint results