### PR TITLE
feat(OnyxTable): set aria label of native table when headline slot is passed

### DIFF
--- a/.changeset/slick-beans-push.md
+++ b/.changeset/slick-beans-push.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxTable): set aria label of native table when headline slot is passed

--- a/apps/demo-app/src/views/DataGridView.vue
+++ b/apps/demo-app/src/views/DataGridView.vue
@@ -170,7 +170,13 @@ const dataFeatures = computed(() => {
       />
     </section>
 
-    <OnyxDataGrid :skeleton="enabledFeatures.skeleton" :features="dataFeatures" :data :columns />
+    <OnyxDataGrid
+      headline="Example headline"
+      :skeleton="enabledFeatures.skeleton"
+      :features="dataFeatures"
+      :data
+      :columns
+    />
   </OnyxPageLayout>
 </template>
 

--- a/packages/sit-onyx/src/components/OnyxTable/OnyxTable.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxTable/OnyxTable.ct.tsx
@@ -288,3 +288,18 @@ test("should focus components with active column hover effect", async ({ page, m
 
   expect(buttonClickCount).toBe(2);
 });
+
+test("should set table aria label when headline is passed", async ({ mount }) => {
+  // ARRANGE
+  const component = await mount(
+    <OnyxTable>
+      <template v-slot:headline>
+        <OnyxHeadline is="h3">Example headline</OnyxHeadline>
+      </template>
+    </OnyxTable>,
+  );
+
+  // ASSERT
+  await expect(component.getByRole("heading", { name: "Example headline" })).toBeAttached();
+  await expect(component.getByRole("table", { name: "Example headline" })).toBeAttached();
+});

--- a/packages/sit-onyx/src/components/OnyxTable/OnyxTable.vue
+++ b/packages/sit-onyx/src/components/OnyxTable/OnyxTable.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, useTemplateRef } from "vue";
+import { computed, useId, useTemplateRef } from "vue";
 import { useDensity } from "../../composables/density";
 import { useResizeObserver } from "../../composables/useResizeObserver";
 import { injectI18n } from "../../i18n";
@@ -15,25 +15,26 @@ const props = withDefaults(defineProps<OnyxTableProps>(), {
 const slots = defineSlots<OnyxTableSlots>();
 
 const { t } = injectI18n();
-
 const { densityClass } = useDensity(props);
 
 const isEmptyMessage = computed(() => t.value("table.empty"));
 
 const table = useTemplateRef("tableRef");
-
 const { height, width } = useResizeObserver(table);
 
 const style = computed(() => ({
   "--onyx-table-observed-height": `${height.value}px`,
   "--onyx-table-observed-width": `${width.value}px`,
 }));
+
+const _headlineId = useId();
+const headlineId = computed(() => (slots.headline ? _headlineId : undefined));
 </script>
 
 <template>
   <div class="onyx-table-wrapper onyx-component" :style>
     <div v-if="!!slots.headline || !!slots.actions" class="onyx-table-wrapper__top">
-      <div>
+      <div :id="headlineId">
         <slot name="headline"></slot>
       </div>
 
@@ -58,6 +59,7 @@ const style = computed(() => ({
           props.withVerticalBorders ? 'onyx-table--vertical-borders' : '',
           densityClass,
         ]"
+        :aria-labelledby="headlineId"
       >
         <colgroup
           v-for="group of props.columnGroups"


### PR DESCRIPTION
Relates to #3437

Set aria-labelledby for table and data grid when headline slot is passed

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
