### PR TITLE
feat(OnyxNavBar): update mobileBreakpoint prop

### DIFF
--- a/.changeset/few-knives-admire.md
+++ b/.changeset/few-knives-admire.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": major
+---
+
+feat(OnyxNavBar)!: rename prop `mobileBreakpoint` to `mobile` - behaves as before, but also supports boolean type

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
@@ -18,6 +18,8 @@ import OnyxMenuItem from "./modules/OnyxMenuItem/OnyxMenuItem.vue";
 import OnyxNavItem from "./modules/OnyxNavItem/OnyxNavItem.vue";
 import OnyxUserMenu from "./modules/OnyxUserMenu/OnyxUserMenu.vue";
 import OnyxNavBar from "./OnyxNavBar.vue";
+import TestCase from "./TestCase.vue";
+import type { OnyxNavBarProps } from "./types";
 
 test.beforeEach(async ({ page }) => {
   await defineLogoMockRoutes(page);
@@ -444,4 +446,60 @@ test("should display More Items correctly", async ({ mount, page }) => {
     await expectNMenuItemsToBeVisible(5, page);
     expect(navItemClickEvents).toBe(4);
   });
+});
+
+test("should switch to mobile correctly", async ({ mount, page }) => {
+  const component = await mount(TestCase);
+
+  type TestCase = {
+    setting: OnyxNavBarProps["mobile"];
+    viewportWidth: number;
+    expectedMobile: boolean;
+  };
+
+  const testCases = [
+    {
+      setting: true,
+      expectedMobile: true,
+      viewportWidth: ONYX_BREAKPOINTS.xl,
+    },
+    {
+      setting: false,
+      expectedMobile: false,
+      viewportWidth: ONYX_BREAKPOINTS.xs,
+    },
+    {
+      setting: 1001,
+      expectedMobile: true,
+      viewportWidth: 1000,
+    },
+    {
+      setting: 999,
+      expectedMobile: false,
+      viewportWidth: 1000,
+    },
+    {
+      setting: "md",
+      expectedMobile: true,
+      viewportWidth: ONYX_BREAKPOINTS.sm,
+    },
+    {
+      setting: "sm",
+      expectedMobile: false,
+      viewportWidth: ONYX_BREAKPOINTS.md,
+    },
+  ] as TestCase[];
+
+  for (const { setting, expectedMobile, viewportWidth } of testCases) {
+    // eslint-disable-next-line playwright/no-conditional-in-test -- conditional is only used in test title
+    await test.step(`should${expectedMobile ? "" : " not"} render in mobile for mobile prop "${setting}" and a viewport width of ${viewportWidth}px`, async () => {
+      await page.setViewportSize({ width: viewportWidth, height: 400 });
+      await component.update({
+        props: { mobile: setting },
+      });
+      await expect(component.getByLabel("Toggle burger menu")).toBeAttached({
+        attached: expectedMobile,
+      });
+    });
+  }
 });

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.stories.ts
@@ -39,7 +39,7 @@ const meta: Meta<typeof OnyxNavBar> = {
     appArea: { control: { type: "text" } },
     mobileActivePage: { control: { type: "text" } },
     globalContextArea: { control: { disable: true } },
-    mobileBreakpoint: {
+    mobile: {
       options: Object.keys(ONYX_BREAKPOINTS),
       control: {
         labels: Object.entries(ONYX_BREAKPOINTS).reduce<Record<string, string>>(
@@ -237,7 +237,7 @@ export const WithLogoutTimer = {
 export const WithOverflowingMobileContent = {
   args: {
     ...WithContextArea.args,
-    mobileBreakpoint: "xl",
+    mobile: "xl",
     default: () => [
       h(OnyxNavItem, { label: "Item 1", link: "/" }),
       h(

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.stories.ts
@@ -234,10 +234,10 @@ export const WithLogoutTimer = {
  * This nav bar has a lot of menu and context area items.
  * Both the nav area as well as the context area will overflow when opened.
  */
-export const WithOverflowingMobileContent = {
+export const Mobile = {
   args: {
     ...WithContextArea.args,
-    mobile: "xl",
+    mobile: true,
     default: () => [
       h(OnyxNavItem, { label: "Item 1", link: "/" }),
       h(

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.vue
@@ -22,7 +22,7 @@ import {
 } from "./types";
 
 const props = withDefaults(defineProps<OnyxNavBarProps>(), {
-  isMobile: "sm",
+  mobile: "sm",
 });
 
 const emit = defineEmits<{
@@ -71,16 +71,17 @@ const {
 const isBurgerOpen = ref(false);
 const isContextOpen = ref(false);
 
-const isMobileWidth = (mobileWidth: number) => width.value !== 0 && width.value < mobileWidth;
+const isMobileWidth = (breakpoint: number, currentWidth: number) =>
+  currentWidth !== 0 && currentWidth < breakpoint;
 
 const actualIsMobile = computed(() => {
-  if (typeof props.isMobile === "number") {
-    return isMobileWidth(props.isMobile);
+  if (typeof props.mobile === "number") {
+    return isMobileWidth(props.mobile, width.value);
   }
-  if (typeof props.isMobile === "string") {
-    return isMobileWidth(ONYX_BREAKPOINTS[props.isMobile]);
+  if (typeof props.mobile === "string") {
+    return isMobileWidth(ONYX_BREAKPOINTS[props.mobile], width.value);
   }
-  return props.isMobile;
+  return props.mobile;
 });
 
 const moreListTargetId = useId();

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.vue
@@ -22,7 +22,7 @@ import {
 } from "./types";
 
 const props = withDefaults(defineProps<OnyxNavBarProps>(), {
-  mobileBreakpoint: "sm",
+  isMobile: "sm",
 });
 
 const emit = defineEmits<{
@@ -71,15 +71,20 @@ const {
 const isBurgerOpen = ref(false);
 const isContextOpen = ref(false);
 
-const isMobile = computed(() => {
-  const mobileWidth =
-    typeof props.mobileBreakpoint === "number"
-      ? props.mobileBreakpoint
-      : ONYX_BREAKPOINTS[props.mobileBreakpoint];
-  return width.value !== 0 && width.value < mobileWidth;
+const isMobileWidth = (mobileWidth: number) => width.value !== 0 && width.value < mobileWidth;
+
+const actualIsMobile = computed(() => {
+  if (typeof props.isMobile === "number") {
+    return isMobileWidth(props.isMobile);
+  }
+  if (typeof props.isMobile === "string") {
+    return isMobileWidth(ONYX_BREAKPOINTS[props.isMobile]);
+  }
+  return props.isMobile;
 });
+
 const moreListTargetId = useId();
-provide(MOBILE_NAV_BAR_INJECTION_KEY, isMobile);
+provide(MOBILE_NAV_BAR_INJECTION_KEY, actualIsMobile);
 provide(NAV_BAR_MORE_LIST_TARGET_INJECTION_KEY, `#${moreListTargetId}`);
 
 const closeMobileMenus = () => {
@@ -112,11 +117,11 @@ defineExpose({
   <header
     ref="navBarRef"
     class="onyx-component onyx-nav-bar"
-    :class="{ 'onyx-nav-bar--mobile': isMobile }"
+    :class="{ 'onyx-nav-bar--mobile': actualIsMobile }"
   >
     <div class="onyx-nav-bar__content">
       <span
-        v-if="isMobile && slots.mobileActivePage && !isBurgerOpen && !isContextOpen"
+        v-if="actualIsMobile && slots.mobileActivePage && !isBurgerOpen && !isContextOpen"
         class="onyx-nav-bar__mobile-page onyx-truncation-ellipsis"
       >
         <slot name="mobileActivePage"></slot>
@@ -143,7 +148,7 @@ defineExpose({
 
       <template v-if="slots.default">
         <OnyxMobileNavButton
-          v-if="isMobile"
+          v-if="actualIsMobile"
           v-model:open="isBurgerOpen"
           class="onyx-nav-bar__burger"
           :icon="menu"
@@ -185,7 +190,7 @@ defineExpose({
       </template>
 
       <template v-if="slots.contextArea || slots.globalContextArea">
-        <div v-if="isMobile" class="onyx-nav-bar__mobile-context">
+        <div v-if="actualIsMobile" class="onyx-nav-bar__mobile-context">
           <div v-if="slots.globalContextArea" class="onyx-nav-bar__mobile-global-context">
             <slot name="globalContextArea"></slot>
           </div>

--- a/packages/sit-onyx/src/components/OnyxNavBar/TestCase.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/TestCase.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import OnyxNavItem from "./modules/OnyxNavItem/OnyxNavItem.vue";
+import OnyxNavBar from "./OnyxNavBar.vue";
+import { type OnyxNavBarProps } from "./types";
+
+const props = defineProps<OnyxNavBarProps>();
+</script>
+
+<template>
+  <OnyxNavBar v-bind="props" app-name="Test App">
+    <OnyxNavItem label="Main One" />
+  </OnyxNavBar>
+</template>
+
+<style>
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/packages/sit-onyx/src/components/OnyxNavBar/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/types.ts
@@ -17,7 +17,7 @@ export type OnyxNavBarProps = Pick<OnyxNavAppAreaProps, "appName" | "logoUrl"> &
    *
    * Determines if and when the `OnyxNavBar` should render in mobile mode.
    *
-   * `isMobile` prop can be one of the following;
+   * `mobile` prop can be one of the following;
    *  - a `boolean`: The NavBar renders in mobile mode, when `true`.
    *  - a `OnyxBreakpoint`: The NavBar renders in mobile mode, when the current breakpoint matches or is smaller.
    *  - a `number`: The NavBar renders in mobile when the viewport width is smaller than the provided value.

--- a/packages/sit-onyx/src/components/OnyxNavBar/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/types.ts
@@ -24,7 +24,7 @@ export type OnyxNavBarProps = Pick<OnyxNavAppAreaProps, "appName" | "logoUrl"> &
    *
    * @see [onyx docs](https://onyx.schwarz/development/breakpoints.html) for more information.
    */
-  isMobile?: boolean | OnyxBreakpoint | number;
+  mobile?: boolean | OnyxBreakpoint | number;
 };
 
 /**

--- a/packages/sit-onyx/src/components/OnyxNavBar/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/types.ts
@@ -14,13 +14,17 @@ export type OnyxNavBarProps = Pick<OnyxNavAppAreaProps, "appName" | "logoUrl"> &
    */
   appArea?: Omit<OnyxNavAppAreaProps, "appName" | "logoUrl">;
   /**
-   * Breakpoint name when the nav bar should switch into mobile mode.
-   * Will switch if **smaller** than the given breakpoint.
-   * Can be either a pre-defined onyx breakpoint or custom width in pixels.
+   *
+   * Determines if and when the `OnyxNavBar` should render in mobile mode.
+   *
+   * `isMobile` prop can be one of the following;
+   *  - a `boolean`: The NavBar renders in mobile mode, when `true`.
+   *  - a `OnyxBreakpoint`: The NavBar renders in mobile mode, when the current breakpoint matches or is smaller.
+   *  - a `number`: The NavBar renders in mobile when the viewport width is smaller than the provided value.
    *
    * @see [onyx docs](https://onyx.schwarz/development/breakpoints.html) for more information.
    */
-  mobileBreakpoint?: OnyxBreakpoint | number;
+  isMobile?: boolean | OnyxBreakpoint | number;
 };
 
 /**


### PR DESCRIPTION
Relates to #2228 

- rename prop `mobileBreakpoint` to `mobile`: behaves as before, but also supports boolean type
- renamed so the naming matches the new behaviour better
