### PR TITLE
fix(@sit-onyx/vite-plugin-svg): Failing module resolution on Windows systems

### DIFF
--- a/.changeset/whole-glasses-stare.md
+++ b/.changeset/whole-glasses-stare.md
@@ -1,0 +1,6 @@
+---
+"@sit-onyx/vite-plugin-svg": patch
+"@sit-onyx/icons": patch
+---
+
+fix(@sit-onyx/vite-plugin-svg): Failing module resolution on Windows systems

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,2 +1,2 @@
 // this virtual import is handled by the @sit-onyx/vite-plugin-svg and will export all SVG icons as JavaScript exports
-export * from "virtual:vite-plugin-svg";
+export type * from "virtual:vite-plugin-svg";

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,2 +1,2 @@
 // this virtual import is handled by the @sit-onyx/vite-plugin-svg and will export all SVG icons as JavaScript exports
-export type * from "virtual:vite-plugin-svg";
+export * from "virtual:vite-plugin-svg";

--- a/packages/vite-plugin-svg/src/index.ts
+++ b/packages/vite-plugin-svg/src/index.ts
@@ -31,6 +31,7 @@ export type PluginOptions = {
  */
 export default function vitePluginSVG(options: PluginOptions): Plugin {
   const virtualModuleId = "virtual:vite-plugin-svg";
+  const typeDefinitionPath = "virtual__vite-plugin-svg.d.ts"; // path must not contain spaces or special characters, to work on Windows systems
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
 
   /** Gets the given path while ensuring cross-platform and correct decoding */
@@ -65,7 +66,7 @@ export default function vitePluginSVG(options: PluginOptions): Plugin {
       // to support intellisense when using the exports
       this.emitFile({
         type: "asset",
-        fileName: `${virtualModuleId}.d.ts`,
+        fileName: typeDefinitionPath,
         source: files.map(({ exportName }) => `export const ${exportName}: string`).join(";\n"),
       });
 
@@ -83,7 +84,7 @@ export default function vitePluginSVG(options: PluginOptions): Plugin {
 
       const newContent = content.replace(
         `from '${virtualModuleId}'`,
-        `from './${virtualModuleId}.d.ts'`,
+        `from './${typeDefinitionPath}'`,
       );
 
       await this.fs.writeFile(dTsPath, newContent, { encoding: "utf8" });

--- a/packages/vite-plugin-svg/src/index.ts
+++ b/packages/vite-plugin-svg/src/index.ts
@@ -71,7 +71,7 @@ export default function vitePluginSVG(options: PluginOptions): Plugin {
       });
 
       return {
-        code: exports.join(";\n"),
+        code: exports.join("\n"),
       };
     },
     async closeBundle() {

--- a/packages/vite-plugin-svg/src/index.ts
+++ b/packages/vite-plugin-svg/src/index.ts
@@ -31,7 +31,8 @@ export type PluginOptions = {
  */
 export default function vitePluginSVG(options: PluginOptions): Plugin {
   const virtualModuleId = "virtual:vite-plugin-svg";
-  const typeDefinitionPath = "virtual__vite-plugin-svg.d.ts"; // path must not contain spaces or special characters, to work on Windows systems
+  // To work on Windows systems, the path must not contain spaces or special characters.
+  const typeDefinitionPath = "virtual__vite-plugin-svg.d.ts";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
 
   /** Gets the given path while ensuring cross-platform and correct decoding */


### PR DESCRIPTION
Relates to #3938

Cause: The typescript definition file was created with the name `virtual:vite-plugin-svg.d.ts`. 
But `:` is a [reserved character on Windows](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions), which causes issues with the module resolution on that OS.

Fix: We now use a file name without any special characters.