### PR TITLE
docs(flags): add docs for country names

### DIFF
--- a/apps/docs/src/flags.md
+++ b/apps/docs/src/flags.md
@@ -28,6 +28,42 @@ yarn install -D @sit-onyx/flags@beta
 
 Afterwards, you can import and use flags as needed. Please see the [OnyxIcon](https://storybook.onyx.schwarz/?path=/docs/basic-icon--docs) for the technical documentation. Technically, flags are used the same way as icons in onyx. This means that also flags can be passed for all components that support icons.
 
+## Country names
+
+You can get the country name of a flag in several languages using JavaScript's native [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) API.
+
+Here is an example on how to use it (together with [vue-i18n](https://vue-i18n.intlify.dev/)):
+
+::: details Expand code snippet
+
+```ts
+import { useI18n } from "vue-i18n";
+
+const { locale } = useI18n();
+
+const countryNames = computed(() => new Intl.DisplayNames(locale.value, { type: "region" }));
+const germany = computed(() => countryNames.value.of("DE"));
+// Output (depending on the locale):
+// "Germany" if locale is EN
+// "Deutschland" if locale is DE
+// ...
+```
+
+:::
+
+Alternatively, there is also metadata available for each flag exported from the `@sit-onyx/flags` package:
+
+::: details Expand code snippet
+
+```ts
+import { FLAG_METADATA } from "@sit-onyx/flags";
+
+console.log(FLAG_METADATA.DE);
+// Output: { internationalName: "Germany", continent: "Europe" }
+```
+
+:::
+
 ## Available flags
 
 You can hover over a flag to see its name. Click on it or press enter when selecting it via keyboard to copy the import statement for the selected flag.

--- a/apps/docs/src/flags.md
+++ b/apps/docs/src/flags.md
@@ -30,7 +30,7 @@ Afterwards, you can import and use flags as needed. Please see the [OnyxIcon](ht
 
 ## Country names
 
-You can get the country name of a flag in several languages using JavaScript's native [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) API.
+You can get the country name of a flag in several languages using JavaScript's [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) API.
 
 Here is an example on how to use it (together with [vue-i18n](https://vue-i18n.intlify.dev/)):
 


### PR DESCRIPTION
Relates to #2701

Add docs for how to get the country name of a flag

## Checklist

- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
