### PR TITLE
fix(OnyxFileUpload): show correct file card type icon

### DIFF
--- a/packages/sit-onyx/src/components/OnyxFileUpload/OnyxFileUpload.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxFileUpload/OnyxFileUpload.ct.tsx
@@ -61,8 +61,8 @@ test.describe("Screenshot tests (max. file sizes)", () => {
 });
 
 const getFile = () => ({
-  name: "file.txt",
-  mimeType: "text/plain",
+  name: "file.pdf",
+  mimeType: "application/pdf",
   buffer: Buffer.from("this is a test"),
 });
 

--- a/packages/sit-onyx/src/components/OnyxFileUpload/OnyxFileUpload.vue
+++ b/packages/sit-onyx/src/components/OnyxFileUpload/OnyxFileUpload.vue
@@ -32,7 +32,7 @@ import OnyxIcon from "../OnyxIcon/OnyxIcon.vue";
 import OnyxIconButton from "../OnyxIconButton/OnyxIconButton.vue";
 import OnyxSkeleton from "../OnyxSkeleton/OnyxSkeleton.vue";
 import OnyxSystemButton from "../OnyxSystemButton/OnyxSystemButton.vue";
-import type { OnyxFileUploadProps } from "./types.js";
+import type { MediaType, OnyxFileUploadProps } from "./types.js";
 
 defineOptions({ inheritAttrs: false });
 
@@ -281,6 +281,7 @@ const shouldShowFileList = computed(() => {
             :size="file.size"
             :status="fileStatuses[index]"
             :link="createFileURL(file)"
+            :type="file.type as MediaType"
           >
             <template #actions>
               <OnyxIconButton


### PR DESCRIPTION
closes #3923

Fix the OnyxFileUpload to pass the file type to the OnyxFileCard so the correct icon is shown depending on the file type.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [ ] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) or functional test is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
