### PR TITLE
fix: implement workaround for boolean shorthands not working

### DIFF
--- a/.changeset/dark-insects-deny.md
+++ b/.changeset/dark-insects-deny.md
@@ -6,4 +6,4 @@ fix: implement workaround for boolean shorthands not working
 
 Previously, some boolean properties did not work when used as shorthand, e.g. `<OnyxSelect multiple />` so they had to be explicitly set to `true`.
 
-We've implemented an internal workaround to fix this until the [issue](https://github.com/SchwarzIT/onyx/issues/2741) is officially fixed by the Vue core team.
+We've implemented an internal workaround to fix this until the [issue](https://github.com/SchwarzIT/onyx/issues/3958) is officially fixed by the Vue core team.

--- a/.changeset/dark-insects-deny.md
+++ b/.changeset/dark-insects-deny.md
@@ -3,3 +3,7 @@
 ---
 
 fix: implement workaround for boolean shorthands not working
+
+Previously, some boolean properties did not work when used as shorthand, e.g. `<OnyxSelect multiple />` so they had to be explicitly set to `true`.
+
+We've implemented an internal workaround to fix this until the [issue](https://github.com/SchwarzIT/onyx/issues/2741) is officially fixed by the Vue core team.

--- a/.changeset/dark-insects-deny.md
+++ b/.changeset/dark-insects-deny.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix: implement workaround for boolean shorthands not working

--- a/apps/demo-app/src/views/HomeView.vue
+++ b/apps/demo-app/src/views/HomeView.vue
@@ -174,18 +174,16 @@ const currentProgressStep = ref(3);
 
           <OnyxSwitch v-model="useSkeleton" label="All as Skeleton" :skeleton="false" />
 
-          <!-- eslint-disable vue/prefer-true-attribute-shorthand -- shorthand does not work here, see: https://github.com/SchwarzIT/onyx/issues/2741 -->
           <OnyxSelect
             v-model="componentsToShow"
             :options="configOptions"
             label="Visible examples"
             list-label="Available components"
             text-mode="preview"
-            :multiple="true"
-            :with-check-all="true"
+            multiple
+            with-check-all
             with-search
           />
-          <!-- eslint-enable vue/prefer-true-attribute-shorthand -->
         </div>
       </OnyxSidebar>
     </template>

--- a/apps/demo-app/src/views/HomeView.vue
+++ b/apps/demo-app/src/views/HomeView.vue
@@ -188,6 +188,8 @@ const currentProgressStep = ref(3);
       </OnyxSidebar>
     </template>
 
+    <OnyxBasicDialog modal label="">Dialog</OnyxBasicDialog>
+
     <div :class="`onyx-density-${activeDensityOption}`">
       <section class="page__intro">
         <OnyxHeadline is="h1" :skeleton="false">Component usages</OnyxHeadline>
@@ -396,11 +398,7 @@ const currentProgressStep = ref(3);
           color="primary"
         />
         <OnyxTag v-if="show('OnyxTag')" label="Example interactive tag" clickable="clickable" />
-        <OnyxFilterTag
-          v-if="show('OnyxTag')"
-          label="Example filter tag"
-          clickable="remove Filter"
-        />
+        <OnyxFilterTag v-if="show('OnyxTag')" label="Example filter tag" />
 
         <OnyxTextarea
           v-if="show('OnyxTextarea')"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -75,10 +75,7 @@ const generalVueTsConfig = {
     "vue/valid-define-options": "error",
     "vue/no-setup-props-reactivity-loss": "error",
     "vue/no-restricted-syntax": "error",
-    /**
-     * TODO: Revert after [#2741](https://github.com/SchwarzIT/onyx/issues/2741) is fixed
-     */
-    "vue/prefer-true-attribute-shorthand": ["error", "always", { except: ["open", "multiple"] }],
+    "vue/prefer-true-attribute-shorthand": "error",
     "vue/no-loss-of-precision": "error",
     "vue/no-irregular-whitespace": "error",
     "vue/require-explicit-slots": "error",

--- a/packages/sit-onyx/src/components/OnyxAlertModal/OnyxAlertModal.vue
+++ b/packages/sit-onyx/src/components/OnyxAlertModal/OnyxAlertModal.vue
@@ -3,7 +3,7 @@ import { iconCircleAttention, iconXSmall } from "@sit-onyx/icons";
 import { useId } from "vue";
 import { useDensity } from "../../composables/density.js";
 import { injectI18n } from "../../i18n/index.js";
-import type { Nullable } from "../../types/utils.js";
+import type { NullableBoolean } from "../../types/utils.js";
 import OnyxBasicDialog from "../OnyxBasicDialog/OnyxBasicDialog.vue";
 import OnyxHeadline from "../OnyxHeadline/OnyxHeadline.vue";
 import OnyxIcon from "../OnyxIcon/OnyxIcon.vue";
@@ -18,7 +18,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the modal dialog should be closed.
    */
-  "update:open": [open: Nullable<boolean>];
+  "update:open": [open: NullableBoolean];
 }>();
 
 defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxAlertModal/TestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxAlertModal/TestWrapper.ct.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
 import { iconCircleAttention } from "@sit-onyx/icons";
-import type { Nullable } from "../../types/utils.js";
+import type { NullableBoolean } from "../../types/utils.js";
 import OnyxButton from "../OnyxButton/OnyxButton.vue";
 import OnyxAlertModal from "./OnyxAlertModal.vue";
 
 const emit = defineEmits<{
-  "update:open": [open: Nullable<boolean>];
+  "update:open": [open: NullableBoolean];
 }>();
 </script>
 
