### PR TITLE
docs(typography): clarify brand fonts imports and Nuxt usage

### DIFF
--- a/apps/docs/src/basics/typography.md
+++ b/apps/docs/src/basics/typography.md
@@ -14,9 +14,9 @@ Lidl and Kaufland font families are coming soon.
 
 ## Brand typography
 
-The default font family is defined to be the Source Sans and Source Code Pro (monospace). If you are creating a new onyx project, this will always be included out-of-the-box. In the initial phase, Source Sans applies to all color themes that are provided by onyx.
+The default font family is defined to be the Source Sans and Source Code Pro (monospace). If you are creating a new onyx project in Figma, this will always be included out-of-the-box. In the initial phase, Source Sans applies to all color themes that are provided by onyx.
 
-If you want to use custom font families, please take a look at the [technical documentation](/development/typography).
+If you want to use font families in development, please take a look at the [technical documentation](/development/typography).
 
 <script lang="ts" setup>
 import OnyxTypography from "../.vitepress/components/OnyxTypography.vue";

--- a/apps/docs/src/development/typography.md
+++ b/apps/docs/src/development/typography.md
@@ -39,6 +39,18 @@ import "@fontsource-variable/source-sans-3";
 
 :::
 
+or if you are using Nuxt, then import them in your `nuxt.config.ts`:
+
+::: code-group
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  css: ["@fontsource-variable/source-sans-3", "@fontsource-variable/source-code-pro"],
+});
+```
+
+:::
+
 For further information about the font families or installation, refer to the [Fontsource docs](https://fontsource.org).
 
 ## Using custom font families


### PR DESCRIPTION
Relates to #3621

Clarify typography docs as requested by the community in #3621 to clary that fonts must be installed and imported by the project.