### PR TITLE
docs: fix import path in code snippets

### DIFF
--- a/packages/sit-onyx/src/components/examples/NotificationCenter/NotificationCenter.stories.ts
+++ b/packages/sit-onyx/src/components/examples/NotificationCenter/NotificationCenter.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta<typeof NotificationCenter> = {
     layout: "fullscreen",
     docs: {
       source: {
-        code: NotificationCenterCode.replace('from "../../.."', 'from "sit-onyx"'),
+        code: NotificationCenterCode.replace('from "../../../index.js"', 'from "sit-onyx"'),
       },
     },
     controls: {

--- a/packages/sit-onyx/src/components/examples/NotificationCenter/NotificationCenter.vue
+++ b/packages/sit-onyx/src/components/examples/NotificationCenter/NotificationCenter.vue
@@ -6,10 +6,6 @@ import inbox from "@sit-onyx/icons/inbox.svg?raw";
 import settings from "@sit-onyx/icons/settings.svg?raw";
 import { computed, ref } from "vue";
 import {
-  SKELETON_INJECTED_SYMBOL,
-  useSkeletonContext,
-} from "../../../composables/useSkeletonState.js";
-import {
   OnyxAccordion,
   OnyxAccordionItem,
   OnyxAppLayout,
@@ -28,7 +24,9 @@ import {
   OnyxNotificationDot,
   OnyxNotifications,
   OnyxUserMenu,
+  SKELETON_INJECTED_SYMBOL,
   useNotification,
+  useSkeletonContext,
   type OnyxNotificationCardProps,
 } from "../../../index.js";
 
@@ -41,10 +39,13 @@ type MyNotification = OnyxNotificationCardProps & {
    */
   description: string;
 };
+
 const props = withDefaults(defineProps<MyNotification>(), {
   skeleton: SKELETON_INJECTED_SYMBOL,
 });
+
 const skeleton = useSkeletonContext(props);
+
 /**
  * Store that will persist all user notifications of the application.
  * In a real project, this could e.g. be a pinia store.

--- a/packages/sit-onyx/src/index.ts
+++ b/packages/sit-onyx/src/index.ts
@@ -232,6 +232,7 @@ export * from "./composables/density.js";
 export * from "./composables/scrollEnd.js";
 export * from "./composables/themeTransition.js";
 export * from "./composables/useLink.js";
+export * from "./composables/useSkeletonState.js";
 
 export { provideI18n, type TranslationFunction } from "./i18n/index.js";
 export type { OnyxTranslations, ProvideI18nOptions } from "./i18n/index.js";

--- a/packages/sit-onyx/src/utils/storybook.ts
+++ b/packages/sit-onyx/src/utils/storybook.ts
@@ -102,7 +102,7 @@ export function createAdvancedStoryExample(componentName: string, exampleName: s
     parameters: {
       docs: {
         source: {
-          code: codeSnippet.replace('from "../../.."', 'from "sit-onyx"'),
+          code: codeSnippet.replace(/from "(\.\.\/)+\w*\.?\w*"/, 'from "sit-onyx"'),
         },
       },
       controls: {


### PR DESCRIPTION
Due to the change of pure ESM package, our Storybook code snippets are currently not showing the correct import paths from "sit-onyx"
<img width="577" height="121" alt="Bildschirmfoto 2025-07-16 um 09 59 31" src="https://github.com/user-attachments/assets/2ab38b05-b037-4533-aa80-0fa75fa91246" />