### PR TITLE
fix(nuxt-docs): update page content when navigating

### DIFF
--- a/.changeset/little-books-invent.md
+++ b/.changeset/little-books-invent.md
@@ -3,3 +3,5 @@
 ---
 
 fix(nuxt-docs): update page content when navigating
+
+Previously the page content did not update when dynamically navigating to another route which is fixed now

--- a/.changeset/little-books-invent.md
+++ b/.changeset/little-books-invent.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt-docs": patch
+---
+
+fix(nuxt-docs): update page content when navigating

--- a/packages/nuxt-docs/app/pages/[...path].vue
+++ b/packages/nuxt-docs/app/pages/[...path].vue
@@ -1,16 +1,30 @@
 <script setup lang="ts">
 const route = useRoute();
-const collection = await useAsyncData(() => queryCollection("content").path(route.path).first());
+const path = computed(() => route.path);
 
-if (!collection.data.value) {
-  throw createError({
-    message: "Page not found",
-    statusCode: 404,
-  });
-}
+const collection = await useAsyncData(path, () =>
+  queryCollection("content").path(path.value).first(),
+);
 
-const data = toRef(() => collection.data.value!);
-useSeoMeta({ ...data.value.seo });
+watch(
+  () => collection.data.value,
+  (data) => {
+    // if data is "null", the page content was not found. "undefined" means it is not loaded yet
+    if (data !== null) return;
+    throw showError({
+      message: "Page not found",
+      statusCode: 404,
+    });
+  },
+  { immediate: true },
+);
+
+const data = computed(() => collection.data.value);
+
+useSeoMeta({
+  title: computed(() => collection.data.value?.seo.title),
+  description: computed(() => collection.data.value?.seo.description),
+});
 </script>
 
 <!-- eslint-disable-next-line vue/no-root-v-if  -- the v-if here is theoretically not needed because we throw above it ifs undefined so the user will be redirected to the error page. However, there is still a console warning so we include the v-if here to prevent it. -->

--- a/packages/nuxt-docs/playground/app/app.config.ts
+++ b/packages/nuxt-docs/playground/app/app.config.ts
@@ -1,3 +1,11 @@
 export default defineAppConfig({
-  onyxDocs: {},
+  onyxDocs: {
+    nav: {
+      items: [
+        { label: "Home", link: "/" },
+        { label: "Foo", link: "/foo" },
+        { label: "Does not exist", link: "/does-not-exist" },
+      ],
+    },
+  },
 });

--- a/packages/nuxt-docs/playground/content/foo.md
+++ b/packages/nuxt-docs/playground/content/foo.md
@@ -1,0 +1,3 @@
+# Foo
+
+This is an example page

--- a/packages/nuxt-docs/playground/tests/playwright/routing.e2e.ts
+++ b/packages/nuxt-docs/playground/tests/playwright/routing.e2e.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@nuxt/test-utils/playwright";
+
+test("should update page content when navigating", async ({ page, goto }) => {
+  // ACT
+  await goto("/", { waitUntil: "hydration" });
+
+  // ASSERT
+  await expect(page.getByRole("heading", { level: 1, name: "H1" })).toBeVisible();
+
+  // ACT
+  await page.getByRole("menuitem", { name: "Foo" }).click();
+
+  // ASSERT
+  await expect(page).toHaveURL(/\/foo/);
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Foo" }),
+    "should show new page content when navigating",
+  ).toBeVisible();
+
+  // ACT
+  await page.getByRole("menuitem", { name: "Does not exist" }).click();
+
+  // ASSERT
+  await expect(page).toHaveURL(/\/does-not-exist/);
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Page not found" }),
+    "should show error page when dynamically navigating to a non-existing page",
+  ).toBeVisible();
+});


### PR DESCRIPTION
Previously the page content of the Nuxt docs template did not update when dynamically navigating to another route which is fixed now.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
