### PR TITLE
docs: fix changelog for version `1.0.0-beta.290`

### DIFF
--- a/.changeset/forty-dogs-stand.md
+++ b/.changeset/forty-dogs-stand.md
@@ -18,9 +18,10 @@ feat!: Renamed Popover, Dialog, Modal components
 <template>
   <!-- OLD -->
   <OnyxComponent :open="isOpen" @close="isOpen = false" />
-  <OnyxComponent open @close="onClose" />
+  <OnyxComponent :open="isOpen" @close="onClose" />
+
   <!-- is now NEW -->
   <OnyxComponent v-model:open="isOpen" />
-  <OnyxComponent open @update:open="$event && onClose($event)" />
+  <OnyxComponent :open="isOpen" @update:open="!$event && onClose()" />
 </template>
 ```

--- a/packages/sit-onyx/CHANGELOG.md
+++ b/packages/sit-onyx/CHANGELOG.md
@@ -72,10 +72,11 @@
   <template>
     <!-- OLD -->
     <OnyxComponent :open="isOpen" @close="isOpen = false" />
-    <OnyxComponent open @close="onClose" />
+    <OnyxComponent :open="isOpen" @close="onClose" />
+
     <!-- is now NEW -->
     <OnyxComponent v-model:open="isOpen" />
-    <OnyxComponent open @update:open="$event && onClose($event)" />
+    <OnyxComponent :open="isOpen" @update:open="!$event && onClose()" />
   </template>
   ```
 


### PR DESCRIPTION
I received feedback that the changelog for version 1.0.0-beta.290 is incorrect because it documents to use `$event && onClose` although it should be `!$event && onClose`