### PR TITLE
fix(nuxt): always provide onyx plugin

### DIFF
--- a/.changeset/twelve-boxes-rest.md
+++ b/.changeset/twelve-boxes-rest.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt": patch
+---
+
+fix(nuxt): always provide onyx plugin

--- a/.changeset/twelve-boxes-rest.md
+++ b/.changeset/twelve-boxes-rest.md
@@ -3,3 +3,6 @@
 ---
 
 fix(nuxt): always provide onyx plugin
+
+Previously, the onyx plugin was only registered if Nuxt I18n was used.
+This caused the issue that the router integration did not work when not using i18n.

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -85,9 +85,9 @@ export default defineNuxtModule<ModuleOptions>({
       };
 
       nuxt.hook("i18n:registerModule", registerOnyxLocales);
-
-      addPlugin({ src: resolve("./runtime/plugins/onyx") });
     }
+
+    addPlugin({ src: resolve("./runtime/plugins/onyx") });
   },
 });
 

--- a/packages/nuxt/src/runtime/plugins/onyx.ts
+++ b/packages/nuxt/src/runtime/plugins/onyx.ts
@@ -2,32 +2,30 @@ import { computed, type ComputedRef } from "#imports";
 import type { LocaleObject } from "@nuxtjs/i18n";
 import { defineNuxtPlugin, useNuxtApp, useRouter } from "nuxt/app";
 import { createOnyx, type TranslationFunction } from "sit-onyx";
-import type { Composer } from "vue-i18n";
+import { type Composer } from "vue-i18n";
 
 type I18n = Composer & { localeProperties: ComputedRef<LocaleObject> };
 
 export default defineNuxtPlugin({
   name: "onyx:plugin",
-  // @ts-ignore: dependency comes from @nuxtjs/i18n
-  dependsOn: ["i18n:plugin"],
+  dependsOn: [],
   setup: (app) => {
-    // This plugin is only added if the i18n module was added as well so it's safe to assume $i18n was provided
-    const { t: translate, localeProperties } = useNuxtApp().$i18n as I18n;
+    const i18n = useNuxtApp().$i18n as I18n | undefined;
     const router = useRouter();
-
-    const t = computed((): TranslationFunction => {
-      return (key, placeholders) => {
-        return translate(`onyx.${key}`, placeholders?.n ?? 1, { named: placeholders });
-      };
-    });
 
     app.vueApp.use(
       createOnyx({
-        i18n: {
-          locale: computed(() => localeProperties.value.language ?? "en-US"),
-          t,
-        },
         router,
+        i18n: i18n
+          ? {
+              locale: computed(() => i18n.localeProperties.value.language ?? "en-US"),
+              t: computed((): TranslationFunction => {
+                return (key, placeholders) => {
+                  return i18n.t(`onyx.${key}`, placeholders?.n ?? 1, { named: placeholders });
+                };
+              }),
+            }
+          : undefined,
       }),
     );
   },


### PR DESCRIPTION
Previously, the onyx plugin was only registered if Nuxt I18n was used.
This caused the issue that the router integration did not work when not using i18n.


## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
