### PR TITLE
fix(OnyxMiniSearch): fix text color with filled value in dark mode

### DIFF
--- a/.changeset/common-otters-leave.md
+++ b/.changeset/common-otters-leave.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxMiniSearch): fix text color with filled value in dark mode

--- a/packages/sit-onyx/src/components/OnyxMiniSearch/OnyxMiniSearch.vue
+++ b/packages/sit-onyx/src/components/OnyxMiniSearch/OnyxMiniSearch.vue
@@ -112,7 +112,7 @@ defineExpose({
       font-style: normal;
       flex-grow: 1;
       min-width: calc(var(--onyx-placeholder-character-count) * 1ch);
-      color: var(--onyx-color-text-icons-neutral-intense);
+      color: inherit;
 
       &::placeholder {
         color: var(--onyx-color-text-icons-neutral-soft);


### PR DESCRIPTION
The text color of the OnxyMiniSearch was not set correctly so it was very dark in dark mode which had very low contrast.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
