### PR TITLE
feat(OnyxDataGrid): support boolean column type

### DIFF
--- a/.changeset/busy-schools-sneeze.md
+++ b/.changeset/busy-schools-sneeze.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxDataGrid): support boolean column type

--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/DefaultExample.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/DefaultExample.vue
@@ -6,14 +6,15 @@ type TEntry = {
   name: string;
   age: number;
   birthday: Date;
+  isActive?: boolean;
 };
 
 const data: TEntry[] = [
-  { id: 1, name: "Alice", age: 30, birthday: new Date("1990-01-01") },
-  { id: 2, name: "Charlie", age: 35, birthday: new Date("1998-02-11") },
-  { id: 3, name: "Bob", age: 25, birthday: new Date("1995-06-15") },
-  { id: 4, name: "Robin", age: 28, birthday: new Date("2001-02-22") },
-  { id: 5, name: "John", age: 42, birthday: new Date("1997-04-18") },
+  { id: 1, name: "Alice", age: 30, birthday: new Date("1990-01-01"), isActive: true },
+  { id: 2, name: "Charlie", age: 35, birthday: new Date("1998-02-11"), isActive: false },
+  { id: 3, name: "Bob", age: 25, birthday: new Date("1995-06-15"), isActive: false },
+  { id: 4, name: "Robin", age: 28, birthday: new Date("2001-02-22"), isActive: true },
+  { id: 5, name: "John", age: 42, birthday: new Date("1997-04-18"), isActive: false },
 ];
 
 const columns: ColumnConfig<TEntry>[] = [
@@ -23,6 +24,21 @@ const columns: ColumnConfig<TEntry>[] = [
     key: "birthday",
     label: "Birthday",
     type: { name: "date", options: { format: { dateStyle: "full" } } },
+  },
+  {
+    key: "isActive",
+    label: "Is active?",
+    width: "max-content",
+    type: "boolean",
+    // you can also pass custom options to the type by passing an object instead of a string
+    // type: {
+    //   name: "boolean",
+    //   options: {
+    //     truthy: {
+    //       color: "success",
+    //     },
+    //   },
+    // },
   },
 ];
 </script>

