### PR TITLE
fix(turbo-remote-cache): fix missing AWS_REGION

### DIFF
--- a/apps/turbo-remote-cache/.cloud-foundry/manifest-prod.yml
+++ b/apps/turbo-remote-cache/.cloud-foundry/manifest-prod.yml
@@ -11,4 +11,5 @@ applications:
       STORAGE_PATH: turbo-remote-cache
       AWS_ACCESS_KEY_ID: ((AWS_ACCESS_KEY_ID))
       AWS_SECRET_ACCESS_KEY: ((AWS_SECRET_ACCESS_KEY))
+      AWS_REGION: eu01
       S3_ENDPOINT: https://object.storage.eu01.onstackit.cloud


### PR DESCRIPTION
We had issues locally and in the pipeline where the remote connection failed with an `412 Precondition Failed` error