### PR TITLE
fix(OnyxFlyoutMenu): fix `alignment` property type and make it optional

### DIFF
--- a/.changeset/blue-seas-watch.md
+++ b/.changeset/blue-seas-watch.md
@@ -2,4 +2,4 @@
 "sit-onyx": patch
 ---
 
-fix(OnyxFlyoutMenu): make `alignment` property optional
+fix(OnyxFlyoutMenu): fix `alignment` property type and make it optional

--- a/.changeset/blue-seas-watch.md
+++ b/.changeset/blue-seas-watch.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxFlyoutMenu): make `alignment` property optional

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
@@ -5,17 +5,20 @@ import OnyxFlyout from "../../../../components/OnyxFlyout/OnyxFlyout.vue";
 import { useVModel, type Nullable } from "../../../../composables/useVModel";
 import type { SelectOptionValue } from "../../../../types";
 import type { OnyxFlyoutMenuProps } from "./types";
+
 const props = withDefaults(defineProps<OnyxFlyoutMenuProps>(), {
   trigger: "hover",
   open: undefined,
   alignment: "auto",
 });
+
 const emit = defineEmits<{
   /**
    * Emitted when the isExpanded state changes.
    */
   "update:open": [value?: Nullable<boolean>];
 }>();
+
 /**
  * If the flyout is expanded or not.
  */
@@ -124,7 +127,7 @@ const {
       padding: 0;
       /**
        * The last option should only be half visible:
-       * 7.5 * OnyxListItem, where OnyxListItem => 2 * padding + line-height of OnyxListItem 
+       * 7.5 * OnyxListItem, where OnyxListItem => 2 * padding + line-height of OnyxListItem
        */
       max-height: calc(
         (var(--onyx-flyout-menu-visible-item-count, 7) + 0.5) * (2 * var(--onyx-density-xs) + 1lh)

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/types.ts
@@ -1,16 +1,16 @@
 import type { OnyxFlyoutProps } from "src/components/OnyxFlyout/types";
 import type { Nullable } from "../../../../composables/useVModel";
 
-export type OnyxFlyoutMenuProps = Pick<OnyxFlyoutProps, "alignment"> & {
+export type OnyxFlyoutMenuProps = Partial<Pick<OnyxFlyoutProps, "alignment">> & {
+  /**
+   * Aria label for the flyout.
+   */
+  label: string;
   /**
    * If the flyout is expanded on click or hover.
    * The default value is 'hover' which will expand the flyout on hover.
    */
   trigger?: "hover" | "click";
-  /**
-   * Aria label for the flyout.
-   */
-  label: string;
   /**
    * Indicates whether the element is expanded or collapsed.
    */

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/types.ts
@@ -1,7 +1,7 @@
-import type { OnyxFlyoutProps } from "src/components/OnyxFlyout/types";
+import type { OnyxFlyoutProps } from "../../../../components/OnyxFlyout/types";
 import type { Nullable } from "../../../../composables/useVModel";
 
-export type OnyxFlyoutMenuProps = Partial<Pick<OnyxFlyoutProps, "alignment">> & {
+export type OnyxFlyoutMenuProps = Pick<OnyxFlyoutProps, "alignment"> & {
   /**
    * Aria label for the flyout.
    */


### PR DESCRIPTION
The type of the `alignment` property of the OnyxFlyoutMenu was invalid because of an invalid import of the type.
This lead to a bug that the property was considered required and did not gave type information.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they 
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