--- a/packages/sit-onyx/src/components/OnyxDataGrid/examples/SortingExample.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/examples/SortingExample.vue
@@ -7,20 +7,22 @@ type TEntry = {
   name: string;
   age: number;
   birthday: Date;
+  isActive?: boolean;
 };
 
 const data: TEntry[] = [
-  { id: 1, name: "Alice", age: 30, birthday: new Date("1990-01-01") },
-  { id: 2, name: "Charlie", age: 35, birthday: new Date("1998-02-11") },
-  { id: 3, name: "Bob", age: 25, birthday: new Date("1995-06-15") },
-  { id: 4, name: "Robin", age: 28, birthday: new Date("2001-02-22") },
-  { id: 5, name: "John", age: 42, birthday: new Date("1997-04-18") },
+  { id: 1, name: "Alice", age: 30, birthday: new Date("1990-01-01"), isActive: true },
+  { id: 2, name: "Charlie", age: 35, birthday: new Date("1998-02-11"), isActive: false },
+  { id: 3, name: "Bob", age: 25, birthday: new Date("1995-06-15"), isActive: false },
+  { id: 4, name: "Robin", age: 28, birthday: new Date("2001-02-22"), isActive: true },
+  { id: 5, name: "John", age: 42, birthday: new Date("1997-04-18"), isActive: false },
 ];
 
 const columns: ColumnConfig<TEntry>[] = [
   { key: "name", label: "Name" },
   { key: "age", label: "Rank" },
   { key: "birthday", label: "Birthday", type: "date" },
+  { key: "isActive", label: "Is active?", width: "max-content", type: "boolean" },
 ];
 
 const sortState = ref<DataGridFeatures.SortState<TEntry>>({
@@ -32,18 +34,17 @@ const sortState = ref<DataGridFeatures.SortState<TEntry>>({
 const withSorting = DataGridFeatures.useSorting<TEntry>({
   sortState,
   columns: {
-    name: { enabled: true },
-    age: { enabled: false },
-    birthday: { enabled: true, sortFunc: (a, b) => a.getTime() - b.getTime() },
+    // sorting can be disabled for specific columns if needed
+    // age: { enabled: false },
+    birthday: { sortFunc: (a, b) => a.getTime() - b.getTime() },
   },
 });
 
 // for demonstration purposes, we are adding an additional feature
 // so you can see that the sorting automatically moves to a "..." flyout for the "birthday" column
 const withFiltering = DataGridFeatures.useFiltering<TEntry>({
+  enabled: false,
   columns: {
-    name: { enabled: false },
-    age: { enabled: false },
     birthday: { enabled: true },
   },
 });

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/base/base.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/base/base.ct.tsx
@@ -138,3 +138,30 @@ test("should show skeleton", async ({ mount }) => {
     "skeleton row count should match actual data count if it exists",
   );
 });
+
+test("should render boolean column type", async ({ mount }) => {
+  // ARRANGE
+  const component = await mount(TestWrapper, {
+    props: {
+      style: "width: 8rem",
+      columns: [{ key: "a", label: "Column A", type: "boolean" }],
+      data: [
+        { id: 1, a: true },
+        { id: 1, a: false },
+      ],
+    },
+  });
+
+  // ASSERT
+  await expect(component).toHaveScreenshot("boolean.png");
+
+  await expect(
+    component.getByRole("cell").first(),
+    "should include visually hidden value",
+  ).toHaveText("true");
+
+  await expect(
+    component.getByRole("cell").nth(1),
+    "should include visually hidden value",
+  ).toHaveText("false");
+});

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/base/base.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/base/base.ts
@@ -5,6 +5,7 @@ import { FILTERING_MUTATION_ORDER } from "../filtering/filtering.js";
 import { createFeature } from "../index.js";
 import { PAGINATION_MUTATION_ORDER } from "../pagination/pagination.js";
 import {
+  BOOLEAN_RENDERER,
   DATE_RENDERER,
   DATETIME_RENDERER,
   NUMBER_RENDERER,
@@ -66,6 +67,7 @@ export const BASE_FEATURE = (options?: BaseFeatureOptions) =>
         time: TIME_RENDERER,
         timestamp: TIMESTAMP_RENDERER,
         skeleton: SKELETON_RENDERER,
+        boolean: BOOLEAN_RENDERER,
       },
       slots: {
         headline: (slotContent) => {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/index.ts
@@ -15,7 +15,6 @@ import {
   type WatchSource,
 } from "vue";
 import type { ComponentSlots } from "vue-component-type-helpers";
-import type { DatetimeFormat } from "../../../i18n/datetime-formats.js";
 import { type OnyxI18n } from "../../../i18n/index.js";
 import type { Nullable } from "../../../types/index.js";
 import { mergeVueProps } from "../../../utils/attrs.js";
@@ -92,7 +91,10 @@ export type ColumnConfig<
       TTypes | RenderTypesFromFeature<[ReturnType<typeof BASE_FEATURE>]>
     >;
 
-export type DefaultSupportedTypes = "string" | "number" | DatetimeFormat;
+export type DefaultSupportedTypes = Extract<
+  RenderTypesFromFeature<[ReturnType<typeof BASE_FEATURE>]>,
+  string
+>;
 
 /**
  * Configuration for the column groupings.

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.scss
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.scss
@@ -6,5 +6,9 @@
       font-family: var(--onyx-font-family-mono);
       text-align: end;
     }
+
+    .onyx-data-grid-boolean-cell {
+      color: var(--onyx-color-text-icons-neutral-medium);
+    }
   }
 }

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.ts
@@ -1,3 +1,4 @@
+import { iconCheck, iconMinus } from "@sit-onyx/icons";
 import { h } from "vue";
 import OnyxSkeleton from "../../../components/OnyxSkeleton/OnyxSkeleton.vue";
 import {
@@ -7,6 +8,8 @@ import {
 } from "../../../i18n/index.js";
 import { allObjectEntries } from "../../../utils/objects.js";
 import type { DateValue } from "../../OnyxDatePicker/types.js";
+import OnyxIcon from "../../OnyxIcon/OnyxIcon.vue";
+import type { OnyxIconProps } from "../../OnyxIcon/types.js";
 import type { DataGridEntry } from "../types.js";
 import HeaderCell from "./HeaderCell.vue";
 import { type DataGridFeatureDescription, type TypeRenderer, type TypeRenderMap } from "./index.js";
@@ -159,6 +162,41 @@ export const TIMESTAMP_RENDERER = createTypeRenderer<DateCellOptions>({
 export const SKELETON_RENDERER = createTypeRenderer<StringCellOptions>({
   cell: {
     component: () => h(OnyxSkeleton),
+  },
+});
+
+export type BooleanCellOptions = {
+  /**
+   * Icon to display when the value is truthy.
+   */
+  truthy?: Partial<OnyxIconProps>;
+  /**
+   * Icon to display when the value is falsy.
+   */
+  falsy?: Partial<OnyxIconProps>;
+};
+
+export const BOOLEAN_RENDERER = createTypeRenderer<BooleanCellOptions>({
+  header: { component: HeaderCell },
+  cell: {
+    tdAttributes: {
+      class: "onyx-data-grid-boolean-cell",
+    },
+    component: (props) => {
+      const value = Boolean(props.modelValue);
+
+      const truthyProps: OnyxIconProps = {
+        icon: iconCheck,
+        ...props.metadata?.typeOptions?.truthy,
+      };
+
+      const falsyProps: OnyxIconProps = {
+        icon: iconMinus,
+        ...props.metadata?.typeOptions?.falsy,
+      };
+
+      return h(OnyxIcon, value ? truthyProps : falsyProps);
+    },
   },
 });
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.ts
@@ -10,6 +10,7 @@ import { allObjectEntries } from "../../../utils/objects.js";
 import type { DateValue } from "../../OnyxDatePicker/types.js";
 import OnyxIcon from "../../OnyxIcon/OnyxIcon.vue";
 import type { OnyxIconProps } from "../../OnyxIcon/types.js";
+import OnyxVisuallyHidden from "../../OnyxVisuallyHidden/OnyxVisuallyHidden.vue";
 import type { DataGridEntry } from "../types.js";
 import HeaderCell from "./HeaderCell.vue";
 import { type DataGridFeatureDescription, type TypeRenderer, type TypeRenderMap } from "./index.js";
@@ -195,7 +196,11 @@ export const BOOLEAN_RENDERER = createTypeRenderer<BooleanCellOptions>({
         ...props.metadata?.typeOptions?.falsy,
       };
 
-      return h(OnyxIcon, value ? truthyProps : falsyProps);
+      return [
+        h(OnyxIcon, value ? truthyProps : falsyProps),
+        // since icons are aria hidden (visual only), we include the value with OnyxVisuallyHidden here for screen readers
+        h(OnyxVisuallyHidden, undefined, value),
+      ];
     },
   },
 });

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/renderer.ts
@@ -1,4 +1,4 @@
-import { iconCheck, iconMinus } from "@sit-onyx/icons";
+import { iconCheck, iconX } from "@sit-onyx/icons";
 import { h } from "vue";
 import OnyxSkeleton from "../../../components/OnyxSkeleton/OnyxSkeleton.vue";
 import {
@@ -192,7 +192,7 @@ export const BOOLEAN_RENDERER = createTypeRenderer<BooleanCellOptions>({
       };
 
       const falsyProps: OnyxIconProps = {
-        icon: iconMinus,
+        icon: iconX,
         ...props.metadata?.typeOptions?.falsy,
       };
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/sorting/defaults.ts
@@ -7,6 +7,8 @@ export const STRING_COMPARE = (a: unknown, b: unknown, collator: Intl.Collator) 
 
 export const NUMBER_COMPARE = (a: unknown, b: unknown) => Number(a) - Number(b);
 
+export const BOOLEAN_COMPARE = (a: unknown, b: unknown) => NUMBER_COMPARE(a ? 1 : 0, b ? 1 : 0);
+
 const toComparableTime = (date: Date) =>
   new Date(
     Date.UTC(
@@ -41,4 +43,5 @@ export const DEFAULT_COMPARES: Record<PropertyKey, Compare<unknown>> = Object.fr
   time: TIME_COMPARE,
   timestamp: NUMBER_COMPARE,
   skeleton: () => 0,
+  boolean: BOOLEAN_COMPARE,
 }) satisfies Record<DefaultSupportedTypes, Compare<DataGridEntry>>;

--- a/packages/sit-onyx/src/components/OnyxDataGrid/types.spec-d.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/types.spec-d.ts
@@ -7,7 +7,12 @@ import type {
   TypeRenderer,
   TypeRenderMap,
 } from "./features/index.js";
-import type { DateCellOptions, NumberCellOptions, StringCellOptions } from "./features/renderer.js";
+import type {
+  BooleanCellOptions,
+  DateCellOptions,
+  NumberCellOptions,
+  StringCellOptions,
+} from "./features/renderer.js";
 import type { DataGridEntry, RenderTypesFromFeature } from "./types.js";
 
 it("should be ensured that RenderTypesFromFeature unwraps correctly", async () => {
@@ -22,6 +27,7 @@ it("should be ensured that RenderTypesFromFeature unwraps correctly", async () =
     | ColumnConfigTypeOption<"time", DateCellOptions>
     | ColumnConfigTypeOption<"timestamp", DateCellOptions>
     | ColumnConfigTypeOption<"skeleton", StringCellOptions>
+    | ColumnConfigTypeOption<"boolean", BooleanCellOptions>
   >();
 
   type SingleFeature = [


### PR DESCRIPTION
Relates to #3879

Add a default renderer for boolean columns

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) or functional test is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
