### PR TITLE
Joca96/3029 feat default sortings data grid

### DIFF
--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.spec.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { DEFAULT_COMPARES } from "./defaults.js";
+import { DEFAULT_COMPARES, TIME_COMPARE } from "./defaults.js";
 
 const OLDER_DATE = new Date(2021, 11, 31);
 const NEWER_DATE = new Date(2022, 0, 1);
@@ -20,7 +20,7 @@ test.for([
   expect(result).toBe(expected);
 });
 
-test.for(["date", "datetime-local", "time", "timestamp"] as const)(
+test.for(["datetime-local", "timestamp", "date"] as const)(
   "should compare dates correctly for type $0",
   (type) => {
     const collator = new Intl.Collator("de-DE");
@@ -29,3 +29,14 @@ test.for(["date", "datetime-local", "time", "timestamp"] as const)(
     expect(DEFAULT_COMPARES[type](OLDER_DATE, new Date(OLDER_DATE), collator)).toBe(0);
   },
 );
+
+test.for([
+  { a: new Date(2020, 0, 1, 12, 34, 56, 78), b: new Date(2020, 0, 1, 12, 34, 56, 78), expected: 0 },
+  { a: new Date(2019, 0, 1, 12, 34, 56, 78), b: new Date(2020, 0, 1, 12, 34, 56, 78), expected: 0 },
+  { a: new Date(2019, 0, 1, 12, 34, 56, 78), b: new Date(2020, 0, 1, 12, 34, 56, 0), expected: 1 },
+  { a: new Date(2019, 0, 1, 12, 34, 56, 0), b: new Date(2020, 0, 1, 12, 34, 56, 78), expected: -1 },
+])("should compare times correctly for $a and $b", ({ a, b, expected }) => {
+  const collator = new Intl.Collator("de-DE");
+  expect(Math.sign(TIME_COMPARE(a, b, collator))).toBeCloseTo(expected);
+  expect(Math.sign(TIME_COMPARE(b, a, collator) * -1)).toBeCloseTo(expected);
+});

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.spec.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { DEFAULT_COMPARES } from "./defaults.ts";
+import { DEFAULT_COMPARES } from "./defaults.js";
 
 const OLDER_DATE = new Date(2021, 11, 31);
 const NEWER_DATE = new Date(2022, 0, 1);

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.spec.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+import { DEFAULT_COMPARES } from "./defaults.ts";
+
+const OLDER_DATE = new Date(2021, 11, 31);
+const NEWER_DATE = new Date(2022, 0, 1);
+
+test.for([
+  { type: "string", a: "a", b: "a", expected: 0 },
+  { type: "string", a: "a", b: "b", expected: -1 },
+  { type: "string", a: "b", b: "a", expected: 1 },
+  { type: "string", a: "1", b: "a", expected: -1 },
+  { type: "number", a: 1, b: 1, expected: 0 },
+  { type: "number", a: 1, b: 2, expected: -1 },
+  { type: "number", a: 2, b: 1, expected: 1 },
+  { type: "skeleton", a: undefined, b: undefined, expected: 0 },
+  { type: "skeleton", a: 1, b: 2, expected: 0 },
+] as const)("should compare correctly for type $type", ({ type, a, b, expected }) => {
+  const collator = new Intl.Collator("de-DE");
+  const result = DEFAULT_COMPARES[type](a, b, collator);
+  expect(result).toBe(expected);
+});
+
+test.for(["date", "datetime-local", "time", "timestamp"] as const)(
+  "should compare dates correctly for type $0",
+  (type) => {
+    const collator = new Intl.Collator("de-DE");
+    expect(DEFAULT_COMPARES[type](NEWER_DATE, OLDER_DATE, collator)).toBeGreaterThanOrEqual(1);
+    expect(DEFAULT_COMPARES[type](OLDER_DATE, NEWER_DATE, collator)).toBeLessThanOrEqual(-1);
+    expect(DEFAULT_COMPARES[type](OLDER_DATE, new Date(OLDER_DATE), collator)).toBe(0);
+  },
+);

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.ts
@@ -1,6 +1,6 @@
-import type { DataGridEntry } from "../../types.ts";
-import type { DefaultSupportedTypes } from "../index.ts";
-import type { Compare } from "./types.ts";
+import type { DataGridEntry } from "../../types.js";
+import type { DefaultSupportedTypes } from "../index.js";
+import type { Compare } from "./types.js";
 
 export const STRING_COMPARE = (a: unknown, b: unknown, collator: Intl.Collator) =>
   collator.compare(String(a), String(b));

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.ts
@@ -7,12 +7,33 @@ export const STRING_COMPARE = (a: unknown, b: unknown, collator: Intl.Collator) 
 
 export const NUMBER_COMPARE = (a: unknown, b: unknown) => Number(a) - Number(b);
 
+const toComparableTime = (date: Date) =>
+  new Date(
+    Date.UTC(
+      0,
+      0,
+      1,
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds(),
+    ),
+  );
+export const TIME_COMPARE = (a: unknown, b: unknown, collator: Intl.Collator) => {
+  if (!(a instanceof Date && b instanceof Date)) {
+    return STRING_COMPARE(a, b, collator);
+  }
+  const dateA = toComparableTime(a);
+  const dateB = toComparableTime(b);
+  return NUMBER_COMPARE(dateA, dateB);
+};
+
 export const DEFAULT_COMPARES: Record<PropertyKey, Compare<unknown>> = Object.freeze({
   string: STRING_COMPARE,
   number: NUMBER_COMPARE,
   date: NUMBER_COMPARE,
   "datetime-local": NUMBER_COMPARE,
-  time: NUMBER_COMPARE,
+  time: TIME_COMPARE,
   timestamp: NUMBER_COMPARE,
   skeleton: () => 0,
 }) satisfies Record<DefaultSupportedTypes, Compare<DataGridEntry>>;

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.ts
@@ -1,0 +1,18 @@
+import type { DataGridEntry } from "../../types.ts";
+import type { DefaultSupportedTypes } from "../index.ts";
+import type { Compare } from "./types.ts";
+
+export const STRING_COMPARE = (a: unknown, b: unknown, collator: Intl.Collator) =>
+  collator.compare(String(a), String(b));
+
+export const NUMBER_COMPARE = (a: unknown, b: unknown) => Number(a) - Number(b);
+
+export const DEFAULT_COMPARES: Record<PropertyKey, Compare<unknown>> = Object.freeze({
+  string: STRING_COMPARE,
+  number: NUMBER_COMPARE,
+  date: NUMBER_COMPARE,
+  "datetime-local": NUMBER_COMPARE,
+  time: NUMBER_COMPARE,
+  timestamp: NUMBER_COMPARE,
+  skeleton: () => 0,
+}) satisfies Record<DefaultSupportedTypes, Compare<DataGridEntry>>;

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/sorting.spec.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/sorting.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "vitest";
 import * as vue from "vue";
 import { ref } from "vue";
-import type { DataGridEntry } from "../../types/index.js";
-import { createFeatureContextMock } from "../index.spec";
+import type { DataGridEntry } from "../../types.js";
+import { createFeatureContextMock } from "../index.spec.js";
 import { useSorting } from "./sorting.js";
 import type { SortOptions, SortState } from "./types.js";
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/types.ts
@@ -48,4 +48,9 @@ export type SortOptions<TEntry extends DataGridEntry> = DataGridFeatureOptions<
    * The currently applied sorting. Will be updated by the data grid, can be used for reading, updating and watching the applied sorting.
    */
   sortState?: MaybeRef<SortState<TEntry>>;
+  /**
+   * The `Intl.Collator` used for the default (string-based) sorting.
+   * Defaults to `new Intl.Collator(i18n.locale.value, { numeric: true })` where `i18n` is the OnyxI18n instance.
+   */
+  collator?: MaybeRef<Intl.Collator>;
 };

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/types.ts
@@ -9,7 +9,7 @@ export type SortDirection = "asc" | "desc" | "none";
  * The returned number value indicates the relative order of two values:
  * -1: less than, 0: equal to, 1: greater than
  */
-export type Compare<T> = (a: T, b: T) => number;
+export type Compare<T> = (a: T, b: T, collator: Intl.Collator) => number;
 
 /**
  * The values by which the data is currently sorted.

--- a/packages/sit-onyx/src/utils/feature.ts
+++ b/packages/sit-onyx/src/utils/feature.ts
@@ -1,5 +1,5 @@
 export type SingleOrderableMapping<T, TOutput = T, TInput = Readonly<TOutput>> = {
-  func: (input: TInput) => TOutput;
+  func: (input: TInput) => TInput | TOutput;
   order?: number;
 };
 


### PR DESCRIPTION
Relates to #3029 

- implement default sortings for our default types
- add extra `TIME_COMPARE` function, which ignores the date and just compares time