@@ -13,7 +13,7 @@ const emit = defineEmits<{
   <OnyxAlertModal
     label="Confirm deletion"
     :icon="{ icon: iconCircleAttention, color: 'danger' }"
-    :open="true"
+    open
     @update:open="emit('update:open', $event)"
   >
     Are you sure that you want to delete the selected item? This action can not be reverted.

--- a/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
@@ -3,7 +3,7 @@ import { useGlobalEventListener, useOutsideClick, wasKeyPressed } from "@sit-ony
 import { computed, useTemplateRef, watch } from "vue";
 import { useDensity } from "../../composables/density.js";
 import { useVModel } from "../../composables/useVModel.js";
-import type { Nullable } from "../../types/index.js";
+import type { NullableBoolean } from "../../types/index.js";
 import type { OnyxBasicDialogProps } from "./types.js";
 
 const props = withDefaults(defineProps<OnyxBasicDialogProps>(), {
@@ -18,7 +18,7 @@ const emit = defineEmits<{
    * Emitted when the dialog should be closed.
    * Opening is always controlled via the `open` prop.
    */
-  "update:open": [open: Nullable<boolean>];
+  "update:open": [open: NullableBoolean];
 }>();
 
 defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxBasicDialog/types.ts
+++ b/packages/sit-onyx/src/components/OnyxBasicDialog/types.ts
@@ -1,5 +1,5 @@
 import type { DensityProp } from "../../composables/density.js";
-import type { Nullable } from "../../types/index.js";
+import type { NullableBoolean } from "../../types/index.js";
 
 export type OnyxBasicDialogProps = DensityProp & {
   /**
@@ -9,7 +9,7 @@ export type OnyxBasicDialogProps = DensityProp & {
   /**
    * Whether the dialog is open.
    */
-  open?: Nullable<boolean>;
+  open?: NullableBoolean;
   /**
    * Whether the dialog is a modal.
    * If `true`, interaction with the rest of the page is prevented and a backdrop is displayed.

--- a/packages/sit-onyx/src/components/OnyxBasicPopover/types.ts
+++ b/packages/sit-onyx/src/components/OnyxBasicPopover/types.ts
@@ -1,6 +1,6 @@
 import type { AnchorPosition } from "../../composables/useAnchorPositionPolyfill.js";
 import type { OpenAlignment } from "../../composables/useOpenAlignment.js";
-import type { Nullable } from "../../types/index.js";
+import type { NullableBoolean } from "../../types/utils.js";
 
 export type OnyxBasicPopoverProps = {
   /**
@@ -10,7 +10,7 @@ export type OnyxBasicPopoverProps = {
   /**
    * Indicates whether the element is expanded or collapsed.
    */
-  open?: Nullable<boolean>;
+  open?: NullableBoolean;
   /**
    * How to position the popover relative to the parent element.
    */

--- a/packages/sit-onyx/src/components/OnyxButton/types.ts
+++ b/packages/sit-onyx/src/components/OnyxButton/types.ts
@@ -1,7 +1,7 @@
 import type { DensityProp } from "../../composables/density.js";
 import type { SkeletonInjected } from "../../composables/useSkeletonState.js";
 import type { AutofocusProp } from "../../types/index.js";
-import type { FormInjected } from "../OnyxForm/OnyxForm.core.js";
+import type { FormInjectedBoolean } from "../OnyxForm/OnyxForm.core.js";
 import type { WithLinkProp } from "../OnyxRouterLink/types.js";
 
 export type OnyxButtonProps = DensityProp &
@@ -13,7 +13,7 @@ export type OnyxButtonProps = DensityProp &
     /**
      * If the button should be disabled or not.
      */
-    disabled?: FormInjected<boolean>;
+    disabled?: FormInjectedBoolean;
     /**
      * Shows a loading indicator.
      */

--- a/packages/sit-onyx/src/components/OnyxCheckbox/types.ts
+++ b/packages/sit-onyx/src/components/OnyxCheckbox/types.ts
@@ -1,11 +1,11 @@
-import type { BaseSelectOption, Nullable, SelectOptionValue } from "../../types/index.js";
+import type { BaseSelectOption, NullableBoolean, SelectOptionValue } from "../../types/index.js";
 
 export type OnyxCheckboxProps<TValue extends SelectOptionValue = SelectOptionValue> =
   BaseSelectOption<TValue> & {
     /**
      * Whether the checkbox is checked.
      */
-    modelValue?: Nullable<boolean>;
+    modelValue?: NullableBoolean;
     /**
      * If `true`, an indeterminate indicator is shown.
      */

--- a/packages/sit-onyx/src/components/OnyxErrorTooltip/OnyxErrorTooltip.vue
+++ b/packages/sit-onyx/src/components/OnyxErrorTooltip/OnyxErrorTooltip.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   /** We don't show an error if the content is not interactive */
   disabled?: boolean;
 }>();
+
 defineSlots<{
   /**
    * Any component. Will be wrapped in an OnyxTooltip showing

--- a/packages/sit-onyx/src/components/OnyxFAB/OnyxFAB.vue
+++ b/packages/sit-onyx/src/components/OnyxFAB/OnyxFAB.vue
@@ -16,6 +16,7 @@ import type { OnyxFABProps } from "./types.js";
 const props = withDefaults(defineProps<OnyxFABProps>(), {
   alignment: "right",
   skeleton: SKELETON_INJECTED_SYMBOL,
+  open: undefined,
 });
 
 const emit = defineEmits<{

--- a/packages/sit-onyx/src/components/OnyxFAB/OnyxFAB.vue
+++ b/packages/sit-onyx/src/components/OnyxFAB/OnyxFAB.vue
@@ -7,7 +7,7 @@ import {
   useSkeletonContext,
 } from "../../composables/useSkeletonState.js";
 import { useVModel } from "../../composables/useVModel.js";
-import type { Nullable } from "../../types/index.js";
+import type { NullableBoolean } from "../../types/index.js";
 import { mergeVueProps } from "../../utils/attrs.js";
 import OnyxFABButton from "../OnyxFABButton/OnyxFABButton.vue";
 import OnyxFlyoutMenu from "../OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue";
@@ -22,7 +22,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the isExpanded state changes.
    */
-  "update:open": [value?: Nullable<boolean>];
+  "update:open": [value?: NullableBoolean];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxFAB/types.ts
+++ b/packages/sit-onyx/src/components/OnyxFAB/types.ts
@@ -1,4 +1,4 @@
-import type { Nullable } from "../../types/index.js";
+import type { NullableBoolean } from "../../types/index.js";
 import type { OnyxFABButtonProps } from "../OnyxFABButton/types.js";
 
 export type OnyxFABProps = OnyxFABButtonProps & {
@@ -10,5 +10,5 @@ export type OnyxFABProps = OnyxFABButtonProps & {
    * Whether the element is expanded or collapsed.
    * If unset, the open state is manged internally.
    */
-  open?: Nullable<boolean>;
+  open?: NullableBoolean;
 };

--- a/packages/sit-onyx/src/components/OnyxFileUpload/examples/FileUploadActionsExample.vue
+++ b/packages/sit-onyx/src/components/OnyxFileUpload/examples/FileUploadActionsExample.vue
@@ -16,7 +16,7 @@ const removeFile = (fileToRemove: File) => {
 </script>
 
 <template>
-  <OnyxFileUpload v-model="allFiles" :multiple="true" class="example-file-upload">
+  <OnyxFileUpload v-model="allFiles" multiple class="example-file-upload">
     <template #default="{ file, status }">
       <OnyxFileCard :filename="file.name" :size="file.size" :status="status">
         <template #actions>

--- a/packages/sit-onyx/src/components/OnyxFileUpload/examples/FileUploadModalExample.vue
+++ b/packages/sit-onyx/src/components/OnyxFileUpload/examples/FileUploadModalExample.vue
@@ -7,6 +7,7 @@ import OnyxIconButton from "../../OnyxIconButton/OnyxIconButton.vue";
 import OnyxModal from "../../OnyxModal/OnyxModal.vue";
 import OnyxSystemButton from "../../OnyxSystemButton/OnyxSystemButton.vue";
 import OnyxFileUpload from "../OnyxFileUpload.vue";
+import type { MediaType } from "../types.js";
 
 const allFiles = ref<File[]>([]);
 const isOpen = ref(false);
@@ -18,7 +19,7 @@ const removeFile = (fileToRemove: File) => {
 
 <template>
   <div class="example-wrapper">
-    <OnyxFileUpload v-model="allFiles" :multiple="true" list-type="hidden" />
+    <OnyxFileUpload v-model="allFiles" multiple list-type="hidden" />
     <OnyxModal v-model:open="isOpen" label="Files">
       <template #default>
         <div v-if="allFiles.length" class="file-list">
@@ -27,7 +28,7 @@ const removeFile = (fileToRemove: File) => {
             :key="file.name"
             :filename="file.name"
             :size="file.size"
-            :type="file.type"
+            :type="file.type as MediaType"
           >
             <template #actions>
               <OnyxIconButton

--- a/packages/sit-onyx/src/components/OnyxFileUpload/types.ts
+++ b/packages/sit-onyx/src/components/OnyxFileUpload/types.ts
@@ -2,7 +2,7 @@ import type { DensityProp } from "../../composables/density.js";
 import type { SkeletonInjected } from "../../composables/useSkeletonState.js";
 import type { Nullable } from "../../types/utils.js";
 import type { BinaryPrefixedSize } from "../../utils/numbers.js";
-import type { FormInjected } from "../OnyxForm/OnyxForm.core.js";
+import type { FormInjectedBoolean } from "../OnyxForm/OnyxForm.core.js";
 import type { SharedFormElementProps } from "../OnyxFormElement/types.js";
 
 export type OnyxFileUploadProps<TMultiple extends boolean> = DensityProp &
@@ -54,7 +54,7 @@ export type OnyxFileUploadProps<TMultiple extends boolean> = DensityProp &
     /**
      * Whether the upload is disabled.
      */
-    disabled?: FormInjected<boolean>;
+    disabled?: FormInjectedBoolean;
     /**
      * The size of the upload container
      * @default large

--- a/packages/sit-onyx/src/components/OnyxFilterTag/OnyxFilterTag.vue
+++ b/packages/sit-onyx/src/components/OnyxFilterTag/OnyxFilterTag.vue
@@ -7,7 +7,7 @@ import {
 } from "../../composables/useSkeletonState.js";
 import { useVModel } from "../../composables/useVModel.js";
 import { injectI18n } from "../../i18n/index.js";
-import type { Nullable } from "../../types/index.js";
+import type { NullableBoolean } from "../../types/index.js";
 import OnyxTag from "../OnyxTag/OnyxTag.vue";
 import type { OnyxTagProps } from "../OnyxTag/types.js";
 
@@ -17,7 +17,7 @@ const props = withDefaults(
       /**
        * If `true` the filter is selected, shows an 'x' icon and can be removed on click.
        */
-      active?: Nullable<boolean>;
+      active?: NullableBoolean;
     }
   >(),
   {
@@ -27,7 +27,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   /** Emitted when the active state changes. */
-  "update:active": [value: Nullable<boolean>];
+  "update:active": [value: NullableBoolean];
 }>();
 
 const { t } = injectI18n();

--- a/packages/sit-onyx/src/components/OnyxFilterTag/OnyxFilterTag.vue
+++ b/packages/sit-onyx/src/components/OnyxFilterTag/OnyxFilterTag.vue
@@ -9,21 +9,12 @@ import { useVModel } from "../../composables/useVModel.js";
 import { injectI18n } from "../../i18n/index.js";
 import type { NullableBoolean } from "../../types/index.js";
 import OnyxTag from "../OnyxTag/OnyxTag.vue";
-import type { OnyxTagProps } from "../OnyxTag/types.js";
+import type { OnyxFilterTagProps } from "./types.js";
 
-const props = withDefaults(
-  defineProps<
-    Omit<OnyxTagProps, "color" | "clickable"> & {
-      /**
-       * If `true` the filter is selected, shows an 'x' icon and can be removed on click.
-       */
-      active?: NullableBoolean;
-    }
-  >(),
-  {
-    skeleton: SKELETON_INJECTED_SYMBOL,
-  },
-);
+const props = withDefaults(defineProps<OnyxFilterTagProps>(), {
+  skeleton: SKELETON_INJECTED_SYMBOL,
+  active: undefined,
+});
 
 const emit = defineEmits<{
   /** Emitted when the active state changes. */
@@ -52,11 +43,7 @@ const skeleton = useSkeletonContext(props);
     :clickable="{ label: tooltipLabel, actionIcon: active ? iconXSmall : undefined }"
     class="onyx-filter-tag"
     :skeleton="skeleton"
-    @click="
-      () => {
-        active = !active;
-      }
-    "
+    @click="active = !active"
   />
 </template>
 

--- a/packages/sit-onyx/src/components/OnyxFilterTag/types.ts
+++ b/packages/sit-onyx/src/components/OnyxFilterTag/types.ts
@@ -1,0 +1,9 @@
+import type { NullableBoolean } from "../../types/utils.js";
+import type { OnyxTagProps } from "../OnyxTag/types.js";
+
+export type OnyxFilterTagProps = Omit<OnyxTagProps, "color" | "clickable"> & {
+  /**
+   * If `true` the filter is selected, shows an 'x' icon and can be removed on click.
+   */
+  active?: NullableBoolean;
+};

--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.spec-d.ts
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.spec-d.ts
@@ -10,11 +10,10 @@ import type OnyxSelect from "../OnyxSelect/OnyxSelect.vue";
 import type OnyxStepper from "../OnyxStepper/OnyxStepper.vue";
 import OnyxSwitch from "../OnyxSwitch/OnyxSwitch.vue";
 import type OnyxTextarea from "../OnyxTextarea/OnyxTextarea.vue";
-import { type __DONT_USE_VUE_FIX_KeyOfFormProps, type FormProps } from "./OnyxForm.core.js";
+import { type FormInjectedProps, type FormProps } from "./OnyxForm.core.js";
 
-it("should be ensured that _KeyofFormProps includes all keys of FormProps", async () => {
-  expectTypeOf<keyof FormProps>().toExtend<__DONT_USE_VUE_FIX_KeyOfFormProps>();
-  expectTypeOf<__DONT_USE_VUE_FIX_KeyOfFormProps>().toExtend<keyof FormProps>();
+it("should be ensured that FormInjectedProps includes all keys of FormProps", async () => {
+  expectTypeOf<keyof FormProps>().toExtend<keyof FormInjectedProps>();
 });
 
 type AllOnyxFormElements =

--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.ts
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.ts
@@ -15,22 +15,25 @@ export type FormProps = {
    * Disabled makes the element not mutable, focusable, or even submitted with the form.
    * It will also not be validated.
    *
-   * Defaults to `false`.
+   * @default `false`
    */
   disabled?: boolean;
   /**
    * Configures if and when errors are shown.
-   * When `true`, errors will be shown initially.
-   * When `false`, errors will never be shown. ⚠️ Only the displaying of the error is effected! An error can still block submission!
+   * - `true`: errors will be shown initially.
+   * - `false`: errors will never be shown. ⚠️ Only the displaying of the error is effected! An error can still block submission!
+   * - "touched": only shows an error *after* a user has significantly interacted with the input, see [:user-invalid](https://drafts.csswg.org/selectors/#user-invalid-pseudo)
    *
-   * The default is `"touched"`, which only shows an error *after* a user has significantly interacted with the input.
-   * See [:user-invalid](https://drafts.csswg.org/selectors/#user-invalid-pseudo).
+   * @default "touched"
    */
   showError?: ShowErrorMode;
   /**
-   * Required mode: `optional` will show an `(optional)` text after the label for optional form elements.
-   * `required` will show an `*` indicator for required inputs after the label instead.
+   * How to display the required / optional marker.
+   * - optional: will show an `(optional)` text after the label for optional form elements.
+   * - required: will show an `*` indicator for required inputs after the label instead.
+   *
    * No marker will be visible if the label is hidden.
+   *
    * @default undefined By default the parents setting is used, if none is defined on any `required` is the default.
    */
   requiredMarker?: RequiredMarkerType;
@@ -44,20 +47,36 @@ export type FormComputedProps = {
 };
 
 /**
- * ❗️ DO NOT USE THIS TYPE ❗️
- *
- * Manual replication of the `keyof FormProps` type.
- * Unfortunately this is necessary because Vue can only support simple index types.
- *
- * See discussion in https://github.com/vuejs/core/issues/8286
- */
-export type __DONT_USE_VUE_FIX_KeyOfFormProps = "disabled" | "showError" | "requiredMarker";
-
-/**
  * Props that may be used by the form child components.
  */
 export type FormInjectedProps = {
-  [TKey in __DONT_USE_VUE_FIX_KeyOfFormProps]?: FormInjected<FormProps[TKey]>;
+  /**
+   * Whether the input should be disabled and prevent the user from interacting with it.
+   * Disabled makes the element not mutable, focusable, or even submitted with the form.
+   * It will also not be validated.
+   *
+   * @default Inherits value from closest `<OnyxForm>` component or `false` if none exists
+   */
+  disabled?: FormInjectedBoolean;
+  /**
+   * Configures if and when errors are shown.
+   * - `true`: errors will be shown initially.
+   * - `false`: errors will never be shown. ⚠️ Only the displaying of the error is effected! An error can still block submission!
+   * - "touched": only shows an error *after* a user has significantly interacted with the input, see [:user-invalid](https://drafts.csswg.org/selectors/#user-invalid-pseudo)
+   *
+   * @default Inherits value from closest `<OnyxForm>` component or `touched` if none exists
+   */
+  showError?: FormInjectedBoolean | FormInjected<ShowErrorMode>;
+  /**
+   * How to display the required / optional marker.
+   * - optional: will show an `(optional)` text after the label for optional form elements.
+   * - required: will show an `*` indicator for required inputs after the label instead.
+   *
+   * No marker will be visible if the label is hidden.
+   *
+   * @default Inherits value from closest `<OnyxForm>` component or `required` if none exists
+   */
+  requiredMarker?: FormInjected<RequiredMarkerType>;
 };
 
 /**
@@ -81,6 +100,11 @@ export type FORM_INJECTED = symbol; // we can't use `typeof FORM_INJECTED_SYMBOL
  * ```
  */
 export type FormInjected<T> = T | FORM_INJECTED;
+
+/**
+ * @deprecated TODO: replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/2741 is fixed
+ */
+export type FormInjectedBoolean = boolean | FORM_INJECTED;
 
 const createCompute = <TKey extends keyof FormProps>(
   formProps: Ref<FormProps> | undefined,

--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.ts
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.ts
@@ -102,7 +102,7 @@ export type FORM_INJECTED = symbol; // we can't use `typeof FORM_INJECTED_SYMBOL
 export type FormInjected<T> = T | FORM_INJECTED;
 
 /**
- * @deprecated TODO: delete this type and replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/2741 is fixed
+ * @deprecated TODO: delete this type and replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/3958 is fixed
  */
 export type FormInjectedBoolean = boolean | FORM_INJECTED;
 

--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.ts
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.ts
@@ -102,7 +102,7 @@ export type FORM_INJECTED = symbol; // we can't use `typeof FORM_INJECTED_SYMBOL
 export type FormInjected<T> = T | FORM_INJECTED;
 
 /**
- * @deprecated TODO: replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/2741 is fixed
+ * @deprecated TODO: delete this type and replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/2741 is fixed
  */
 export type FormInjectedBoolean = boolean | FORM_INJECTED;
 

--- a/packages/sit-onyx/src/components/OnyxIconButton/types.ts
+++ b/packages/sit-onyx/src/components/OnyxIconButton/types.ts
@@ -2,7 +2,7 @@ import type { DensityProp } from "../../composables/density.js";
 import type { SkeletonInjected } from "../../composables/useSkeletonState.js";
 import type { AutofocusProp } from "../../types/index.js";
 import type { ButtonColor, ButtonType, OnyxButtonProps } from "../OnyxButton/types.js";
-import type { FormInjected } from "../OnyxForm/OnyxForm.core.js";
+import type { FormInjectedBoolean } from "../OnyxForm/OnyxForm.core.js";
 
 export type OnyxIconButtonProps = DensityProp &
   AutofocusProp &
@@ -14,7 +14,7 @@ export type OnyxIconButtonProps = DensityProp &
     /**
      * If the button should be disabled or not.
      */
-    disabled?: FormInjected<boolean>;
+    disabled?: FormInjectedBoolean;
     /**
      * The button type.
      */

--- a/packages/sit-onyx/src/components/OnyxModal/OnyxModal.vue
+++ b/packages/sit-onyx/src/components/OnyxModal/OnyxModal.vue
@@ -3,7 +3,7 @@ import { iconXSmall } from "@sit-onyx/icons";
 import { computed, useId } from "vue";
 import { useDensity } from "../../composables/density.js";
 import { injectI18n } from "../../i18n/index.js";
-import type { Nullable } from "../../types/index.js";
+import type { NullableBoolean } from "../../types/index.js";
 import OnyxBasicDialog from "../OnyxBasicDialog/OnyxBasicDialog.vue";
 import OnyxHeadline from "../OnyxHeadline/OnyxHeadline.vue";
 import OnyxSystemButton from "../OnyxSystemButton/OnyxSystemButton.vue";
@@ -16,7 +16,7 @@ const emit = defineEmits<{
    * Emitted when the modal dialog should be closed.
    * Opening is always controlled via the `open` prop.
    */
-  "update:open": [open: Nullable<boolean>];
+  "update:open": [open: NullableBoolean];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxModal/TestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxModal/TestWrapper.ct.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { Nullable } from "../../types/utils.js";
+import type { NullableBoolean } from "../../types/utils.js";
 import type { DialogAlignment } from "../OnyxBasicDialog/types.js";
 import OnyxModal from "./OnyxModal.vue";
 
@@ -15,7 +15,7 @@ defineSlots<{
 }>();
 
 const emit = defineEmits<{
-  "update:open": [open: Nullable<boolean>];
+  "update:open": [open: NullableBoolean];
 }>();
 </script>
 
@@ -23,7 +23,7 @@ const emit = defineEmits<{
   <OnyxModal
     label="Example modal dialog"
     :alignment="props.alignment"
-    :open="true"
+    open
     @update:open="emit('update:open', $event)"
   >
     <template #headline>

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.ct.tsx
@@ -525,7 +525,6 @@ test("should switch to mobile correctly", async ({ mount, page }) => {
   ] as TestCase[];
 
   for (const { setting, expectedMobile, viewportWidth } of testCases) {
-    // eslint-disable-next-line playwright/no-conditional-in-test -- conditional is only used in test title
     await test.step(`should${expectedMobile ? "" : " not"} render in mobile for mobile prop "${setting}" and a viewport width of ${viewportWidth}px`, async () => {
       await page.setViewportSize({ width: viewportWidth, height: 400 });
       await component.update({

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxColorSchemeDialog/OnyxColorSchemeDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxColorSchemeDialog/OnyxColorSchemeDialog.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 import { injectI18n } from "../../../../i18n/index.js";
-import type { Nullable } from "../../../../types/utils.js";
+import type { NullableBoolean } from "../../../../types/utils.js";
 import OnyxSelectDialog from "../../../OnyxSelectDialog/OnyxSelectDialog.vue";
 import type { SelectDialogOption } from "../../../OnyxSelectDialog/types.js";
 import autoImage from "./auto.svg?raw";
@@ -21,7 +21,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the dialog should be closed.
    */
-  "update:open": [value: Nullable<boolean>];
+  "update:open": [value: NullableBoolean];
 }>();
 
 const { t } = injectI18n();

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.ct.tsx
@@ -158,9 +158,7 @@ test.describe("Disabled Screenshot tests", () => {
 
 test("should behave correctly with nested items (via mouse)", async ({ page, mount }) => {
   // ARRANGE
-  await mount(TestWrapperNestedCt, {
-    props: { label: "Choose item" },
-  });
+  await mount(<TestWrapperNestedCt />);
 
   const trigger = page.getByRole("button", { name: "Trigger" });
   const firstItem = page.getByRole("menuitem", { name: "Item 1", exact: true });

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
@@ -3,7 +3,7 @@
 import { createMenuButton } from "@sit-onyx/headless";
 import { computed, ref, type ComponentInstance, type VNodeRef } from "vue";
 import { useVModel } from "../../../../composables/useVModel.js";
-import type { Nullable } from "../../../../types/index.js";
+import type { NullableBoolean } from "../../../../types/index.js";
 import { mergeVueProps } from "../../../../utils/attrs.js";
 import OnyxBasicPopover from "../../../OnyxBasicPopover/OnyxBasicPopover.vue";
 import type { OnyxFlyoutMenuProps } from "./types.js";
@@ -18,7 +18,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the isExpanded state changes.
    */
-  "update:open": [value?: Nullable<boolean>];
+  "update:open": [value?: NullableBoolean];
 }>();
 
 /**

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/TestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/TestWrapper.ct.vue
@@ -5,7 +5,9 @@ import OnyxMenuItem from "../OnyxMenuItem/OnyxMenuItem.vue";
 import OnyxFlyoutMenu from "./OnyxFlyoutMenu.vue";
 import type { OnyxFlyoutMenuProps } from "./types.js";
 
-const props = defineProps<OnyxFlyoutMenuProps>();
+const props = withDefaults(defineProps<OnyxFlyoutMenuProps>(), {
+  open: undefined,
+});
 </script>
 
 <template>

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/TestWrapperNested.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/TestWrapperNested.ct.vue
@@ -4,11 +4,11 @@ import OnyxMenuItem from "../OnyxMenuItem/OnyxMenuItem.vue";
 import OnyxFlyoutMenu from "./OnyxFlyoutMenu.vue";
 import type { OnyxFlyoutMenuProps } from "./types.js";
 
-const props = defineProps<OnyxFlyoutMenuProps>();
+const props = defineProps<Pick<OnyxFlyoutMenuProps, "trigger">>();
 </script>
 
 <template>
-  <OnyxFlyoutMenu v-bind="props">
+  <OnyxFlyoutMenu v-bind="props" label="Choose item">
     <template #button="{ trigger: _trigger }">
       <button type="button" v-bind="_trigger">Trigger</button>
     </template>

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/types.ts
@@ -1,4 +1,4 @@
-import type { Nullable } from "../../../../types/index.js";
+import type { NullableBoolean } from "../../../../types/index.js";
 import type { OnyxBasicPopoverProps } from "../../../OnyxBasicPopover/types.js";
 
 export type OnyxFlyoutMenuProps = Pick<OnyxBasicPopoverProps, "alignment"> & {
@@ -14,7 +14,7 @@ export type OnyxFlyoutMenuProps = Pick<OnyxBasicPopoverProps, "alignment"> & {
   /**
    * Indicates whether the element is expanded or collapsed.
    */
-  open?: Nullable<boolean>;
+  open?: NullableBoolean;
   /**
    * Whether the flyout is disabled and can not be opened.
    */

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue
@@ -20,6 +20,18 @@ const { t } = injectI18n();
 
 const { rootAttrs, restAttrs } = useRootAttrs();
 
+const props = withDefaults(defineProps<OnyxMenuItemProps>(), {
+  active: "auto",
+  open: undefined,
+});
+
+const emit = defineEmits<{
+  /**
+   * Emitted when the open state should update.
+   */
+  "update:open": [value: NullableBoolean];
+}>();
+
 const slots = defineSlots<{
   /**
    * Button/link text and additional inline content.
@@ -29,17 +41,6 @@ const slots = defineSlots<{
    * Children menuitems.
    */
   children(): unknown;
-}>();
-
-const props = withDefaults(defineProps<OnyxMenuItemProps>(), {
-  active: "auto",
-});
-
-const emit = defineEmits<{
-  /**
-   * Emitted when the open state should update.
-   */
-  "update:open": [value: NullableBoolean];
 }>();
 
 /**

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue
@@ -5,7 +5,7 @@ import { computed, nextTick, useTemplateRef, withModifiers } from "vue";
 import { useLink } from "../../../../composables/useLink.js";
 import { useVModel } from "../../../../composables/useVModel.js";
 import { injectI18n } from "../../../../i18n/index.js";
-import type { Nullable } from "../../../../types/index.js";
+import type { NullableBoolean } from "../../../../types/index.js";
 import { mergeVueProps, useRootAttrs } from "../../../../utils/attrs.js";
 import { extractLinkProps } from "../../../../utils/router.js";
 import ButtonOrLinkLayout from "../../../OnyxButton/ButtonOrLinkLayout.vue";
@@ -39,7 +39,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the open state should update.
    */
-  "update:open": [value: Nullable<boolean>];
+  "update:open": [value: NullableBoolean];
 }>();
 
 /**

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/types.ts
@@ -1,11 +1,11 @@
-import type { Nullable, OnyxColor } from "../../../../types/index.js";
+import type { NullableBoolean, OnyxColor } from "../../../../types/index.js";
 import type { WithLinkProp } from "../../../OnyxRouterLink/types.js";
 
 export type OnyxMenuItemProps = WithLinkProp & {
   /**
    * If the children of the menu item are visible.
    */
-  open?: Nullable<boolean>;
+  open?: NullableBoolean;
   /**
    * Label text for the menu item.
    */

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
@@ -5,7 +5,7 @@ import { useLink } from "../../../../composables/useLink.js";
 import { useMoreListChild } from "../../../../composables/useMoreList.js";
 import { useVModel } from "../../../../composables/useVModel.js";
 import { injectI18n } from "../../../../i18n/index.js";
-import type { Nullable } from "../../../../types/index.js";
+import type { NullableBoolean } from "../../../../types/index.js";
 import { mergeVueProps, useRootAttrs } from "../../../../utils/attrs.js";
 import OnyxButton from "../../../OnyxButton/OnyxButton.vue";
 import OnyxSeparator from "../../../OnyxSeparator/OnyxSeparator.vue";
@@ -30,7 +30,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the state of mobile children visibility changes.
    */
-  "update:open": [value: Nullable<boolean>];
+  "update:open": [value: NullableBoolean];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/types.ts
@@ -1,4 +1,4 @@
-import type { Nullable } from "../../../../types/index.js";
+import type { NullableBoolean } from "../../../../types/index.js";
 import type { WithLinkProp } from "../../../OnyxRouterLink/types.js";
 
 export type OnyxNavItemProps = WithLinkProp<true> & {
@@ -16,5 +16,5 @@ export type OnyxNavItemProps = WithLinkProp<true> & {
   /**
    * Controls whether child elements are open.
    */
-  open?: Nullable<boolean>;
+  open?: NullableBoolean;
 };

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/OnyxUserMenu.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/OnyxUserMenu.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, inject } from "vue";
 import { useVModel } from "../../../../composables/useVModel.js";
-import type { Nullable } from "../../../../types/index.js";
+import type { NullableBoolean } from "../../../../types/index.js";
 import OnyxAvatar from "../../../OnyxAvatar/OnyxAvatar.vue";
 import { MOBILE_NAV_BAR_INJECTION_KEY } from "../../types.js";
 import type { OnyxUserMenuProps } from "./types.js";
@@ -15,7 +15,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the state of flyoutOpen changes.
    */
-  "update:flyoutOpen": [value: Nullable<boolean>];
+  "update:flyoutOpen": [value: NullableBoolean];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/UserMenuLayout.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/UserMenuLayout.vue
@@ -3,7 +3,7 @@
 // to easily switch between mobile and desktop layout
 import { useVModel } from "../../../../composables/useVModel.js";
 import { injectI18n } from "../../../../i18n/index.js";
-import type { Nullable, SelectOptionValue } from "../../../../types/index.js";
+import type { NullableBoolean, SelectOptionValue } from "../../../../types/index.js";
 import OnyxListItem from "../../../OnyxListItem/OnyxListItem.vue";
 import OnyxFlyoutMenu from "../OnyxFlyoutMenu/OnyxFlyoutMenu.vue";
 
@@ -16,7 +16,7 @@ const props = withDefaults(
     /**
      * Controls whether the flyout menu is open.
      */
-    flyoutOpen?: Nullable<boolean>;
+    flyoutOpen?: NullableBoolean;
     /**
      * Whether the flyout is disabled and can not be opened.
      */
@@ -30,7 +30,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the state of flyoutOpen changes.
    */
-  "update:flyoutOpen": [value?: Nullable<boolean>];
+  "update:flyoutOpen": [value?: NullableBoolean];
 }>();
 
 /**

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/types.ts
@@ -1,4 +1,4 @@
-import type { Nullable } from "../../../../types/index.js";
+import type { NullableBoolean } from "../../../../types/index.js";
 import type { OnyxAvatarProps } from "../../../OnyxAvatar/types.js";
 
 export type OnyxUserMenuProps = {
@@ -19,7 +19,7 @@ export type OnyxUserMenuProps = {
   /**
    * Controls whether the flyout menu is open.
    */
-  flyoutOpen?: Nullable<boolean>;
+  flyoutOpen?: NullableBoolean;
   /**
    * Whether the user menu is disabled and can not be opened.
    */

--- a/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
+++ b/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
@@ -182,14 +182,14 @@ const filteredOptions = computed(() => {
 const isMultiple = computed(() => {
   // currently there is a Vue bug that when setting multiple as boolean shorthand, e.g. "<OnyxSelect multiple />"
   // it is not applied correctly and instead passed as empty string
-  // see: https://github.com/SchwarzIT/onyx/issues/2741
+  // see: https://github.com/SchwarzIT/onyx/issues/3958
   return props.multiple || (props.multiple as typeof props.multiple | string) === "";
 });
 
 const hasCheckAll = computed(() => {
   // currently there is a Vue bug that when setting withCheckAll as boolean shorthand, e.g. "<OnyxSelect with-check-all />"
   // it is not applied correctly and instead passed as empty string
-  // see: https://github.com/SchwarzIT/onyx/issues/2741
+  // see: https://github.com/SchwarzIT/onyx/issues/3958
   return props.withCheckAll || (props.withCheckAll as typeof props.withCheckAll | string) === "";
 });
 

--- a/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
+++ b/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
@@ -179,13 +179,27 @@ const filteredOptions = computed(() => {
   );
 });
 
+const isMultiple = computed(() => {
+  // currently there is a Vue bug that when setting multiple as boolean shorthand, e.g. "<OnyxSelect multiple />"
+  // it is not applied correctly and instead passed as empty string
+  // see: https://github.com/SchwarzIT/onyx/issues/2741
+  return props.multiple || (props.multiple as typeof props.multiple | string) === "";
+});
+
+const hasCheckAll = computed(() => {
+  // currently there is a Vue bug that when setting withCheckAll as boolean shorthand, e.g. "<OnyxSelect with-check-all />"
+  // it is not applied correctly and instead passed as empty string
+  // see: https://github.com/SchwarzIT/onyx/issues/2741
+  return props.withCheckAll || (props.withCheckAll as typeof props.withCheckAll | string) === "";
+});
+
 /**
  * Sync the active option with the selected option on single select.
  */
 watch(
   arrayValue,
   () => {
-    if (!props.multiple) {
+    if (!isMultiple.value) {
       activeValue.value = arrayValue.value.at(0);
     }
   },
@@ -200,7 +214,7 @@ const CHECK_ALL_ID = useId() as TValue;
  * Includes "select all" up front if it is used.
  */
 const allKeyboardOptionIds = computed(() => {
-  return (props.multiple && props.withCheckAll && !searchTerm.value ? [CHECK_ALL_ID] : []).concat(
+  return (isMultiple.value && hasCheckAll.value && !searchTerm.value ? [CHECK_ALL_ID] : []).concat(
     enabledOptionValues.value,
   );
 });
@@ -278,7 +292,7 @@ const onSelect = (selectedOption: TValue) => {
   if (!newValue) {
     return;
   }
-  if (!props.multiple) {
+  if (!isMultiple.value) {
     modelValue.value = selectedOption as unknown as TModelValue;
     return;
   }
@@ -296,7 +310,7 @@ const onSelect = (selectedOption: TValue) => {
 
 const autocomplete = computed<ComboboxAutoComplete>(() => (props.withSearch ? "list" : "none"));
 
-const { label, listLabel, listDescription, multiple } = toRefs(props);
+const { label, listLabel, listDescription } = toRefs(props);
 
 const {
   elements: { input, option: headlessOption, group: headlessGroup, listbox },
@@ -305,7 +319,7 @@ const {
   label,
   listLabel,
   listDescription,
-  multiple,
+  multiple: isMultiple,
   activeOption: computed(() => activeValue.value),
   isExpanded: open,
   templateRef: select,
@@ -359,7 +373,7 @@ const enabledOptionValues = computed(() =>
  * Only available when multiple and withCheckAll are set.
  */
 const checkAll = computed(() => {
-  if (!props.multiple || !props.withCheckAll) return undefined;
+  if (!isMultiple.value || !hasCheckAll.value) return undefined;
   return useCheckAll(enabledOptionValues, arrayValue, (newValues: TValue[]) => {
     // with selectedOptions we verify that the options all still exist
     const selectedOptions: TValue[] = newValues
@@ -370,12 +384,12 @@ const checkAll = computed(() => {
 });
 
 const checkAllLabel = computed<string>(() => {
-  if (!props.multiple) {
+  if (!isMultiple.value) {
     return "";
   }
   const defaultText = t.value("selections.selectAll");
-  if (typeof props.withCheckAll === "boolean") return defaultText;
-  return props.withCheckAll?.label ?? defaultText;
+  if (typeof props.withCheckAll === "object") return props.withCheckAll.label ?? defaultText;
+  return defaultText;
 });
 
 watchEffect(() => {
@@ -461,7 +475,7 @@ watch(
             <template v-else>
               <!-- select-all option for "multiple" -->
               <ul
-                v-if="props.multiple && props.withCheckAll && !searchTerm"
+                v-if="isMultiple && hasCheckAll && !searchTerm"
                 class="onyx-select__check-all"
                 v-bind="headlessGroup({ label: checkAllLabel })"
               >
@@ -508,7 +522,7 @@ watch(
                       selected: arrayValue.some((value: TValue) => value === option.value),
                     })
                   "
-                  :multiple="props.multiple"
+                  :multiple="isMultiple"
                   :active="option.value === activeValue"
                   :icon="option.icon"
                   :density="props.density"

--- a/packages/sit-onyx/src/components/OnyxSelect/types.ts
+++ b/packages/sit-onyx/src/components/OnyxSelect/types.ts
@@ -3,9 +3,10 @@ import type {
   AutofocusProp,
   BaseSelectOption,
   Nullable,
+  NullableBoolean,
   SelectOptionValue,
 } from "../../types/index.js";
-import type { FormInjected } from "../OnyxForm/OnyxForm.core.js";
+import type { FormInjectedBoolean } from "../OnyxForm/OnyxForm.core.js";
 import type { OnyxSelectInputProps } from "../OnyxSelectInput/types.js";
 import type { OnyxSelectOptionProps } from "../OnyxSelectOption/types.js";
 
@@ -48,11 +49,10 @@ export type OnyxSelectProps<
               label?: string;
             }
       : never;
-
     /**
      * Whether the select should be disabled.
      */
-    disabled?: FormInjected<boolean>;
+    disabled?: FormInjectedBoolean;
     /**
      * Label that will be shown in the input of OnyxSelect.
      * If unset, will be managed internally by comparing `modelValue` with `options`.
@@ -84,7 +84,6 @@ export type OnyxSelectProps<
      * If you want to use a button instead, use the `optionsEnd` slot.
      */
     lazyLoading?: SelectLazyLoading;
-
     /**
      * Whether to preserve the selection order when reopening the dropdown.
      */
@@ -94,7 +93,13 @@ export type OnyxSelectProps<
      * Currently selected options. Can be either a single value or an array of values.
      */
     modelValue?: Nullable<TModelValue>;
-    open?: Nullable<boolean>;
+    /**
+     * Whether the flyout is currently open.
+     */
+    open?: NullableBoolean;
+    /**
+     * Current search term when `withSearch` is enabled.
+     */
     searchTerm?: Nullable<string>;
   };
 

--- a/packages/sit-onyx/src/components/OnyxSelectDialog/OnyxSelectDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxSelectDialog/OnyxSelectDialog.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup generic="TValue extends string">
 import { ref, useId, watchEffect } from "vue";
 import { injectI18n } from "../../i18n/index.js";
-import type { Nullable } from "../../types/index.js";
+import type { NullableBoolean } from "../../types/index.js";
 import OnyxBottomBar from "../OnyxBottomBar/OnyxBottomBar.vue";
 import OnyxButton from "../OnyxButton/OnyxButton.vue";
 import OnyxCard from "../OnyxCard/OnyxCard.vue";
@@ -22,7 +22,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the dialog should be closed.
    */
-  "update:open": [open: Nullable<boolean>];
+  "update:open": [open: NullableBoolean];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxSelectInput/types.ts
+++ b/packages/sit-onyx/src/components/OnyxSelectInput/types.ts
@@ -15,6 +15,9 @@ export type OnyxSelectInputProps = Omit<SharedFormElementProps, "maxlength" | "w
    *            A number-badge appears next to it including a tooltip with all selected names.
    */
   textMode?: MultiselectTextMode;
+  /**
+   * Whether to hide the check icon when the input is in a success state.
+   */
   hideSuccessIcon?: boolean;
   /**
    * Highlight input as if it has focus.

--- a/packages/sit-onyx/src/components/OnyxSwitch/OnyxSwitch.vue
+++ b/packages/sit-onyx/src/components/OnyxSwitch/OnyxSwitch.vue
@@ -25,6 +25,7 @@ const props = withDefaults(defineProps<OnyxSwitchProps>(), {
   truncation: "ellipsis",
   requiredMarker: FORM_INJECTED_SYMBOL,
   skeleton: SKELETON_INJECTED_SYMBOL,
+  showError: FORM_INJECTED_SYMBOL,
   modelValue: undefined,
 });
 

--- a/packages/sit-onyx/src/components/OnyxSwitch/OnyxSwitch.vue
+++ b/packages/sit-onyx/src/components/OnyxSwitch/OnyxSwitch.vue
@@ -10,7 +10,7 @@ import {
   useSkeletonContext,
 } from "../../composables/useSkeletonState.js";
 import { useVModel } from "../../composables/useVModel.js";
-import type { Nullable } from "../../types/index.js";
+import type { NullableBoolean } from "../../types/index.js";
 import { useRootAttrs } from "../../utils/attrs.js";
 import OnyxErrorTooltip from "../OnyxErrorTooltip/OnyxErrorTooltip.vue";
 import { FORM_INJECTED_SYMBOL, useFormContext } from "../OnyxForm/OnyxForm.core.js";
@@ -30,7 +30,7 @@ const props = withDefaults(defineProps<OnyxSwitchProps>(), {
 
 const emit = defineEmits<{
   /** Emitted when the checked state changes. */
-  "update:modelValue": [value?: Nullable<boolean>];
+  "update:modelValue": [value?: NullableBoolean];
   /**
    * Emitted when the validity state of the input changes.
    */

--- a/packages/sit-onyx/src/components/OnyxSwitch/types.ts
+++ b/packages/sit-onyx/src/components/OnyxSwitch/types.ts
@@ -1,4 +1,4 @@
-import type { BaseSelectOption, Nullable, SelectOptionValue } from "../../types/index.js";
+import type { BaseSelectOption, NullableBoolean, SelectOptionValue } from "../../types/index.js";
 
 export type OnyxSwitchProps<TValue extends SelectOptionValue = SelectOptionValue> = Omit<
   BaseSelectOption<TValue>,
@@ -7,5 +7,5 @@ export type OnyxSwitchProps<TValue extends SelectOptionValue = SelectOptionValue
   /**
    * Whether the switch should be checked or not.
    */
-  modelValue?: Nullable<boolean>;
+  modelValue?: NullableBoolean;
 };

--- a/packages/sit-onyx/src/index.ts
+++ b/packages/sit-onyx/src/index.ts
@@ -210,6 +210,7 @@ export { default as OnyxFileUpload } from "./components/OnyxFileUpload/OnyxFileU
 export * from "./components/OnyxFileUpload/types.js";
 
 export { default as OnyxFilterTag } from "./components/OnyxFilterTag/OnyxFilterTag.vue";
+export * from "./components/OnyxFilterTag/types.js";
 
 export { default as OnyxBasicPopover } from "./components/OnyxBasicPopover/OnyxBasicPopover.vue";
 export * from "./components/OnyxBasicPopover/types.js";

--- a/packages/sit-onyx/src/types/utils.ts
+++ b/packages/sit-onyx/src/types/utils.ts
@@ -98,6 +98,6 @@ export type Nullable<T = never> = T | undefined | null;
 /**
  * A boolean type that can also be null or undefined.
  *
- * @deprecated TODO: replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/2741 is fixed
+ * @deprecated TODO: delete this type and replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/2741 is fixed
  */
 export type NullableBoolean = boolean | undefined | null;

--- a/packages/sit-onyx/src/types/utils.ts
+++ b/packages/sit-onyx/src/types/utils.ts
@@ -94,3 +94,10 @@ export type PrimitiveType = null | number | string | boolean | symbol;
  * A type that can also be null or undefined.
  */
 export type Nullable<T = never> = T | undefined | null;
+
+/**
+ * A boolean type that can also be null or undefined.
+ *
+ * @deprecated TODO: replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/2741 is fixed
+ */
+export type NullableBoolean = boolean | undefined | null;

--- a/packages/sit-onyx/src/types/utils.ts
+++ b/packages/sit-onyx/src/types/utils.ts
@@ -98,6 +98,6 @@ export type Nullable<T = never> = T | undefined | null;
 /**
  * A boolean type that can also be null or undefined.
  *
- * @deprecated TODO: delete this type and replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/2741 is fixed
+ * @deprecated TODO: delete this type and replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/3958 is fixed
  */
 export type NullableBoolean = boolean | undefined | null;


### PR DESCRIPTION
closes #2741

Previously, some boolean properties did not work when used as shorthand, e.g. `<OnyxSelect multiple />` so they had to be explicitly set to `true`.

We've implemented an internal workaround to fix this until the [issue](https://github.com/SchwarzIT/onyx/issues/2741) is officially fixed by the Vue core team.


## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
