### PR TITLE
fix(OnyxNavBar): prevent console warning for invalid `mobile` property

### DIFF
--- a/.changeset/metal-mice-unite.md
+++ b/.changeset/metal-mice-unite.md
@@ -1,0 +1,6 @@
+---
+"@sit-onyx/shared": patch
+"sit-onyx": patch
+---
+
+fix(OnyxNavBar): prevent console warning for invalid `mobile` property

--- a/packages/shared/src/breakpoints.ts
+++ b/packages/shared/src/breakpoints.ts
@@ -16,4 +16,7 @@ export const ONYX_MAX_WIDTHS = {
   lg: ONYX_BREAKPOINTS.xl - 1,
 } as const;
 
-export type OnyxBreakpoint = keyof typeof ONYX_BREAKPOINTS;
+// "string &" is needed to fix a current Vue issue where a warning is logged for invalid property types
+// when this types is used in a union, see:
+// https://github.com/SchwarzIT/onyx/issues/3290
+export type OnyxBreakpoint = string & keyof typeof ONYX_BREAKPOINTS;


### PR DESCRIPTION
closes #3290

Fix console warning for OnyxNavBar `mobile` property

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
