### PR TITLE
feat(OnyxFab): implement skeleton, fix z-index and export component

### DIFF
--- a/.changeset/thick-ads-fly.md
+++ b/.changeset/thick-ads-fly.md
@@ -2,4 +2,6 @@
 "sit-onyx": minor
 ---
 
-feat(OnyxFab): implement skeleton
+- feat(OnyxFab): implement skeleton
+- export OnyxFab, OnyxFabButton and OnyxFabItem component and types
+- fix(OnyxFab): set z-index correctly

--- a/.changeset/thick-ads-fly.md
+++ b/.changeset/thick-ads-fly.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxFab): implement skeleton

--- a/apps/demo-app/src/views/HomeView.vue
+++ b/apps/demo-app/src/views/HomeView.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import emojiHappy2 from "@sit-onyx/icons/emoji-happy-2.svg?raw";
+import placeholder from "@sit-onyx/icons/placeholder.svg?raw";
 import { useStorage } from "@vueuse/core";
 import {
   DENSITIES,
@@ -15,6 +16,8 @@ import {
   OnyxCheckboxGroup,
   OnyxDatePicker,
   OnyxEmpty,
+  OnyxFab,
+  OnyxFabItem,
   OnyxFilterTag,
   OnyxHeadline,
   OnyxIcon,
@@ -61,6 +64,7 @@ const COMPONENTS = [
   "OnyxCheckboxGroup",
   "OnyxDatePicker",
   "OnyxEmpty",
+  "OnyxFab",
   "OnyxHeadline",
   "OnyxIcon",
   "OnyxIconButton",
@@ -234,6 +238,12 @@ const currentProgressStep = ref(3);
         <OnyxDatePicker v-if="show('OnyxDatePicker')" v-model="selectedDate" label="Date picker" />
 
         <OnyxEmpty v-if="show('OnyxEmpty')">No data available</OnyxEmpty>
+
+        <OnyxFab v-if="show('OnyxFab')" label="Example label">
+          <OnyxFabItem :icon="placeholder" label="Action 3" />
+          <OnyxFabItem :icon="placeholder" label="Action 2" />
+          <OnyxFabItem :icon="placeholder" label="Action 1" />
+        </OnyxFab>
 
         <OnyxHeadline is="h1" v-if="show('OnyxHeadline')" hash="headline">Headline</OnyxHeadline>
 

--- a/packages/sit-onyx/src/components/OnyxFab/OnyxFab.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxFab/OnyxFab.ct.tsx
@@ -9,9 +9,15 @@ test.describe("Screenshot tests", () => {
   executeMatrixScreenshotTest({
     name: "Fab",
     columns: DENSITIES,
-    rows: ["default", "hover", "focus-visible"],
-    component: (column) => (
-      <OnyxFab label="Label" hideLabel={true} icon={mockPlaywrightIcon} density={column} />
+    rows: ["default", "hover", "focus-visible", "skeleton"],
+    component: (column, row) => (
+      <OnyxFab
+        label="Label"
+        hideLabel={true}
+        icon={mockPlaywrightIcon}
+        density={column}
+        skeleton={row === "skeleton"}
+      />
     ),
     hooks: {
       beforeEach: async (component, page, column, row) => {

--- a/packages/sit-onyx/src/components/OnyxFab/OnyxFab.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxFab/OnyxFab.stories.ts
@@ -80,3 +80,10 @@ export const LeftAligned = {
     alignment: "left",
   },
 } satisfies Story;
+
+export const Skeleton = {
+  args: {
+    ...Default.args,
+    skeleton: true,
+  },
+} satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxFab/OnyxFab.vue
+++ b/packages/sit-onyx/src/components/OnyxFab/OnyxFab.vue
@@ -98,6 +98,7 @@ const triggerIcon = computed(() => {
     position: fixed;
     bottom: var(--onyx-fab-viewport-gap);
     right: var(--onyx-fab-viewport-gap);
+    z-index: var(--onyx-z-index-notification);
 
     &:has(.onyx-popover__dialog--alignment-left) {
       right: unset;

--- a/packages/sit-onyx/src/components/OnyxFab/OnyxFab.vue
+++ b/packages/sit-onyx/src/components/OnyxFab/OnyxFab.vue
@@ -3,6 +3,10 @@ import moreHorizontalSmall from "@sit-onyx/icons/more-horizontal-small.svg?raw";
 import x from "@sit-onyx/icons/x.svg?raw";
 import { computed } from "vue";
 import { useDensity } from "../../composables/density.js";
+import {
+  SKELETON_INJECTED_SYMBOL,
+  useSkeletonContext,
+} from "../../composables/useSkeletonState.js";
 import { useVModel } from "../../composables/useVModel.js";
 import type { Nullable } from "../../types/index.js";
 import { mergeVueProps } from "../../utils/attrs.js";
@@ -12,6 +16,7 @@ import type { OnyxFabProps } from "./types.js";
 
 const props = withDefaults(defineProps<OnyxFabProps>(), {
   alignment: "right",
+  skeleton: SKELETON_INJECTED_SYMBOL,
 });
 
 const emit = defineEmits<{
@@ -29,6 +34,7 @@ const slots = defineSlots<{
 }>();
 
 const { densityClass } = useDensity(props);
+const skeleton = useSkeletonContext(props);
 
 /**
  * If the flyout is expanded or not.
@@ -49,8 +55,16 @@ const triggerIcon = computed(() => {
 </script>
 
 <template>
+  <OnyxFabButton
+    v-if="!hasOptions || skeleton"
+    class="onyx-fab"
+    v-bind="props"
+    :icon="triggerIcon"
+    :skeleton
+  />
+
   <OnyxFlyoutMenu
-    v-if="hasOptions"
+    v-else
     v-model:open="isExpanded"
     :label="props.label"
     trigger="click"
@@ -70,8 +84,6 @@ const triggerIcon = computed(() => {
       <slot name="default"></slot>
     </template>
   </OnyxFlyoutMenu>
-
-  <OnyxFabButton v-else class="onyx-fab" v-bind="props" :icon="triggerIcon" />
 </template>
 
 <style lang="scss">

--- a/packages/sit-onyx/src/components/OnyxFabButton/OnyxFabButton.vue
+++ b/packages/sit-onyx/src/components/OnyxFabButton/OnyxFabButton.vue
@@ -1,16 +1,27 @@
 <script lang="ts" setup>
 import { useDensity } from "../../composables/density.js";
+import {
+  SKELETON_INJECTED_SYMBOL,
+  useSkeletonContext,
+} from "../../composables/useSkeletonState.js";
 import ButtonOrLinkLayout from "../OnyxButton/ButtonOrLinkLayout.vue";
 import OnyxIcon from "../OnyxIcon/OnyxIcon.vue";
+import OnyxSkeleton from "../OnyxSkeleton/OnyxSkeleton.vue";
 import type { OnyxFabButtonProps } from "./types.js";
 
-const props = defineProps<OnyxFabButtonProps>();
+const props = withDefaults(defineProps<OnyxFabButtonProps>(), {
+  skeleton: SKELETON_INJECTED_SYMBOL,
+});
 
 const { densityClass } = useDensity(props);
+const skeleton = useSkeletonContext(props);
 </script>
 
 <template>
+  <OnyxSkeleton v-if="skeleton" :class="['onyx-fab-button-skeleton', densityClass]" />
+
   <ButtonOrLinkLayout
+    v-else
     :class="['onyx-component', 'onyx-fab-button', densityClass, 'onyx-text']"
     :title="props.hideLabel ? props.label : undefined"
     :aria-label="props.label"
@@ -24,13 +35,26 @@ const { densityClass } = useDensity(props);
 <style lang="scss">
 @use "../../styles/mixins/layers.scss";
 
-.onyx-fab-button {
+.onyx-fab-button,
+.onyx-fab-button-skeleton {
   @include layers.component() {
     --onyx-fab-button-background: var(--onyx-color-base-neutral-800);
     --onyx-fab-button-background-hover: var(--onyx-color-base-neutral-500);
     --onyx-fab-button-padding: var(--onyx-density-md);
     --onyx-fab-button-gap: var(--onyx-density-xs);
+  }
+}
 
+.onyx-fab-button-skeleton {
+  @include layers.component() {
+    width: calc(1.5rem + 2 * var(--onyx-fab-button-padding));
+    height: calc(1.5rem + 2 * var(--onyx-fab-button-padding));
+    border-radius: var(--onyx-radius-full);
+  }
+}
+
+.onyx-fab-button {
+  @include layers.component() {
     font-family: var(--onyx-font-family);
     background: var(--onyx-fab-button-background);
     border: none;

--- a/packages/sit-onyx/src/components/OnyxFabButton/types.ts
+++ b/packages/sit-onyx/src/components/OnyxFabButton/types.ts
@@ -1,4 +1,5 @@
 import type { DensityProp } from "../../composables/density.js";
+import type { SkeletonInjected } from "../../composables/useSkeletonState.js";
 import type { WithLinkProp } from "../OnyxRouterLink/types.js";
 
 export type OnyxFabButtonProps = DensityProp &
@@ -16,4 +17,8 @@ export type OnyxFabButtonProps = DensityProp &
      * Icon to show in the action button.
      */
     icon?: string;
+    /**
+     * Whether to show a skeleton button.
+     */
+    skeleton?: SkeletonInjected;
   };

--- a/packages/sit-onyx/src/index.ts
+++ b/packages/sit-onyx/src/index.ts
@@ -62,6 +62,15 @@ export * from "./components/OnyxDrawer/types.js";
 
 export { default as OnyxEmpty } from "./components/OnyxEmpty/OnyxEmpty.vue";
 
+export { default as OnyxFab } from "./components/OnyxFab/OnyxFab.vue";
+export * from "./components/OnyxFab/types.js";
+
+export { default as OnyxFabButton } from "./components/OnyxFabButton/OnyxFabButton.vue";
+export * from "./components/OnyxFabButton/types.js";
+
+export { default as OnyxFabItem } from "./components/OnyxFabItem/OnyxFabItem.vue";
+export * from "./components/OnyxFabItem/types.js";
+
 export { default as OnyxExternalLinkIcon } from "./components/OnyxExternalLinkIcon/OnyxExternalLinkIcon.vue";
 export * from "./components/OnyxExternalLinkIcon/types.js";
 


### PR DESCRIPTION
Relates to #3565

- feat(OnyxFab): implement skeleton
- export OnyxFab, OnyxFabButton and OnyxFabItem component and types
- fix(OnyxFab): set z-index correctly

## Checklist

<!-- If bullet points below do not apply to your changes (e.g. no documentation needed), just remove it. -->

- [ ] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [ ] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) or functional test is added
- [ ] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [ ] I have performed a self review of my code ("Files changed" tab in the pull request)
- [ ] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
