### PR TITLE
chore: ignore suppressed eslint rules in sarif report

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,7 +83,7 @@ jobs:
         if: always() # needed to also upload test results when they failed (useful for debugging)
         with:
           name: coverage
-          path: packages/sit-onyx/coverage
+          path: coverage
 
       - name: Upload Storybook artifact
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "stylelint": "turbo run stylelint",
     "lint:all": "eslint .",
     "lint:fix:all": "pnpm run lint:all --fix",
-    "lint:ci:all": "pnpm run lint:all --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",
+    "lint:ci:all": "SARIF_ESLINT_IGNORE_SUPPRESSED=true pnpm run lint:all --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",
     "publint:all": "pnpm -r --parallel --no-reporter-hide-prefix exec publint",
     "prepare": "simple-git-hooks",
     "gh:show-report": "./scripts/show-last-test-report.sh",


### PR DESCRIPTION
Relates to #2940

- fix vitest coverage directory for github coverage upload
- ignore suppressed (disabled) eslint warnings in sarif report, so that github and sonarqube do not complain about them also