### PR TITLE
fix(import-variables): correctly get theme name when combinesDarkLight is enabled

### DIFF
--- a/.changeset/lazy-llamas-lose.md
+++ b/.changeset/lazy-llamas-lose.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/figma-utils": patch
+---
+
+fix(import-variables): correctly get theme name when combinesDarkLight is enabled

--- a/.changeset/lazy-llamas-lose.md
+++ b/.changeset/lazy-llamas-lose.md
@@ -3,3 +3,5 @@
 ---
 
 fix(import-variables): correctly get theme name when combinesDarkLight is enabled
+
+Previously the mode name was determined by using the part before the first "-" character which does not work correctly if the theme/mode name itself contains dashes.

--- a/packages/figma-utils/src/commands/import-variables.ts
+++ b/packages/figma-utils/src/commands/import-variables.ts
@@ -118,7 +118,7 @@ export async function importVariablesCommandAction(options: ImportVariablesComma
 
       const baseName = getBaseFileName(data.modeName);
       if (options.combinesDarkLight) {
-        const themeName = baseName.split("-")[0];
+        const themeName = baseName.replace("-light", "").replace("-dark", "");
         const fullPath = path.join(outputDirectory, `${themeName}.${format.toLowerCase()}`);
 
         // find the matching theme

--- a/packages/sit-onyx/src/styles/variables/density-compact.css
+++ b/packages/sit-onyx/src/styles/variables/density-compact.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "compact" theme.
- * Imported from Figma API on Mon, 28 Jul 2025 13:14:05 GMT
+ * Imported from Figma API on Tue, 29 Jul 2025 06:23:58 GMT
  */
 :where(.onyx-density-compact) {
   --onyx-density-2xl: var(--onyx-number-spacing-600);

--- a/packages/sit-onyx/src/styles/variables/density-cozy.css
+++ b/packages/sit-onyx/src/styles/variables/density-cozy.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "cozy" theme.
- * Imported from Figma API on Mon, 28 Jul 2025 13:14:05 GMT
+ * Imported from Figma API on Tue, 29 Jul 2025 06:23:58 GMT
  */
 :where(.onyx-density-cozy) {
   --onyx-density-2xl: var(--onyx-number-spacing-800);

--- a/packages/sit-onyx/src/styles/variables/density-default.css
+++ b/packages/sit-onyx/src/styles/variables/density-default.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "default" theme.
- * Imported from Figma API on Mon, 28 Jul 2025 13:13:28 GMT
+ * Imported from Figma API on Tue, 29 Jul 2025 06:23:24 GMT
  */
 :where(:root),
 :where(.onyx-density-default) {

--- a/packages/sit-onyx/src/styles/variables/spacing.css
+++ b/packages/sit-onyx/src/styles/variables/spacing.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "spacing" theme.
- * Imported from Figma API on Mon, 28 Jul 2025 13:12:50 GMT
+ * Imported from Figma API on Tue, 29 Jul 2025 06:22:39 GMT
  */
 :where(:root) {
   --onyx-spacing-2xl: var(--onyx-number-spacing-700);

--- a/packages/sit-onyx/src/styles/variables/themes/onyx.css
+++ b/packages/sit-onyx/src/styles/variables/themes/onyx.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "onyx" theme.
- * Imported from Figma API on Mon, 28 Jul 2025 13:12:13 GMT
+ * Imported from Figma API on Tue, 29 Jul 2025 06:22:05 GMT
  */
 :where(:root),
 .onyx-theme-default {

--- a/packages/sit-onyx/src/styles/variables/themes/value.css
+++ b/packages/sit-onyx/src/styles/variables/themes/value.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "value" theme.
- * Imported from Figma API on Mon, 28 Jul 2025 13:12:13 GMT
+ * Imported from Figma API on Tue, 29 Jul 2025 06:22:05 GMT
  */
 :where(:root),
 .onyx-theme-default {


### PR DESCRIPTION
Relates to #3650

The base theme name was not determined correctly, e.g. "schwarzgroup-scos-light" was set to "schwarzgroup" only instead of "schwarzgroup-scos"

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
