### PR TITLE
fix(nuxt-docs): correctly pack files when publishing

### DIFF
--- a/.changeset/bitter-paths-run.md
+++ b/.changeset/bitter-paths-run.md
@@ -1,0 +1,8 @@
+---
+"@sit-onyx/nuxt-docs": patch
+---
+
+fix: correctly pack files when publishing
+
+After the release of version `1.0.0-beta.92`, the Nuxt docs layer did not work at all when used inside a project.
+The reason is that due to the Nuxt 4 migration, all relevant files are now placed inside the "app" directory but our "files" definition in package.json did not include the directory when publishing so the file were missing in the npm package.

--- a/packages/nuxt-docs/package.json
+++ b/packages/nuxt-docs/package.json
@@ -18,14 +18,9 @@
   },
   "main": "./nuxt.config.ts",
   "files": [
-    "components",
-    "composables",
-    "layouts",
-    "pages",
-    "*.ts",
-    "!*.e2e.ts",
-    "*.vue",
-    "*.json"
+    "app",
+    "content.config.ts",
+    "nuxt.config.ts"
   ],
   "scripts": {
     "dev": "pnpm dev:prepare && nuxi dev playground",


### PR DESCRIPTION
Relates to #3800 

After the release of #3800, I noticed that the Nuxt docs layer does not work at all when used inside a project.
The reason is that due to the Nuxt 4 migration, all relevant files are now placed inside the "app" directory but our "files" definition in package.json did not include the directory when publishing so the file were missing in the npm package.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
