### PR TITLE
feat(OnyxTimer): expose `timeLeft`

### DIFF
--- a/.changeset/tall-jokes-relax.md
+++ b/.changeset/tall-jokes-relax.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxTimer): expose `timeLeft`

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxTimer/OnyxTimer.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxTimer/OnyxTimer.vue
@@ -27,6 +27,13 @@ const timeFormat = computed(
 const formattedTime = computed(() => formatTime(timeLeft.value, timeFormat.value));
 
 watchEffect(() => isEnded.value && emit("timerEnded"));
+
+defineExpose({
+  /**
+   * Time (in milliseconds) that the timer has left.
+   */
+  timeLeft,
+});
 </script>
 
 <template>

--- a/packages/sit-onyx/src/composables/useTimer.ts
+++ b/packages/sit-onyx/src/composables/useTimer.ts
@@ -1,4 +1,4 @@
-import { computed, onBeforeUnmount, ref, watch, type Ref } from "vue";
+import { computed, onBeforeUnmount, readonly, ref, watch, type Ref } from "vue";
 
 /**
  * Composable for managing a single timer.
@@ -36,7 +36,7 @@ export const useTimer = (endTime: Ref<ConstructorParameters<typeof Date>[0]>) =>
     /**
      * Time (in milliseconds) that the timer has left.
      */
-    timeLeft,
+    timeLeft: readonly(timeLeft),
     /**
      * Whether the timer is ended.
      */


### PR DESCRIPTION
closes #3518

Expose internal `timeLeft` (and make it readonly) so the project can use it for custom logic (e.g. do some action 30 seconds before the timer expires).

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
