### PR TITLE
fix(OnyxStepper): correctly format 0 when used with precision

### DIFF
--- a/.changeset/good-oranges-heal.md
+++ b/.changeset/good-oranges-heal.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxStepper): correctly format 0 when used with precision

--- a/packages/sit-onyx/src/components/OnyxStepper/OnyxStepper.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxStepper/OnyxStepper.ct.tsx
@@ -2,6 +2,7 @@ import { DENSITIES } from "../../composables/density";
 import type { FormMessages } from "../../composables/useCustomValidity";
 import { expect, test } from "../../playwright/a11y";
 import { executeMatrixScreenshotTest } from "../../playwright/screenshots";
+import type { Nullable } from "../../types";
 import { createFormElementUtils } from "../OnyxFormElement/OnyxFormElement.ct-utils";
 import OnyxStepper from "./OnyxStepper.vue";
 
@@ -527,4 +528,30 @@ test("Should display an error if the value is not a multiple of validStepSize", 
   await expect(errorMessage).toContainText(
     "Please enter a valid number, that is a multiple of 0.5.",
   );
+});
+
+test("should format zero with precision", async ({ mount }) => {
+  let modelValue: Nullable<number>;
+
+  // ARRANGE
+  const component = await mount(
+    <OnyxStepper
+      label="Label"
+      precision={2}
+      onUpdate:modelValue={(newValue) => (modelValue = newValue)}
+    />,
+  );
+  const input = component.getByLabel("Label");
+
+  // ASSERT
+  await expect(input).toHaveValue("");
+  await expect(() => expect(modelValue).toBeUndefined()).toPass();
+
+  // ACT
+  await input.fill("0");
+  await input.blur();
+
+  // ASSERT
+  await expect(input).toHaveValue("0.00");
+  await expect(() => expect(modelValue).toBe(0)).toPass();
 });

--- a/packages/sit-onyx/src/components/OnyxStepper/OnyxStepper.vue
+++ b/packages/sit-onyx/src/components/OnyxStepper/OnyxStepper.vue
@@ -73,8 +73,9 @@ const modelValue = useVModel({
 const inputValue = ref<string>();
 
 const getFormattedValue = computed(() => {
-  return (value?: number | null) => {
-    if (props.precision !== undefined && value !== undefined && value !== null) {
+  return (value?: Nullable<number>) => {
+    // using "!=" here to check for both undefined and null
+    if (props.precision !== undefined && value != undefined) {
       return roundToPrecision(value, props.precision);
     } else {
       return value?.toString() ?? "";
@@ -96,7 +97,7 @@ const handleClick = (direction: "stepUp" | "stepDown") => {
 
 const handleChange = () => {
   wasTouched.value = true;
-  if (!inputValue.value) {
+  if (inputValue.value == undefined) {
     modelValue.value = undefined;
     return;
   }

--- a/packages/sit-onyx/src/utils/numbers.spec.ts
+++ b/packages/sit-onyx/src/utils/numbers.spec.ts
@@ -50,4 +50,8 @@ describe("roundToPrecision", () => {
   it("returns empty string if value is undefined", () => {
     expect(roundToPrecision(undefined, 2)).toBe("");
   });
+
+  it("rounds zero value when precision is set", () => {
+    expect(roundToPrecision(0, 2)).toBe("0.00");
+  });
 });

--- a/packages/sit-onyx/src/utils/numbers.ts
+++ b/packages/sit-onyx/src/utils/numbers.ts
@@ -24,8 +24,8 @@ export const applyLimits = (
  * @param precision - The number of decimal places for rounding (e.g., 0.01 for 2 decimals). Can also be negative.
  * @returns The rounded number as a string. Returns an empty string if `value` is `undefined`.
  */
-export const roundToPrecision = (value: number, precision: number): string => {
-  if (!value) return "";
+export const roundToPrecision = (value: number | undefined, precision: number): string => {
+  if (value == undefined) return "";
   if (precision >= 0) return value.toFixed(precision);
   const factor = Math.pow(10, precision);
   return (Math.round(value * factor) / factor).toString();


### PR DESCRIPTION
closes #3389

Fix current stepper bug where 0 is not correctly formatted when used with precision

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
