### PR TITLE
docs: fix broken "About illustrations" page

### DIFF
--- a/packages/sit-onyx/.storybook/pages/illustrations.mdx
+++ b/packages/sit-onyx/.storybook/pages/illustrations.mdx
@@ -1,3 +1,5 @@
+import { Meta } from "@storybook/blocks";
+
 {/* workaround for hiding the table of contents, see docs-template.scss file */}
 
 <div className="storybook-hide-toc"></div>


### PR DESCRIPTION
Fix the current [about illustrations](https://storybook.onyx.schwarz/?path=/docs/illustrations-about-illustrations--docs) Storybook page due to a missing import.
