### PR TITLE
feat: update onyx icon code replacement to use JavaScript instead of raw SVG imports

### DIFF
--- a/.changeset/petite-waves-cut.md
+++ b/.changeset/petite-waves-cut.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/storybook-utils": minor
+---
+
+feat: update onyx icon code replacement to use JavaScript instead of raw SVG imports

--- a/.changeset/wild-forks-burn.md
+++ b/.changeset/wild-forks-burn.md
@@ -1,0 +1,6 @@
+---
+"@sit-onyx/flags": patch
+"@sit-onyx/icons": patch
+---
+
+fix declaration of "sideEffects" in package.json

--- a/packages/flags/package.json
+++ b/packages/flags/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "author": "Schwarz IT KG",
   "license": "Apache-2.0",
-  "sideEffects": "false",
+  "sideEffects": false,
   "engines": {
     "node": ">=20"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "author": "Schwarz IT KG",
   "license": "Apache-2.0",
-  "sideEffects": "false",
+  "sideEffects": false,
   "engines": {
     "node": ">=20"
   },

--- a/packages/storybook-utils/src/preview.spec.ts
+++ b/packages/storybook-utils/src/preview.spec.ts
@@ -1,14 +1,12 @@
-import bellRing from "@sit-onyx/icons/bell-ring.svg?raw";
-import calendar from "@sit-onyx/icons/calendar.svg?raw";
-import placeholder from "@sit-onyx/icons/placeholder.svg?raw";
+import { iconBellRing, iconCalendar, iconPlaceholder } from "@sit-onyx/icons";
 import { describe, expect, test } from "vitest";
 import { replaceAll, sourceCodeTransformer } from "./preview.js";
 
 describe("preview.ts", () => {
-  test("should transform source code and add icon/onyx imports", () => {
+  test("should transform source code and add icon/onyx imports", async () => {
     // ACT
-    const sourceCode = sourceCodeTransformer(`<template>
-<OnyxTest icon='${placeholder}' test='${bellRing}' :obj="{foo:'${replaceAll(calendar, '"', "\\'")}'}" />
+    const sourceCode = await sourceCodeTransformer(`<template>
+<OnyxTest icon='${iconPlaceholder}' test='${iconBellRing}' :obj="{foo:'${replaceAll(iconCalendar, '"', "\\'")}'}" />
 <OnyxOtherComponent />
 <OnyxComp>Test</OnyxComp>
 </template>`);
@@ -16,13 +14,11 @@ describe("preview.ts", () => {
     // ASSERT
     expect(sourceCode).toBe(`<script lang="ts" setup>
 import { OnyxComp, OnyxOtherComponent, OnyxTest } from "sit-onyx";
-import bellRing from "@sit-onyx/icons/bell-ring.svg?raw";
-import calendar from "@sit-onyx/icons/calendar.svg?raw";
-import placeholder from "@sit-onyx/icons/placeholder.svg?raw";
+import { iconBellRing, iconCalendar, iconPlaceholder } from "@sit-onyx/icons";
 </script>
 
 <template>
-<OnyxTest :icon="placeholder" :test="bellRing" :obj="{foo:calendar}" />
+<OnyxTest :icon="iconPlaceholder" :test="iconBellRing" :obj="{foo:iconCalendar}" />
 <OnyxOtherComponent />
 <OnyxComp>Test</OnyxComp>
 </template>`);

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -1,4 +1,3 @@
-import { getIconImportName } from "@sit-onyx/icons/utils";
 import type { Preview } from "@storybook/vue3-vite";
 import { DARK_MODE_EVENT_NAME } from "@vueless/storybook-dark-mode";
 import { deepmerge } from "deepmerge-ts";
@@ -132,51 +131,43 @@ export const createPreview = <T extends Preview = Preview>(
  *
  * @see https://storybook.js.org/docs/react/api/doc-block-source
  */
-export const sourceCodeTransformer = (originalSourceCode: string): string => {
-  const RAW_ICONS = import.meta.glob("../node_modules/@sit-onyx/icons/src/assets/*.svg", {
-    query: "?raw",
-    import: "default",
-    eager: true,
-  });
+export const sourceCodeTransformer = async (originalSourceCode: string): Promise<string> => {
+  const ALL_ICONS = await import("@sit-onyx/icons");
 
   let code = originalSourceCode;
-
-  /**
-   * Mapping between icon SVG content (key) and icon name (value).
-   * Needed to display a labelled dropdown list of all available icons.
-   */
-  const ALL_ICONS = Object.entries(RAW_ICONS).reduce<Record<string, string>>(
-    (obj, [filePath, content]) => {
-      obj[filePath.split("/").at(-1)!.replace(".svg", "")] = content as string;
-      return obj;
-    },
-    {},
-  );
 
   const additionalImports: string[] = [];
 
   // add icon imports to the source code for all used onyx icons
+  const usedIcons = new Set<string>();
+
   Object.entries(ALL_ICONS).forEach(([iconName, iconContent]) => {
-    const importName = getIconImportName(iconName);
     const singleQuotedIconContent = `'${replaceAll(iconContent, '"', "\\'")}'`;
     const escapedIconContent = `"${replaceAll(iconContent, '"', '\\"')}"`;
 
     if (code.includes(iconContent)) {
+      usedIcons.add(iconName);
+
       code = code.replace(
         new RegExp(` (\\S+)=['"]${escapeRegExp(iconContent)}['"]`),
-        ` :$1="${importName}"`,
+        ` :$1="${iconName}"`,
       );
-      additionalImports.push(`import ${importName} from "@sit-onyx/icons/${iconName}.svg?raw";`);
     } else if (code.includes(singleQuotedIconContent)) {
       // support icons inside objects
-      code = code.replace(singleQuotedIconContent, importName);
-      additionalImports.push(`import ${importName} from "@sit-onyx/icons/${iconName}.svg?raw";`);
+      usedIcons.add(iconName);
+      code = code.replace(singleQuotedIconContent, iconName);
     } else if (code.includes(escapedIconContent)) {
       // support icons inside objects
-      code = code.replace(escapedIconContent, importName);
-      additionalImports.push(`import ${importName} from "@sit-onyx/icons/${iconName}.svg?raw";`);
+      usedIcons.add(iconName);
+      code = code.replace(escapedIconContent, iconName);
     }
   });
+
+  if (usedIcons.size > 0) {
+    additionalImports.push(
+      `import { ${Array.from(usedIcons.values()).sort().join(", ")} } from "@sit-onyx/icons";`,
+    );
+  }
 
   // add imports for all used onyx components
   // Set is used here to only include unique components if they are used multiple times


### PR DESCRIPTION
<!-- Is your PR related to an issue? Then please link it via the "Relates to #" below. Else, remove it. -->

closes #3836
relates to #1802

The usage of "getIconImportName" in our Storybook utils seemed to break the deployed Storybook (see #1802). Weirdly, the utility works totally fine when used with Vitest or in our documentation.

Regardlessly, we want to update the Storybook utils anyways in #3836 to use the new JavaScript imports for the code snippets instead of raw SVG imports. This was implemented in this PR so the "getIconImportName" utility is no longer needed and therefore the deployed Storybook works fine again.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
