### PR TITLE
docs: rename scos theme to schwarz group and scos

### DIFF
--- a/apps/docs/src/development/theming.md
+++ b/apps/docs/src/development/theming.md
@@ -13,7 +13,7 @@ If you are an Schwarz employee and want to access one the following themes, plea
 - Kaufland
 - Lidl
 - PreZero
-- Schwarz corporate solutions
+- Schwarz group and Schwarz corporate solutions
 
 If you have any other questions or need support, please get in touch with the [team](/about/team).
 


### PR DESCRIPTION
Relates to #3650

Update docs to rename the scos theme to schwarz group + scos
