### PR TITLE
feat: update docs and Storybook utils for icons and flags

### DIFF
--- a/.changeset/social-terms-look.md
+++ b/.changeset/social-terms-look.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/flags": minor
+---
+
+feat: add `getFlagImportName` utility

--- a/.changeset/thick-cows-fetch.md
+++ b/.changeset/thick-cows-fetch.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/icons": major
+---
+
+feat: update `getIconImportName` utility to return the JavaScript import name instead of raw SVG import name

--- a/.changeset/thick-cows-fetch.md
+++ b/.changeset/thick-cows-fetch.md
@@ -3,3 +3,5 @@
 ---
 
 feat: update `getIconImportName` utility to return the JavaScript import name instead of raw SVG import name
+
+The utility will now return the JavaScript import name (e.g. iconBellDisabled) instead of the raw SVG import name (bellDisabled)

--- a/.changeset/tidy-lights-drive.md
+++ b/.changeset/tidy-lights-drive.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/storybook-utils": minor
+---
+
+feat: replace flags in source code snippets that are imported from `@sit-onyx/flags` with corresponding import statements

--- a/apps/docs/src/.vitepress/components/AssetLibrary.vue
+++ b/apps/docs/src/.vitepress/components/AssetLibrary.vue
@@ -1,18 +1,18 @@
-<script lang="ts" setup>
+<script lang="ts" setup generic="TData">
 import { normalizedIncludes, OnyxEmpty, OnyxHeadline, OnyxInput } from "sit-onyx";
 import { computed, ref } from "vue";
 
