### PR TITLE
fix(OnyxTab): prevent call stack size exceed error in Nuxt

### DIFF
--- a/.changeset/late-mangos-greet.md
+++ b/.changeset/late-mangos-greet.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxTab): prevent call stack size exceed error in Nuxt

--- a/packages/sit-onyx/src/components/OnyxTab/OnyxTab.vue
+++ b/packages/sit-onyx/src/components/OnyxTab/OnyxTab.vue
@@ -65,7 +65,7 @@ const tab = computed(() =>
        we need a separated HTML structure where the tab and the panel must not be nested.
        The <Teleport> will allow us to achieve this by moving the panel content to the `OnyxTabs` component.
      -->
-  <Teleport :to="tabsContext?.panel.value" :disabled="!tabsContext?.panel.value" defer>
+  <Teleport v-if="tabsContext?.panel.value" :to="tabsContext?.panel.value" defer>
     <div
       v-if="tab?.['aria-selected']"
       v-bind="tabsContext?.headless.elements.tabpanel.value({ value: props.value })"


### PR DESCRIPTION
closes #3190

Fix maximum call stack size exceed error in Nuxt which is caused by the `<Teleport>`.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
