### PR TITLE
chore: setup trusted publishing for npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
     permissions:
+      id-token: write
       contents: write
     steps:
       - uses: actions/checkout@v4
@@ -23,10 +24,6 @@ jobs:
           ssh-key: ${{ secrets.GH_PUSH_PROTECTED_KEY }}
           # needed when building VitePress docs so timestamps can be calculated correctly
           fetch-depth: 0
-
-      - uses: ./.github/templates/node-setup
-        with:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: 🛠️ Build packages
         run: pnpm build:all --filter=!docs


### PR DESCRIPTION
Relates to [3844](https://github.com/SchwarzIT/onyx/issues/3844)

The **npm** registry now supports [Trusted publishing for npm packages](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/).
This allows packages to be published using oidc, without the need for long-living API tokens.
Also each new published version is then directly coupled to a pipeline run and commit, which is also shown on a new tile in the npm UI.

See also the [official docs](https://docs.npmjs.com/trusted-publishers).