### PR TITLE
chore: add typerenderer custom option Story example

### DIFF
--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/CustomColumnTypes.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/CustomColumnTypes.vue
@@ -1,24 +1,16 @@
 <script setup lang="ts">
 import forward from "@sit-onyx/icons/forward.svg?raw";
 import { h } from "vue";
-import {
-  createFeature,
-  OnyxDataGrid,
-  OnyxSystemButton,
-  type ColumnConfig,
-  type ColumnGroupConfig,
-  type TypeRenderMap,
-} from "../../..";
+import { createFeature, OnyxDataGrid, OnyxSystemButton, type TypeRenderMap } from "../../..";
+import { createTypeRenderer } from "../features/renderer";
 
-type TEntry = {
+type Entry = {
   id: number;
   name: string;
   age: number;
 };
 
-type CustomType = "ageIcon" | "detailsButton";
-
-const data: TEntry[] = [
+const data: Entry[] = [
   { id: 1, name: "Alice", age: 10 },
   { id: 2, name: "Charlie", age: 35 },
   { id: 3, name: "Bob", age: 71 },
@@ -26,24 +18,23 @@ const data: TEntry[] = [
   { id: 5, name: "John", age: 42 },
 ];
 
-const columns: ColumnConfig<TEntry, ColumnGroupConfig, CustomType>[] = [
-  { key: "name", label: "Name", type: "string" },
-  { key: "age", label: "Age", type: "ageIcon" },
-  { key: "id", label: "", type: "detailsButton" },
-];
-
 // create a custom reusable data grid feature for custom types that you can also e.g. share / re-use in your project to be used in multiple data grids
 const withCustomType = createFeature(() => ({
   name: Symbol("example feature name"),
   typeRenderer: {
-    ageIcon: {
+    // use the `createTypeRenderer` function to create a type renderer with custom column type options
+    // all properties must be optional
+    ageIcon: createTypeRenderer<{ offset?: number }, Entry>({
       cell: {
-        component: (props) => {
-          const age = Number(props.modelValue);
+        component: ({ modelValue, metadata }) => {
+          // the custom column options are provided via `props.metadata.typeOptions`
+          const offset = metadata?.typeOptions?.offset ?? 0;
+
+          const age = Number(modelValue) + offset;
           return age < 15 ? "🐣" : age > 60 ? "🐉" : "🐍";
         },
       },
-    },
+    }),
     detailsButton: {
       cell: {
         tdAttributes: {
@@ -60,12 +51,20 @@ const withCustomType = createFeature(() => ({
         },
       },
     },
-  } satisfies TypeRenderMap<TEntry, CustomType>,
+  } satisfies TypeRenderMap<Entry>,
 }));
 
 const features = [withCustomType()];
 </script>
 
 <template>
-  <OnyxDataGrid :columns :data :features />
+  <OnyxDataGrid
+    :columns="[
+      { key: 'name', label: 'Name', type: 'string' },
+      { key: 'age', label: 'Age', type: { name: 'ageIcon', options: { offset: -5 } } },
+      { key: 'id', label: '', type: 'detailsButton' },
+    ]"
+    :data
+    :features
+  />
 </template>

--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/DefaultExample.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/DefaultExample.vue
@@ -19,7 +19,11 @@ const data: TEntry[] = [
 const columns: ColumnConfig<TEntry>[] = [
   { key: "name", label: "Name" },
   { key: "age", label: "Age", type: "number" },
-  { key: "birthday", label: "Birthday", type: "date" },
+  {
+    key: "birthday",
+    label: "Birthday",
+    type: { name: "date", options: { format: { dateStyle: "full" } } },
+  },
 ];
 </script>
 


### PR DESCRIPTION
Relates to #2783 

- added usage example for `createTypeRenderer`
- added example for base type renderer options