### PR TITLE
feat(router): consider hash for active state

### DIFF
--- a/.changeset/polite-bags-send.md
+++ b/.changeset/polite-bags-send.md
@@ -3,3 +3,5 @@
 ---
 
 feat(router): consider hash for active state
+
+Also consider hashes when determining the active state of a link when a Vue Router is provided. E.g. the link `#some-headline` will now be active when the current route is `/page-1#some-headline`

--- a/.changeset/polite-bags-send.md
+++ b/.changeset/polite-bags-send.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(router): consider hash for active state

--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.spec-d.ts
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.spec-d.ts
@@ -13,8 +13,8 @@ import type OnyxTextarea from "../OnyxTextarea/OnyxTextarea.vue";
 import { type __DONT_USE_VUE_FIX_KeyOfFormProps, type FormProps } from "./OnyxForm.core";
 
 it("should be ensured that _KeyofFormProps includes all keys of FormProps", async () => {
-  expectTypeOf<keyof FormProps>().toMatchTypeOf<__DONT_USE_VUE_FIX_KeyOfFormProps>();
-  expectTypeOf<__DONT_USE_VUE_FIX_KeyOfFormProps>().toMatchTypeOf<keyof FormProps>();
+  expectTypeOf<keyof FormProps>().toExtend<__DONT_USE_VUE_FIX_KeyOfFormProps>();
+  expectTypeOf<__DONT_USE_VUE_FIX_KeyOfFormProps>().toExtend<keyof FormProps>();
 });
 
 type AllOnyxFormElements =
@@ -27,7 +27,7 @@ type AllOnyxFormElements =
   | typeof OnyxSwitch;
 
 it("should be ensured that all onyx form elements support the basic input props", async () => {
-  expectTypeOf<ComponentProps<AllOnyxFormElements>>().toMatchTypeOf<{
+  expectTypeOf<ComponentProps<AllOnyxFormElements>>().toExtend<{
     modelValue?: unknown;
     label: string;
     customError?: CustomMessageType;
@@ -35,7 +35,7 @@ it("should be ensured that all onyx form elements support the basic input props"
 });
 
 it("should be ensured that all onyx form elements expose the internal input", async () => {
-  expectTypeOf<ComponentExposed<AllOnyxFormElements>>().toMatchTypeOf<{
+  expectTypeOf<ComponentExposed<AllOnyxFormElements>>().toExtend<{
     input: (HTMLInputElement | HTMLTextAreaElement) | null | undefined;
   }>();
 });
@@ -43,7 +43,7 @@ it("should be ensured that all onyx form elements expose the internal input", as
 type AllOnyxFormGroups = typeof OnyxCheckboxGroup | typeof OnyxRadioGroup;
 
 it("should be ensured that all onyx form element groups expose the internal inputs", async () => {
-  expectTypeOf<ComponentExposed<AllOnyxFormGroups>>().toMatchTypeOf<{
+  expectTypeOf<ComponentExposed<AllOnyxFormGroups>>().toExtend<{
     inputs: HTMLInputElement[];
   }>();
 });

--- a/packages/sit-onyx/src/composables/useLink.spec-d.ts
+++ b/packages/sit-onyx/src/composables/useLink.spec-d.ts
@@ -3,5 +3,5 @@ import type { Router } from "vue-router";
 import type { ProvideRouterOptions } from "./useLink";
 
 test("OnProvideRouterOptions should match vue-router", async () => {
-  expectTypeOf<Router>().toMatchTypeOf<ProvideRouterOptions>();
+  expectTypeOf<Router>().toExtend<ProvideRouterOptions>();
 });

--- a/packages/sit-onyx/src/composables/useLink.spec.ts
+++ b/packages/sit-onyx/src/composables/useLink.spec.ts
@@ -28,6 +28,11 @@ describe("useLink", () => {
     { current: "/parent/child", link: "/parent/child", active: true },
     { current: "/parent/child", link: "/parent", active: true },
     { current: "/parent", link: "/parent/child", active: false },
+    // hashes
+    { current: "#some-hash", link: "#some-hash", active: true },
+    { current: { path: "/test", hash: "#some-hash" }, link: "#some-hash", active: true },
+    { current: "#some-hash", link: "#some-other-hash", active: false },
+    { current: { path: "/test", hash: "" }, link: "#some-hash", active: false },
   ])("should mark $link with current $current as active: $active", ({ current, link, active }) => {
     vi.spyOn(vue, "inject").mockImplementation((key) => {
       if (key !== ROUTER_INJECTION_KEY) return;

--- a/packages/sit-onyx/src/composables/useLink.ts
+++ b/packages/sit-onyx/src/composables/useLink.ts
@@ -57,8 +57,10 @@ export const useLink = () => {
 
       const href = normalizeHref(extractLinkProps(link).href);
       const path = normalizeHref(currentRoute.value.path);
+      const { hash } = currentRoute.value;
 
       if (href === "/") return path === href;
+      if (hash && hash === href) return true;
       return path.startsWith(href);
     };
   });
@@ -111,7 +113,7 @@ export type ProvideRouterOptions = {
    * Currently active route.
    * @see https://router.vuejs.org/api/interfaces/Router.html#currentRoute
    */
-  currentRoute: Ref<string | { path: string }>;
+  currentRoute: Ref<string | { path: string; hash?: string }>;
 };
 
 export const ROUTER_INJECTION_KEY = Symbol() as InjectionKey<ProvideRouterOptions>;


### PR DESCRIPTION
Relates to #3450

Also consider hashes when determining the active state of a link when a Vue Router is provided. E.g. the link `#some-headline` will now be active when the current route is `/page-1#some-headline`

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