-export type AssetLibraryProps = {
-  groups: AssetLibraryGroup[];
+export type AssetLibraryProps<TData = unknown> = {
+  groups: AssetLibraryGroup<TData>[];
   searchPlaceholder: string;
 };
 
-export type AssetLibraryGroup = {
+export type AssetLibraryGroup<TData = unknown> = {
   name: string;
-  assets: Asset[];
+  assets: Asset<TData>[];
 };
 
-export type Asset = {
+export type Asset<TData = unknown> = {
   /**
    * Unique ID of the asset.
    *
@@ -29,15 +29,19 @@ export type Asset = {
    * Optional alias names of the asset what can be searched by to find the asset.
    */
   aliases?: string[];
+  /**
+   * Optional custom data to be associated with the asset.
+   */
+  data?: TData;
 };
 
-const props = defineProps<AssetLibraryProps>();
+const props = defineProps<AssetLibraryProps<TData>>();
 
 defineSlots<{
   /**
    * Slot to render an individual asset item.
    */
-  item(props: { asset: Asset }): unknown;
+  item(props: { asset: Asset<TData> }): unknown;
 }>();
 
 const search = ref("");

--- a/apps/docs/src/.vitepress/components/OnyxFlagLibrary.vue
+++ b/apps/docs/src/.vitepress/components/OnyxFlagLibrary.vue
@@ -1,40 +1,35 @@
 <script lang="ts" setup>
-import { FLAG_METADATA, groupFlagsByContinent } from "@sit-onyx/flags/utils";
+import * as ALL_FLAGS from "@sit-onyx/flags";
+import { FLAG_METADATA, getFlagImportName, groupFlagsByContinent } from "@sit-onyx/flags/utils";
 import type { Asset, AssetLibraryGroup } from "./AssetLibrary.vue";
 import AssetLibrary from "./AssetLibrary.vue";
 import AssetLibraryItem from "./AssetLibraryItem.vue";
 
-const ALL_FLAGS = import.meta.glob("../../../node_modules/@sit-onyx/flags/src/assets/*.svg", {
-  query: "?raw",
-  import: "default",
-  eager: true,
-}) as Record<string, string>;
-
-const assetGroups = Object.entries(groupFlagsByContinent(FLAG_METADATA)).map<AssetLibraryGroup>(
+const assetGroups = Object.entries(groupFlagsByContinent(FLAG_METADATA)).map(
   ([continent, flags]) => {
     return {
       name: continent,
-      assets: flags.map<Asset>((flag) => ({
-        id: flag.code,
-        name: flag.metadata.internationalName,
-      })),
-    };
+      assets: flags.map(
+        (flag) =>
+          ({
+            id: getFlagImportName(flag.code),
+            name: flag.metadata.internationalName,
+            data: { code: flag.code },
+          }) satisfies Asset,
+      ),
+    } satisfies AssetLibraryGroup;
   },
 );
-
-const getSvgContent = (code: string) => {
-  return ALL_FLAGS[`../../../node_modules/@sit-onyx/flags/src/assets/${code}.svg`];
-};
 </script>
 
 <template>
   <AssetLibrary :groups="assetGroups" search-placeholder="Country code or name...">
     <template #item="{ asset: flag }">
       <AssetLibraryItem
-        :tooltip-text="`${flag.name} (${flag.id})`"
-        :content="getSvgContent(flag.id)"
-        :clipboard-value="`import ${flag.id} from &quot;@sit-onyx/flags/${flag.id}.svg?raw&quot;`"
-        :success-message="`Import for flag &quot;${flag.id}&quot; (${flag.name}) has been copied to your clipboard.`"
+        :tooltip-text="`${flag.name} (${flag.data?.code})`"
+        :content="ALL_FLAGS[flag.id]"
+        :clipboard-value="`import { ${flag.id} } from &quot;@sit-onyx/flags&quot;`"
+        :success-message="`Import for flag &quot;${flag.data?.code}&quot; (${flag.name}) has been copied to your clipboard.`"
       />
     </template>
   </AssetLibrary>

--- a/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
+++ b/apps/docs/src/.vitepress/components/OnyxIconLibrary.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import * as ALL_ICONS from "@sit-onyx/icons";
 import {
   capitalize,
   getIconImportName,
@@ -9,18 +10,12 @@ import type { Asset, AssetLibraryGroup } from "./AssetLibrary.vue";
 import AssetLibrary from "./AssetLibrary.vue";
 import AssetLibraryItem from "./AssetLibraryItem.vue";
 
-const ALL_ICONS = import.meta.glob("../../../node_modules/@sit-onyx/icons/src/assets/*.svg", {
-  query: "?raw",
-  import: "default",
-  eager: true,
-}) as Record<string, string>;
-
 const assetGroups = Object.entries(groupIconsByCategory(ICON_METADATA)).map<AssetLibraryGroup>(
   ([category, icons]) => {
     return {
       name: category,
       assets: icons.map<Asset>((icon) => ({
-        id: icon.iconName,
+        id: getIconImportName(icon.iconName),
         aliases: icon.metadata.aliases,
         name: icon.iconName
           .split("-")
@@ -30,10 +25,6 @@ const assetGroups = Object.entries(groupIconsByCategory(ICON_METADATA)).map<Asse
     };
   },
 );
-
-const getSvgContent = (iconName: string) => {
-  return ALL_ICONS[`../../../node_modules/@sit-onyx/icons/src/assets/${iconName}.svg`];
-};
 </script>
 
 <template>
@@ -41,9 +32,9 @@ const getSvgContent = (iconName: string) => {
     <template #item="{ asset: icon }">
       <AssetLibraryItem
         :tooltip-text="icon.name"
-        :content="getSvgContent(icon.id)"
-        :clipboard-value="`import ${getIconImportName(icon.id)} from &quot;@sit-onyx/icons/${icon.id}.svg?raw&quot;`"
-        :success-message="`Import for icon &quot;${getIconImportName(icon.id)}&quot; has been copied to your clipboard.`"
+        :content="ALL_ICONS[icon.id]"
+        :clipboard-value="`import { ${icon.id} } from &quot;@sit-onyx/icons&quot;`"
+        :success-message="`Import for &quot;${icon.id}&quot; has been copied to your clipboard.`"
       />
     </template>
   </AssetLibrary>

--- a/apps/docs/src/flags.md
+++ b/apps/docs/src/flags.md
@@ -28,6 +28,34 @@ yarn install -D @sit-onyx/flags@beta
 
 Afterwards, you can import and use flags as needed. Please see the [OnyxIcon](https://storybook.onyx.schwarz/?path=/docs/basic-icon--docs) for the technical documentation. Technically, flags are used the same way as icons in onyx. This means that also flags can be passed for all components that support icons.
 
+## Usage
+
+There are two different ways of using / importing flags from this package:
+
+### Option 1: JavaScript import <Badge text="recommended" />
+
+> **Requires @sit-onyx/flags version >= 1.0.0-beta.5**
+
+For the best developer experience, it is recommended to use JavaScript imports. This approach also supports IDE intellisense, so you can e.g. just start typing "flag" in your editor and all available flags will be suggested to you.
+
+```ts
+import { flagDE } from "@sit-onyx/flags";
+
+// or to import all flags (note: no tree-shaking will be supported then):
+// import * as ALL_FLAGS from "@sit-onyx/flags";
+```
+
+### Option 2: Import from SVG file
+
+Alternatively, you can import the icon from the raw SVG file:
+
+```ts
+// Note that "?raw" is needed to import the SVG content instead of a path to the file itself.
+// ?raw will be resolved by the bundler (e.g. Vite).
+// if you want to import the path to the flag instead of the content, you can omit the "?raw" part
+import flagDE from "@sit-onyx/flags/DE.svg?raw";
+```
+
 ## Country names
 
 You can get the country name of a flag in several languages using JavaScript's [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) API.

--- a/apps/docs/src/icons.md
+++ b/apps/docs/src/icons.md
@@ -28,6 +28,34 @@ yarn install -D @sit-onyx/icons@beta
 
 Afterwards, you can import and use icons as needed. Please see the [OnyxIcon](https://storybook.onyx.schwarz/?path=/docs/basic-icon--docs) for the technical documentation.
 
+## Usage
+
+There are two different ways of using / importing icons from this package:
+
+### Option 1: JavaScript import <Badge text="recommended" />
+
+> **Requires @sit-onyx/icons version >= 1.0.0-beta.22**
+
+For the best developer experience, it is recommended to use JavaScript imports. This approach also supports IDE intellisense, so you can e.g. just start typing "icon" in your editor and all available icons will be suggested to you.
+
+```ts
+import { iconPlaceholder } from "@sit-onyx/icons";
+
+// or to import all icons (note: no tree-shaking will be supported then):
+// import * as ALL_ICONS from "@sit-onyx/icons";
+```
+
+### Option 2: Import from SVG file
+
+Alternatively, you can import the icon from the raw SVG file:
+
+```ts
+// Note that "?raw" is needed to import the SVG content instead of a path to the file itself.
+// ?raw will be resolved by the bundler (e.g. Vite).
+// if you want to import the path to the icon instead of the content, you can omit the "?raw" part
+import iconPlaceholder from "@sit-onyx/icons/placeholder.svg?raw";
+```
+
 ## Available icons
 
 You can hover over an icon to see its name. Click on it or press enter when selecting it via keyboard to copy the import statement for the selected icon.

--- a/packages/flags/src/utils.ts
+++ b/packages/flags/src/utils.ts
@@ -37,3 +37,16 @@ export const groupFlagsByContinent = (flagMetadata: Record<string, FlagMetadata>
 
   return sortedContinents;
 };
+
+/**
+ * Transform a flag file name to its corresponding JavaScript import name.
+ *
+ * @example
+ * ```ts
+ * "DE.svg" => "flagDE"
+ * // e.g. used as 'import { flagDE } from "@sit-onyx/flags"'
+ * ```
+ */
+export const getFlagImportName = (flagName: string) => {
+  return `flag${flagName.replace(".svg", "").replaceAll("-", "_")}`;
+};

--- a/packages/flags/vite.config.ts
+++ b/packages/flags/vite.config.ts
@@ -5,6 +5,7 @@ import { DiagnosticCategory } from "typescript";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
+import { getFlagImportName } from "./src/utils.js";
 
 // https://vitejs.dev/config
 export default defineConfig({
@@ -13,7 +14,7 @@ export default defineConfig({
     svg({
       base: import.meta.url,
       input: "src/assets",
-      modifyExportName: (name, rawName) => `flag${rawName.replaceAll("-", "_")}`,
+      modifyExportName: (name) => getFlagImportName(name),
     }),
     dts({
       afterDiagnostic: async (diagnostics) => {

--- a/packages/icons/src/utils.ts
+++ b/packages/icons/src/utils.ts
@@ -39,22 +39,20 @@ export const groupIconsByCategory = (iconMetadata: Record<string, IconMetadata>)
 };
 
 /**
- * Transform an icon name to its corresponding JavaScript import name.
+ * Transform an icon file name to its corresponding JavaScript import name.
  *
  * @example
  * ```ts
- * "bell-disabled" => "bellDisabled"
- * // e.g. used as 'import bellDisabled from "@sit-onyx/icons/bell-disabled.svg?raw"'
+ * "bell-disabled.svg" => "iconBellDisabled"
+ * // e.g. used as 'import { iconBellDisabled } from "@sit-onyx/icons"'
  * ```
  */
 export const getIconImportName = (iconName: string) => {
-  return iconName
+  return `icon${iconName
+    .replace(".svg", "")
     .split("-")
-    .map((word, index) => {
-      if (index === 0) return word;
-      return capitalize(word);
-    })
-    .join("");
+    .map((word) => capitalize(word))
+    .join("")}`;
 };
 
 /**

--- a/packages/icons/vite.config.ts
+++ b/packages/icons/vite.config.ts
@@ -5,7 +5,7 @@ import { DiagnosticCategory } from "typescript";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
-import { capitalize } from "./src/utils.js";
+import { getIconImportName } from "./dist/utils.js";
 
 // https://vitejs.dev/config
 export default defineConfig({
@@ -14,7 +14,7 @@ export default defineConfig({
     svg({
       base: import.meta.url,
       input: "src/assets",
-      modifyExportName: (name) => `icon${capitalize(name)}`,
+      modifyExportName: (name) => getIconImportName(name),
     }),
     dts({
       afterDiagnostic: async (diagnostics) => {

--- a/packages/icons/vite.config.ts
+++ b/packages/icons/vite.config.ts
@@ -5,7 +5,7 @@ import { DiagnosticCategory } from "typescript";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
-import { getIconImportName } from "./dist/utils.js";
+import { getIconImportName } from "./src/utils.js";
 
 // https://vitejs.dev/config
 export default defineConfig({

--- a/packages/sit-onyx/.storybook/main.ts
+++ b/packages/sit-onyx/.storybook/main.ts
@@ -55,11 +55,7 @@ const config: StorybookConfig = {
   viteFinal: (config) => {
     return mergeConfig(config, {
       optimizeDeps: {
-        exclude: [
-          "node_module/.cache/sb-vite",
-          "node_module/.cache/storybook",
-          "node_module/.cache",
-        ],
+        exclude: ["node_module/.cache/*"],
       },
     } satisfies typeof config);
   },

--- a/packages/sit-onyx/src/components/OnyxIcon/OnyxIcon.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxIcon/OnyxIcon.stories.ts
@@ -7,6 +7,9 @@ import OnyxIcon from "./OnyxIcon.vue";
  * Icons allow developers to integrate library icons directly into a project, enhancing visual communication and accessibility within the interface.
  * We recommend using the official icons from [`@sit-onyx/icons`](https://onyx.schwarz/icons.html).
  *
+ * When importing icons from .svg files, make sure to add `?raw` after the file name to import the SVG content
+ * instead of the file system path to the file.
+ *
  * For usage instructions and a list of all onyx icons, please visit our [icon library](https://onyx.schwarz/icons.html).
  */
 const meta: Meta<typeof OnyxIcon> = {

--- a/packages/sit-onyx/src/components/OnyxIcon/OnyxIcon.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxIcon/OnyxIcon.stories.ts
@@ -5,12 +5,9 @@ import OnyxIcon from "./OnyxIcon.vue";
 
 /**
  * Icons allow developers to integrate library icons directly into a project, enhancing visual communication and accessibility within the interface.
- * We recommend using the official icons from `@sit-onyx/icons`.
+ * We recommend using the official icons from [`@sit-onyx/icons`](https://onyx.schwarz/icons.html).
  *
- * When importing SVG icon files, make sure to add `?raw` after the file name as shown in the examples to import the SVG content
- * instead of the file system path to the file.
- *
- * For a list of all onyx icons, please visit our [icon library](https://onyx.schwarz/icons.html).
+ * For usage instructions and a list of all onyx icons, please visit our [icon library](https://onyx.schwarz/icons.html).
  */
 const meta: Meta<typeof OnyxIcon> = {
   title: "Basic/Icon",

--- a/packages/sit-onyx/src/components/OnyxIcon/OnyxIcon.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxIcon/OnyxIcon.stories.ts
@@ -5,7 +5,7 @@ import OnyxIcon from "./OnyxIcon.vue";
 
 /**
  * Icons allow developers to integrate library icons directly into a project, enhancing visual communication and accessibility within the interface.
- * We recommend using the official icons from [`@sit-onyx/icons`](https://onyx.schwarz/icons.html).
+ * We recommend using the official icons from `@sit-onyx/icons` (see [documentation](https://onyx.schwarz/icons.html)).
  *
  * When importing icons from .svg files, make sure to add `?raw` after the file name to import the SVG content
  * instead of the file system path to the file.

--- a/packages/storybook-utils/package.json
+++ b/packages/storybook-utils/package.json
@@ -32,6 +32,7 @@
     "stylelint": "stylelint \"src/**/*.css\""
   },
   "peerDependencies": {
+    "@sit-onyx/flags": "workspace:^",
     "@sit-onyx/icons": "workspace:^",
     "@sit-onyx/shared": "workspace:^",
     "@storybook/vue3-vite": ">= 9.0.0",

--- a/packages/storybook-utils/src/preview.spec.ts
+++ b/packages/storybook-utils/src/preview.spec.ts
@@ -1,3 +1,4 @@
+import { flagDE } from "@sit-onyx/flags";
 import { iconBellRing, iconCalendar, iconPlaceholder } from "@sit-onyx/icons";
 import { describe, expect, test } from "vitest";
 import { replaceAll, sourceCodeTransformer } from "./preview.js";
@@ -6,7 +7,7 @@ describe("preview.ts", () => {
   test("should transform source code and add icon/onyx imports", async () => {
     // ACT
     const sourceCode = await sourceCodeTransformer(`<template>
-<OnyxTest icon='${iconPlaceholder}' test='${iconBellRing}' :obj="{foo:'${replaceAll(iconCalendar, '"', "\\'")}'}" />
+<OnyxTest icon='${iconPlaceholder}' test='${iconBellRing}' :obj="{foo:'${replaceAll(iconCalendar, '"', "\\'")}'}" flag='${flagDE}' />
 <OnyxOtherComponent />
 <OnyxComp>Test</OnyxComp>
 </template>`);
@@ -15,6 +16,7 @@ describe("preview.ts", () => {
     expect(sourceCode).toBe(`<script lang="ts" setup>
 import { OnyxComp, OnyxOtherComponent, OnyxTest } from "sit-onyx";
 import { iconBellRing, iconCalendar, iconPlaceholder } from "@sit-onyx/icons";
+import { flagDE } from "@sit-onyx/flags";
 </script>
 
 <template>
@@ -22,6 +24,7 @@ import { iconBellRing, iconCalendar, iconPlaceholder } from "@sit-onyx/icons";
     :icon="iconPlaceholder"
     :test="iconBellRing"
     :obj="{foo:iconCalendar}"
+    :flag="flagDE"
   />
   <OnyxOtherComponent />
   <OnyxComp>Test</OnyxComp>

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -132,65 +132,92 @@ export const createPreview = <T extends Preview = Preview>(
  * @see https://storybook.js.org/docs/react/api/doc-block-source
  */
 export const sourceCodeTransformer = async (originalSourceCode: string): Promise<string> => {
-  const ALL_ICONS = await import("@sit-onyx/icons");
-
   let code = originalSourceCode;
 
-  const additionalImports: string[] = [];
-
-  // add icon imports to the source code for all used onyx icons
-  const usedIcons = new Set<string>();
-
-  Object.entries(ALL_ICONS).forEach(([iconName, iconContent]) => {
-    const singleQuotedIconContent = `'${replaceAll(iconContent, '"', "\\'")}'`;
-    const escapedIconContent = `"${replaceAll(iconContent, '"', '\\"')}"`;
-
-    if (code.includes(iconContent)) {
-      usedIcons.add(iconName);
-
-      code = code.replace(
-        new RegExp(` (\\S+)=['"]${escapeRegExp(iconContent)}['"]`),
-        ` :$1="${iconName}"`,
-      );
-    } else if (code.includes(singleQuotedIconContent)) {
-      // support icons inside objects
-      usedIcons.add(iconName);
-      code = code.replace(singleQuotedIconContent, iconName);
-    } else if (code.includes(escapedIconContent)) {
-      // support icons inside objects
-      usedIcons.add(iconName);
-      code = code.replace(escapedIconContent, iconName);
-    }
-  });
-
-  if (usedIcons.size > 0) {
-    additionalImports.push(
-      `import { ${Array.from(usedIcons.values()).sort().join(", ")} } from "@sit-onyx/icons";`,
-    );
-  }
+  /**
+   * A list of additional JavaScript imports to be added at the top of the source code.
+   *
+   * key = module/package name to import from, value: set of imports to import from the package
+   */
+  const additionalImports = new Map<string, Set<string>>();
 
   // add imports for all used onyx components
   // Set is used here to only include unique components if they are used multiple times
-  const usedOnyxComponents = [
-    ...new Set(Array.from(code.matchAll(/<(Onyx\w+)(?:\s*\/?)/g)).map((match) => match[1])),
-  ].sort();
+  const usedOnyxComponents = new Set(
+    Array.from(code.matchAll(/<(Onyx\w+)(?:\s*\/?)/g)).map((match) => match[1]),
+  );
+  additionalImports.set("sit-onyx", usedOnyxComponents);
 
-  if (usedOnyxComponents.length > 0) {
-    additionalImports.unshift(`import { ${usedOnyxComponents.join(", ")} } from "sit-onyx";`);
+  /**
+   * List of npm packages to replace the source code with.
+   * The source code will be checked for any import of the package and (if its used), the code will be replaced by the corresponding import.
+   */
+  const packagesToReplace = [
+    { name: "@sit-onyx/icons", data: await import("@sit-onyx/icons") },
+    { name: "@sit-onyx/flags", data: await import("@sit-onyx/flags") },
+  ];
+
+  packagesToReplace.forEach((_package) => {
+    Object.entries(_package.data).forEach(([name, content]) => {
+      const singleQuotedContent = `'${replaceAll(content, '"', "\\'")}'`;
+      const escapedContent = `"${replaceAll(content, '"', '\\"')}"`;
+
+      const imports = additionalImports.get(_package.name) ?? new Set<string>();
+
+      if (code.includes(content)) {
+        imports.add(name);
+
+        code = code.replace(
+          new RegExp(` (\\S+)=['"]${escapeRegExp(content)}['"]`),
+          ` :$1="${name}"`,
+        );
+      } else if (code.includes(singleQuotedContent)) {
+        // support values inside objects
+        imports.add(name);
+        code = code.replace(singleQuotedContent, name);
+      } else if (code.includes(escapedContent)) {
+        // support values inside objects
+        imports.add(name);
+        code = code.replace(escapedContent, name);
+      }
+
+      additionalImports.set(_package.name, imports);
+    });
+  });
+
+  // remove imports without any data so we don't add empty imports
+  additionalImports.forEach((value, key) => {
+    if (!value.size) additionalImports.delete(key);
+  });
+
+  if (additionalImports.size === 0) return code;
+
+  // generate the source code for the additional imports and add them to the top of the code snippet
+  const additionalImportsCode = Array.from(additionalImports.entries()).reduce(
+    (code, [packageName, imports]) => {
+      if (imports.size) {
+        code.push(
+          `import { ${Array.from(imports.values()).sort().join(", ")} } from "${packageName}";`,
+        );
+      }
+      return code;
+    },
+    [] as string[],
+  );
+
+  if (code.startsWith("<script")) {
+    const index = code.indexOf("\n");
+    const hasOtherImports = code.includes("import {");
+    return (
+      code.slice(0, index) +
+      additionalImportsCode.join("\n") +
+      (!hasOtherImports ? "\n" : "") +
+      code.slice(index)
+    );
   }
 
-  if (additionalImports.length > 1) {
-    if (code.startsWith("<script")) {
-      const index = code.indexOf("\n");
-      const hasOtherImports = code.includes("import {");
-      code =
-        code.slice(0, index) +
-        additionalImports.join("\n") +
-        (!hasOtherImports ? "\n" : "") +
-        code.slice(index);
-    } else {
-      code = `<script lang="ts" setup>
-${additionalImports.join("\n")}
+  return `<script lang="ts" setup>
+${additionalImportsCode.join("\n")}
 </script>
 
 ${code}`;

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -190,33 +190,30 @@ export const sourceCodeTransformer = async (originalSourceCode: string): Promise
     if (!value.size) additionalImports.delete(key);
   });
 
-  if (additionalImports.size === 0) return code;
-
   // generate the source code for the additional imports and add them to the top of the code snippet
-  const additionalImportsCode = Array.from(additionalImports.entries()).reduce(
-    (code, [packageName, imports]) => {
-      if (imports.size) {
-        code.push(
-          `import { ${Array.from(imports.values()).sort().join(", ")} } from "${packageName}";`,
-        );
-      }
-      return code;
-    },
-    [] as string[],
-  );
-
-  if (code.startsWith("<script")) {
-    const index = code.indexOf("\n");
-    const hasOtherImports = code.includes("import {");
-    return (
-      code.slice(0, index) +
-      additionalImportsCode.join("\n") +
-      (!hasOtherImports ? "\n" : "") +
-      code.slice(index)
+  if (additionalImports.size > 0) {
+    const additionalImportsCode = Array.from(additionalImports.entries()).reduce(
+      (code, [packageName, imports]) => {
+        if (imports.size) {
+          code.push(
+            `import { ${Array.from(imports.values()).sort().join(", ")} } from "${packageName}";`,
+          );
+        }
+        return code;
+      },
+      [] as string[],
     );
-  }
 
-  return `<script lang="ts" setup>
+    if (code.startsWith("<script")) {
+      const index = code.indexOf("\n");
+      const hasOtherImports = code.includes("import {");
+      code =
+        code.slice(0, index) +
+        additionalImportsCode.join("\n") +
+        (!hasOtherImports ? "\n" : "") +
+        code.slice(index);
+    } else {
+      code = `<script lang="ts" setup>
 ${additionalImportsCode.join("\n")}
 </script>
 

--- a/packages/vite-plugin-svg/src/index.ts
+++ b/packages/vite-plugin-svg/src/index.ts
@@ -1,7 +1,6 @@
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Plugin } from "vite";
-import { toCamelCase } from "./utils.js";
 
 export type PluginOptions = {
   /**
@@ -21,11 +20,10 @@ export type PluginOptions = {
   /**
    * Modifies the export name for a given SVG.
    *
-   * @param name Java-Script safe export name in camelCase, e.g. "myFile"
-   * @param rawName The raw SVG file name, e.g. "my-file.svg"
+   * @param rawName The raw SVG file name (without .svg suffix), e.g. "my-file.svg"
    * @returns
    */
-  modifyExportName?: (name: string, rawName: string) => string;
+  modifyExportName?: (rawName: string) => string;
 };
 
 /**
@@ -52,11 +50,7 @@ export default function vitePluginSVG(options: PluginOptions): Plugin {
         .filter((file) => file.endsWith(".svg"))
         .map((fileName) => {
           const baseName = fileName.replace(".svg", "");
-          let exportName = toCamelCase(baseName);
-          if (options.modifyExportName) {
-            exportName = options.modifyExportName(exportName, baseName);
-          }
-
+          const exportName = options.modifyExportName?.(baseName) ?? baseName;
           return { fileName, exportName };
         });
 

--- a/packages/vite-plugin-svg/src/utils.ts
+++ b/packages/vite-plugin-svg/src/utils.ts
@@ -1,7 +1,0 @@
-/**
- * Transforms the given string into camelCase.
- */
-export const toCamelCase = (value: string) => {
-  const a = value.toLowerCase().replace(/[-_\s.]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ""));
-  return a.substring(0, 1).toLowerCase() + a.substring(1);
-};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,9 @@ importers:
 
   packages/storybook-utils:
     dependencies:
+      '@sit-onyx/flags':
+        specifier: workspace:^
+        version: link:../flags
       '@storybook/vue3-vite':
         specifier: '>= 9.0.0'
         version: 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.5(@types/node@24.1.0)(jiti@2.5.1)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue@3.5.18(typescript@5.8.3))


### PR DESCRIPTION
Relates to #1802

- update icon and flag docs to mention the new JavaScript imports
- update Storybook utils to also support replacing flag imports in the source code snippets (can be tested on http://localhost:6006/?path=/docs/navigation-navbar-modules-colorschememenuitem--docs)

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
