### PR TITLE
fix(OnyxTextarea): fix invisible overflow

### DIFF
--- a/.changeset/light-mirrors-jump.md
+++ b/.changeset/light-mirrors-jump.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxTextarea): fix invisible overflow causing growing page height for large inputs

--- a/packages/sit-onyx/src/components/OnyxTextarea/OnyxTextarea.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxTextarea/OnyxTextarea.ct.tsx
@@ -1,8 +1,8 @@
 import { DENSITIES } from "../../composables/density.js";
-import { testMaxLengthBehavior } from "../../composables/useLenientMaxLengthValidation.ct-utils";
+import { testMaxLengthBehavior } from "../../composables/useLenientMaxLengthValidation.ct-utils.js";
 import { expect, test } from "../../playwright/a11y.js";
 import { executeMatrixScreenshotTest } from "../../playwright/screenshots.js";
-import { createFormElementUtils } from "../OnyxFormElement/OnyxFormElement.ct-utils";
+import { createFormElementUtils } from "../OnyxFormElement/OnyxFormElement.ct-utils.js";
 import OnyxTextarea from "./OnyxTextarea.vue";
 
 test.describe("Screenshot tests", () => {

--- a/packages/sit-onyx/src/components/OnyxTextarea/OnyxTextarea.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxTextarea/OnyxTextarea.ct.tsx
@@ -518,7 +518,7 @@ test("should not cause the page to grow for large inputs", async ({ mount, page 
   const textarea = component.getByLabel("Label");
   const textareaBb = await textarea.boundingBox();
   const pageHeight = await page.locator("body").evaluate((e) => e.scrollHeight);
-  expect(pageHeight).toBeCloseTo(textareaBb!.height, 2);
+  expect(pageHeight).toBeCloseTo(textareaBb!.height, -2);
 });
 
 testMaxLengthBehavior(OnyxTextarea);

--- a/packages/sit-onyx/src/components/OnyxTextarea/OnyxTextarea.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxTextarea/OnyxTextarea.ct.tsx
@@ -510,4 +510,15 @@ test("should show correct message", async ({ mount }) => {
   await expect(errorMessageElement).toBeVisible();
 });
 
+test("should not cause the page to grow for large inputs", async ({ mount, page }) => {
+  // Bug #3797 https://github.com/SchwarzIT/onyx/issues/3797
+  const modelValue = "Zaphod Beeblebrox\n".repeat(1028);
+  const component = await mount(<OnyxTextarea label="Label" required modelValue={modelValue} />);
+
+  const textarea = component.getByLabel("Label");
+  const textareaBb = await textarea.boundingBox();
+  const pageHeight = await page.locator("body").evaluate((e) => e.scrollHeight);
+  expect(pageHeight).toBeCloseTo(textareaBb!.height, 2);
+});
+
 testMaxLengthBehavior(OnyxTextarea);

--- a/packages/sit-onyx/src/components/OnyxTextarea/OnyxTextarea.vue
+++ b/packages/sit-onyx/src/components/OnyxTextarea/OnyxTextarea.vue
@@ -169,18 +169,6 @@ useAutofocus(input, props);
   @include input.define-skeleton-styles($height: var(--min-height));
 }
 
-/**
-* Styles that are shared between the <textarea> and the ::after element of the wrapper
-* that is used for the autosize feature.
-*/
-@mixin define-shared-autosize-styles() {
-  grid-area: 1 / 1;
-  height: 100%;
-  min-height: var(--min-height);
-  max-height: var(--max-height);
-  padding: var(--onyx-textarea-padding-vertical) var(--onyx-density-sm);
-}
-
 .onyx-textarea {
   @include layers.component() {
     @include input.define-shared-styles(
@@ -195,17 +183,29 @@ useAutofocus(input, props);
 
       // auto-resize, based on: https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas
       &::after {
-        @include define-shared-autosize-styles;
         /* Note the weird space! Needed to prevent jumpy behavior */
         content: attr(data-autosize-value) " ";
         white-space: pre-wrap; // this is how textarea text behaves
         visibility: hidden; // hidden from view, clicks, and screen readers
         overflow-wrap: anywhere;
+        overflow-y: hidden;
       }
     }
 
+    /**
+     * Styles that are shared between the <textarea> and the ::after element of the wrapper
+     * that is used for the autosize feature.
+     */
+    &__wrapper:after,
     &__native {
-      @include define-shared-autosize-styles;
+      grid-area: 1 / 1;
+      height: 100%;
+      min-height: var(--min-height);
+      max-height: var(--max-height);
+      padding: var(--onyx-textarea-padding-vertical) var(--onyx-density-sm);
+    }
+
+    &__native {
       resize: vertical;
 
       &--no-resize {


### PR DESCRIPTION
Closes #3797

Cause: We use a invisible pseudo element which duplicates the input text as reference element to determine the wanted textarea height (Because replaced elements are weird). The pseudo element had a `max-height`, but text can grow outside anyways, which caused the page height grow.

Fix: Add an `overflow-y` restriction.
