### PR TITLE
refactor: revert workaround for boolean casting

### DIFF
--- a/.changeset/silly-colts-bow.md
+++ b/.changeset/silly-colts-bow.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+refactor: revert workaround for boolean casting

--- a/.changeset/silly-colts-bow.md
+++ b/.changeset/silly-colts-bow.md
@@ -8,4 +8,4 @@ The issue described [here](https://github.com/SchwarzIT/onyx/issues/3958) that b
 
 We removed the onyx internal workarounds in this version which were originally implemented in onyx version [1.0.0-beta.301](https://onyx.schwarz/development/packages/changelogs/sit-onyx.html#_1-0-0-beta-301).
 
-Note: You can use a Vue version <= 3.5.19 in your project, the fix will still be included because onyx itself will be build with the correct >= 3.5.19 version.
+Note: You can use a Vue version <= 3.5.19 in your project. The fix will still be included because onyx itself is build with the correct >= 3.5.19 version since its a compile-time fix.

--- a/.changeset/silly-colts-bow.md
+++ b/.changeset/silly-colts-bow.md
@@ -3,3 +3,7 @@
 ---
 
 refactor: revert workaround for boolean casting
+
+The issue described [here](https://github.com/SchwarzIT/onyx/issues/3958) that boolean shorthands / boolean casting is not working for some properties has been officially fixed with Vue 3.5.19.
+
+We removed the onyx internal workarounds in this version.

--- a/.changeset/silly-colts-bow.md
+++ b/.changeset/silly-colts-bow.md
@@ -6,4 +6,6 @@ refactor: revert workaround for boolean casting
 
 The issue described [here](https://github.com/SchwarzIT/onyx/issues/3958) that boolean shorthands / boolean casting is not working for some properties has been officially fixed with Vue 3.5.19.
 
-We removed the onyx internal workarounds in this version.
+We removed the onyx internal workarounds in this version which were originally implemented in onyx version [1.0.0-beta.301](https://onyx.schwarz/development/packages/changelogs/sit-onyx.html#_1-0-0-beta-301).
+
+Note: You can use a Vue version <= 3.5.19 in your project, the fix will still be included because onyx itself will be build with the correct >= 3.5.19 version.

--- a/packages/sit-onyx/src/components/OnyxAlertModal/OnyxAlertModal.vue
+++ b/packages/sit-onyx/src/components/OnyxAlertModal/OnyxAlertModal.vue
@@ -3,7 +3,7 @@ import { iconCircleAttention, iconXSmall } from "@sit-onyx/icons";
 import { useId } from "vue";
 import { useDensity } from "../../composables/density.js";
 import { injectI18n } from "../../i18n/index.js";
-import type { NullableBoolean } from "../../types/utils.js";
+import type { Nullable } from "../../types/utils.js";
 import OnyxBasicDialog from "../OnyxBasicDialog/OnyxBasicDialog.vue";
 import OnyxHeadline from "../OnyxHeadline/OnyxHeadline.vue";
 import OnyxIcon from "../OnyxIcon/OnyxIcon.vue";
@@ -18,7 +18,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the modal dialog should be closed.
    */
-  "update:open": [open: NullableBoolean];
+  "update:open": [open: Nullable<boolean>];
 }>();
 
 defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxAlertModal/TestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxAlertModal/TestWrapper.ct.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
 import { iconCircleAttention } from "@sit-onyx/icons";
-import type { NullableBoolean } from "../../types/utils.js";
+import type { Nullable } from "../../types/utils.js";
 import OnyxButton from "../OnyxButton/OnyxButton.vue";
 import OnyxAlertModal from "./OnyxAlertModal.vue";
 
 const emit = defineEmits<{
-  "update:open": [open: NullableBoolean];
+  "update:open": [open: Nullable<boolean>];
 }>();
 </script>
 

--- a/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
@@ -3,7 +3,7 @@ import { useGlobalEventListener, useOutsideClick, wasKeyPressed } from "@sit-ony
 import { computed, useTemplateRef, watch } from "vue";
 import { useDensity } from "../../composables/density.js";
 import { useVModel } from "../../composables/useVModel.js";
-import type { NullableBoolean } from "../../types/index.js";
+import type { Nullable } from "../../types/utils.js";
 import type { OnyxBasicDialogProps } from "./types.js";
 
 const props = withDefaults(defineProps<OnyxBasicDialogProps>(), {
@@ -18,7 +18,7 @@ const emit = defineEmits<{
    * Emitted when the dialog should be closed.
    * Opening is always controlled via the `open` prop.
    */
-  "update:open": [open: NullableBoolean];
+  "update:open": [open: Nullable<boolean>];
 }>();
 
 defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxBasicDialog/types.ts
+++ b/packages/sit-onyx/src/components/OnyxBasicDialog/types.ts
@@ -1,5 +1,5 @@
 import type { DensityProp } from "../../composables/density.js";
-import type { NullableBoolean } from "../../types/index.js";
+import type { Nullable } from "../../types/index.js";
 
 export type OnyxBasicDialogProps = DensityProp & {
   /**
@@ -9,7 +9,7 @@ export type OnyxBasicDialogProps = DensityProp & {
   /**
    * Whether the dialog is open.
    */
-  open?: NullableBoolean;
+  open?: Nullable<boolean>;
   /**
    * Whether the dialog is a modal.
    * If `true`, interaction with the rest of the page is prevented and a backdrop is displayed.

--- a/packages/sit-onyx/src/components/OnyxBasicPopover/types.ts
+++ b/packages/sit-onyx/src/components/OnyxBasicPopover/types.ts
@@ -1,6 +1,6 @@
 import type { AnchorPosition } from "../../composables/useAnchorPositionPolyfill.js";
 import type { OpenAlignment } from "../../composables/useOpenAlignment.js";
-import type { NullableBoolean } from "../../types/utils.js";
+import type { Nullable } from "../../types/utils.js";
 
 export type OnyxBasicPopoverProps = {
   /**
@@ -10,7 +10,7 @@ export type OnyxBasicPopoverProps = {
   /**
    * Indicates whether the element is expanded or collapsed.
    */
-  open?: NullableBoolean;
+  open?: Nullable<boolean>;
   /**
    * How to position the popover relative to the parent element.
    */

--- a/packages/sit-onyx/src/components/OnyxButton/types.ts
+++ b/packages/sit-onyx/src/components/OnyxButton/types.ts
@@ -1,7 +1,7 @@
 import type { DensityProp } from "../../composables/density.js";
 import type { SkeletonInjected } from "../../composables/useSkeletonState.js";
 import type { AutofocusProp } from "../../types/index.js";
-import type { FormInjectedBoolean } from "../OnyxForm/OnyxForm.core.js";
+import type { FormInjected } from "../OnyxForm/OnyxForm.core.js";
 import type { WithLinkProp } from "../OnyxRouterLink/types.js";
 
 export type OnyxButtonProps = DensityProp &
@@ -13,7 +13,7 @@ export type OnyxButtonProps = DensityProp &
     /**
      * If the button should be disabled or not.
      */
-    disabled?: FormInjectedBoolean;
+    disabled?: FormInjected<boolean>;
     /**
      * Shows a loading indicator.
      */

--- a/packages/sit-onyx/src/components/OnyxCheckbox/types.ts
+++ b/packages/sit-onyx/src/components/OnyxCheckbox/types.ts
@@ -1,11 +1,11 @@
-import type { BaseSelectOption, NullableBoolean, SelectOptionValue } from "../../types/index.js";
+import type { BaseSelectOption, Nullable, SelectOptionValue } from "../../types/index.js";
 
 export type OnyxCheckboxProps<TValue extends SelectOptionValue = SelectOptionValue> =
   BaseSelectOption<TValue> & {
     /**
      * Whether the checkbox is checked.
      */
-    modelValue?: NullableBoolean;
+    modelValue?: Nullable<boolean>;
     /**
      * If `true`, an indeterminate indicator is shown.
      */

--- a/packages/sit-onyx/src/components/OnyxFAB/OnyxFAB.vue
+++ b/packages/sit-onyx/src/components/OnyxFAB/OnyxFAB.vue
@@ -7,7 +7,7 @@ import {
   useSkeletonContext,
 } from "../../composables/useSkeletonState.js";
 import { useVModel } from "../../composables/useVModel.js";
-import type { NullableBoolean } from "../../types/index.js";
+import type { Nullable } from "../../types/index.js";
 import { mergeVueProps } from "../../utils/attrs.js";
 import OnyxFABButton from "../OnyxFABButton/OnyxFABButton.vue";
 import OnyxFlyoutMenu from "../OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue";
@@ -23,7 +23,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the isExpanded state changes.
    */
-  "update:open": [value?: NullableBoolean];
+  "update:open": [value?: Nullable<boolean>];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxFAB/types.ts
+++ b/packages/sit-onyx/src/components/OnyxFAB/types.ts
@@ -1,4 +1,4 @@
-import type { NullableBoolean } from "../../types/index.js";
+import type { Nullable } from "../../types/index.js";
 import type { OnyxFABButtonProps } from "../OnyxFABButton/types.js";
 
 export type OnyxFABProps = OnyxFABButtonProps & {
@@ -10,5 +10,5 @@ export type OnyxFABProps = OnyxFABButtonProps & {
    * Whether the element is expanded or collapsed.
    * If unset, the open state is manged internally.
    */
-  open?: NullableBoolean;
+  open?: Nullable<boolean>;
 };

--- a/packages/sit-onyx/src/components/OnyxFileUpload/types.ts
+++ b/packages/sit-onyx/src/components/OnyxFileUpload/types.ts
@@ -2,7 +2,7 @@ import type { DensityProp } from "../../composables/density.js";
 import type { SkeletonInjected } from "../../composables/useSkeletonState.js";
 import type { Nullable } from "../../types/utils.js";
 import type { BinaryPrefixedSize } from "../../utils/numbers.js";
-import type { FormInjectedBoolean } from "../OnyxForm/OnyxForm.core.js";
+import type { FormInjected } from "../OnyxForm/OnyxForm.core.js";
 import type { SharedFormElementProps } from "../OnyxFormElement/types.js";
 
 export type OnyxFileUploadProps<TMultiple extends boolean> = DensityProp &
@@ -54,7 +54,7 @@ export type OnyxFileUploadProps<TMultiple extends boolean> = DensityProp &
     /**
      * Whether the upload is disabled.
      */
-    disabled?: FormInjectedBoolean;
+    disabled?: FormInjected<boolean>;
     /**
      * The size of the upload container
      * @default large

--- a/packages/sit-onyx/src/components/OnyxFilterTag/OnyxFilterTag.vue
+++ b/packages/sit-onyx/src/components/OnyxFilterTag/OnyxFilterTag.vue
@@ -7,7 +7,7 @@ import {
 } from "../../composables/useSkeletonState.js";
 import { useVModel } from "../../composables/useVModel.js";
 import { injectI18n } from "../../i18n/index.js";
-import type { NullableBoolean } from "../../types/index.js";
+import type { Nullable } from "../../types/index.js";
 import OnyxTag from "../OnyxTag/OnyxTag.vue";
 import type { OnyxFilterTagProps } from "./types.js";
 
@@ -18,7 +18,7 @@ const props = withDefaults(defineProps<OnyxFilterTagProps>(), {
 
 const emit = defineEmits<{
   /** Emitted when the active state changes. */
-  "update:active": [value: NullableBoolean];
+  "update:active": [value: Nullable<boolean>];
 }>();
 
 const { t } = injectI18n();

--- a/packages/sit-onyx/src/components/OnyxFilterTag/types.ts
+++ b/packages/sit-onyx/src/components/OnyxFilterTag/types.ts
@@ -1,9 +1,9 @@
-import type { NullableBoolean } from "../../types/utils.js";
+import type { Nullable } from "../../types/utils.js";
 import type { OnyxTagProps } from "../OnyxTag/types.js";
 
 export type OnyxFilterTagProps = Omit<OnyxTagProps, "color" | "clickable"> & {
   /**
    * If `true` the filter is selected, shows an 'x' icon and can be removed on click.
    */
-  active?: NullableBoolean;
+  active?: Nullable<boolean>;
 };

--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.ts
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.ts
@@ -57,7 +57,7 @@ export type FormInjectedProps = {
    *
    * @default Inherits value from closest `<OnyxForm>` component or `false` if none exists
    */
-  disabled?: FormInjectedBoolean;
+  disabled?: FormInjected<boolean>;
   /**
    * Configures if and when errors are shown.
    * - `true`: errors will be shown initially.
@@ -66,7 +66,7 @@ export type FormInjectedProps = {
    *
    * @default Inherits value from closest `<OnyxForm>` component or `touched` if none exists
    */
-  showError?: FormInjectedBoolean | FormInjected<ShowErrorMode>;
+  showError?: FormInjected<ShowErrorMode>;
   /**
    * How to display the required / optional marker.
    * - optional: will show an `(optional)` text after the label for optional form elements.
@@ -100,11 +100,6 @@ export type FORM_INJECTED = symbol; // we can't use `typeof FORM_INJECTED_SYMBOL
  * ```
  */
 export type FormInjected<T> = T | FORM_INJECTED;
-
-/**
- * @deprecated TODO: delete this type and replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/3958 is fixed
- */
-export type FormInjectedBoolean = boolean | FORM_INJECTED;
 
 const createCompute = <TKey extends keyof FormProps>(
   formProps: Ref<FormProps> | undefined,

--- a/packages/sit-onyx/src/components/OnyxIconButton/types.ts
+++ b/packages/sit-onyx/src/components/OnyxIconButton/types.ts
@@ -2,7 +2,7 @@ import type { DensityProp } from "../../composables/density.js";
 import type { SkeletonInjected } from "../../composables/useSkeletonState.js";
 import type { AutofocusProp } from "../../types/index.js";
 import type { ButtonColor, ButtonType, OnyxButtonProps } from "../OnyxButton/types.js";
-import type { FormInjectedBoolean } from "../OnyxForm/OnyxForm.core.js";
+import type { FormInjected } from "../OnyxForm/OnyxForm.core.js";
 
 export type OnyxIconButtonProps = DensityProp &
   AutofocusProp &
@@ -14,7 +14,7 @@ export type OnyxIconButtonProps = DensityProp &
     /**
      * If the button should be disabled or not.
      */
-    disabled?: FormInjectedBoolean;
+    disabled?: FormInjected<boolean>;
     /**
      * The button type.
      */

--- a/packages/sit-onyx/src/components/OnyxInfoTooltip/OnyxInfoTooltip.vue
+++ b/packages/sit-onyx/src/components/OnyxInfoTooltip/OnyxInfoTooltip.vue
@@ -12,6 +12,7 @@ import type { OnyxInfoTooltipProps } from "./types.js";
 const props = withDefaults(defineProps<OnyxInfoTooltipProps>(), {
   trigger: "click",
   color: "neutral",
+  open: undefined,
 });
 
 const emit = defineEmits<{

--- a/packages/sit-onyx/src/components/OnyxModal/OnyxModal.vue
+++ b/packages/sit-onyx/src/components/OnyxModal/OnyxModal.vue
@@ -3,7 +3,7 @@ import { iconXSmall } from "@sit-onyx/icons";
 import { computed, useId } from "vue";
 import { useDensity } from "../../composables/density.js";
 import { injectI18n } from "../../i18n/index.js";
-import type { NullableBoolean } from "../../types/index.js";
+import type { Nullable } from "../../types/index.js";
 import OnyxBasicDialog from "../OnyxBasicDialog/OnyxBasicDialog.vue";
 import OnyxHeadline from "../OnyxHeadline/OnyxHeadline.vue";
 import OnyxSystemButton from "../OnyxSystemButton/OnyxSystemButton.vue";
@@ -16,7 +16,7 @@ const emit = defineEmits<{
    * Emitted when the modal dialog should be closed.
    * Opening is always controlled via the `open` prop.
    */
-  "update:open": [open: NullableBoolean];
+  "update:open": [open: Nullable<boolean>];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxModal/TestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxModal/TestWrapper.ct.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { NullableBoolean } from "../../types/utils.js";
+import type { Nullable } from "../../types/utils.js";
 import type { DialogAlignment } from "../OnyxBasicDialog/types.js";
 import OnyxModal from "./OnyxModal.vue";
 
@@ -15,7 +15,7 @@ defineSlots<{
 }>();
 
 const emit = defineEmits<{
-  "update:open": [open: NullableBoolean];
+  "update:open": [open: Nullable<boolean>];
 }>();
 </script>
 

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxColorSchemeDialog/OnyxColorSchemeDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxColorSchemeDialog/OnyxColorSchemeDialog.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 import { injectI18n } from "../../../../i18n/index.js";
-import type { NullableBoolean } from "../../../../types/utils.js";
+import type { Nullable } from "../../../../types/utils.js";
 import OnyxSelectDialog from "../../../OnyxSelectDialog/OnyxSelectDialog.vue";
 import type { SelectDialogOption } from "../../../OnyxSelectDialog/types.js";
 import autoImage from "./auto.svg?raw";
@@ -21,7 +21,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the dialog should be closed.
    */
-  "update:open": [value: NullableBoolean];
+  "update:open": [value: Nullable<boolean>];
 }>();
 
 const { t } = injectI18n();

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/OnyxFlyoutMenu.vue
@@ -3,7 +3,7 @@
 import { createMenuButton } from "@sit-onyx/headless";
 import { computed, ref, type ComponentInstance, type VNodeRef } from "vue";
 import { useVModel } from "../../../../composables/useVModel.js";
-import type { NullableBoolean } from "../../../../types/index.js";
+import type { Nullable } from "../../../../types/index.js";
 import { mergeVueProps } from "../../../../utils/attrs.js";
 import OnyxBasicPopover from "../../../OnyxBasicPopover/OnyxBasicPopover.vue";
 import type { OnyxFlyoutMenuProps } from "./types.js";
@@ -18,7 +18,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the isExpanded state changes.
    */
-  "update:open": [value?: NullableBoolean];
+  "update:open": [value?: Nullable<boolean>];
 }>();
 
 /**

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxFlyoutMenu/types.ts
@@ -1,4 +1,4 @@
-import type { NullableBoolean } from "../../../../types/index.js";
+import type { Nullable } from "../../../../types/index.js";
 import type { OnyxBasicPopoverProps } from "../../../OnyxBasicPopover/types.js";
 
 export type OnyxFlyoutMenuProps = Pick<OnyxBasicPopoverProps, "alignment"> & {
@@ -14,7 +14,7 @@ export type OnyxFlyoutMenuProps = Pick<OnyxBasicPopoverProps, "alignment"> & {
   /**
    * Indicates whether the element is expanded or collapsed.
    */
-  open?: NullableBoolean;
+  open?: Nullable<boolean>;
   /**
    * Whether the flyout is disabled and can not be opened.
    */

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/OnyxMenuItem.vue
@@ -5,7 +5,7 @@ import { computed, nextTick, useTemplateRef, withModifiers } from "vue";
 import { useLink } from "../../../../composables/useLink.js";
 import { useVModel } from "../../../../composables/useVModel.js";
 import { injectI18n } from "../../../../i18n/index.js";
-import type { NullableBoolean } from "../../../../types/index.js";
+import type { Nullable } from "../../../../types/index.js";
 import { mergeVueProps, useRootAttrs } from "../../../../utils/attrs.js";
 import { extractLinkProps } from "../../../../utils/router.js";
 import ButtonOrLinkLayout from "../../../OnyxButton/ButtonOrLinkLayout.vue";
@@ -29,7 +29,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the open state should update.
    */
-  "update:open": [value: NullableBoolean];
+  "update:open": [value: Nullable<boolean>];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxMenuItem/types.ts
@@ -1,11 +1,11 @@
-import type { NullableBoolean, OnyxColor } from "../../../../types/index.js";
+import type { Nullable, OnyxColor } from "../../../../types/index.js";
 import type { WithLinkProp } from "../../../OnyxRouterLink/types.js";
 
 export type OnyxMenuItemProps = WithLinkProp & {
   /**
    * If the children of the menu item are visible.
    */
-  open?: NullableBoolean;
+  open?: Nullable<boolean>;
   /**
    * Label text for the menu item.
    */

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
@@ -5,7 +5,7 @@ import { useLink } from "../../../../composables/useLink.js";
 import { useMoreListChild } from "../../../../composables/useMoreList.js";
 import { useVModel } from "../../../../composables/useVModel.js";
 import { injectI18n } from "../../../../i18n/index.js";
-import type { NullableBoolean } from "../../../../types/index.js";
+import type { Nullable } from "../../../../types/index.js";
 import { mergeVueProps, useRootAttrs } from "../../../../utils/attrs.js";
 import OnyxButton from "../../../OnyxButton/OnyxButton.vue";
 import OnyxSeparator from "../../../OnyxSeparator/OnyxSeparator.vue";
@@ -30,7 +30,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the state of mobile children visibility changes.
    */
-  "update:open": [value: NullableBoolean];
+  "update:open": [value: Nullable<boolean>];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/types.ts
@@ -1,4 +1,4 @@
-import type { NullableBoolean } from "../../../../types/index.js";
+import type { Nullable } from "../../../../types/index.js";
 import type { WithLinkProp } from "../../../OnyxRouterLink/types.js";
 
 export type OnyxNavItemProps = WithLinkProp<true> & {
@@ -16,5 +16,5 @@ export type OnyxNavItemProps = WithLinkProp<true> & {
   /**
    * Controls whether child elements are open.
    */
-  open?: NullableBoolean;
+  open?: Nullable<boolean>;
 };

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/OnyxUserMenu.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/OnyxUserMenu.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, inject } from "vue";
 import { useVModel } from "../../../../composables/useVModel.js";
-import type { NullableBoolean } from "../../../../types/index.js";
+import type { Nullable } from "../../../../types/index.js";
 import OnyxAvatar from "../../../OnyxAvatar/OnyxAvatar.vue";
 import { MOBILE_NAV_BAR_INJECTION_KEY } from "../../types.js";
 import type { OnyxUserMenuProps } from "./types.js";
@@ -15,7 +15,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the state of flyoutOpen changes.
    */
-  "update:flyoutOpen": [value: NullableBoolean];
+  "update:flyoutOpen": [value: Nullable<boolean>];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/UserMenuLayout.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/UserMenuLayout.vue
@@ -3,7 +3,7 @@
 // to easily switch between mobile and desktop layout
 import { useVModel } from "../../../../composables/useVModel.js";
 import { injectI18n } from "../../../../i18n/index.js";
-import type { NullableBoolean, SelectOptionValue } from "../../../../types/index.js";
+import type { Nullable, SelectOptionValue } from "../../../../types/index.js";
 import OnyxListItem from "../../../OnyxListItem/OnyxListItem.vue";
 import OnyxFlyoutMenu from "../OnyxFlyoutMenu/OnyxFlyoutMenu.vue";
 
@@ -16,7 +16,7 @@ const props = withDefaults(
     /**
      * Controls whether the flyout menu is open.
      */
-    flyoutOpen?: NullableBoolean;
+    flyoutOpen?: Nullable<boolean>;
     /**
      * Whether the flyout is disabled and can not be opened.
      */
@@ -30,7 +30,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the state of flyoutOpen changes.
    */
-  "update:flyoutOpen": [value?: NullableBoolean];
+  "update:flyoutOpen": [value?: Nullable<boolean>];
 }>();
 
 /**

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/types.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxUserMenu/types.ts
@@ -1,4 +1,4 @@
-import type { NullableBoolean } from "../../../../types/index.js";
+import type { Nullable } from "../../../../types/index.js";
 import type { OnyxAvatarProps } from "../../../OnyxAvatar/types.js";
 
 export type OnyxUserMenuProps = {
@@ -19,7 +19,7 @@ export type OnyxUserMenuProps = {
   /**
    * Controls whether the flyout menu is open.
    */
-  flyoutOpen?: NullableBoolean;
+  flyoutOpen?: Nullable<boolean>;
   /**
    * Whether the user menu is disabled and can not be opened.
    */

--- a/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
+++ b/packages/sit-onyx/src/components/OnyxSelect/OnyxSelect.vue
@@ -179,27 +179,13 @@ const filteredOptions = computed(() => {
   );
 });
 
-const isMultiple = computed(() => {
-  // currently there is a Vue bug that when setting multiple as boolean shorthand, e.g. "<OnyxSelect multiple />"
-  // it is not applied correctly and instead passed as empty string
-  // see: https://github.com/SchwarzIT/onyx/issues/3958
-  return props.multiple || (props.multiple as typeof props.multiple | string) === "";
-});
-
-const hasCheckAll = computed(() => {
-  // currently there is a Vue bug that when setting withCheckAll as boolean shorthand, e.g. "<OnyxSelect with-check-all />"
-  // it is not applied correctly and instead passed as empty string
-  // see: https://github.com/SchwarzIT/onyx/issues/3958
-  return props.withCheckAll || (props.withCheckAll as typeof props.withCheckAll | string) === "";
-});
-
 /**
  * Sync the active option with the selected option on single select.
  */
 watch(
   arrayValue,
   () => {
-    if (!isMultiple.value) {
+    if (!props.multiple) {
       activeValue.value = arrayValue.value.at(0);
     }
   },
@@ -214,7 +200,7 @@ const CHECK_ALL_ID = useId() as TValue;
  * Includes "select all" up front if it is used.
  */
 const allKeyboardOptionIds = computed(() => {
-  return (isMultiple.value && hasCheckAll.value && !searchTerm.value ? [CHECK_ALL_ID] : []).concat(
+  return (props.multiple && props.withCheckAll && !searchTerm.value ? [CHECK_ALL_ID] : []).concat(
     enabledOptionValues.value,
   );
 });
@@ -292,7 +278,7 @@ const onSelect = (selectedOption: TValue) => {
   if (!newValue) {
     return;
   }
-  if (!isMultiple.value) {
+  if (!props.multiple) {
     modelValue.value = selectedOption as unknown as TModelValue;
     return;
   }
@@ -310,7 +296,7 @@ const onSelect = (selectedOption: TValue) => {
 
 const autocomplete = computed<ComboboxAutoComplete>(() => (props.withSearch ? "list" : "none"));
 
-const { label, listLabel, listDescription } = toRefs(props);
+const { label, listLabel, listDescription, multiple } = toRefs(props);
 
 const {
   elements: { input, option: headlessOption, group: headlessGroup, listbox },
@@ -319,7 +305,7 @@ const {
   label,
   listLabel,
   listDescription,
-  multiple: isMultiple,
+  multiple,
   activeOption: computed(() => activeValue.value),
   isExpanded: open,
   templateRef: select,
@@ -373,7 +359,7 @@ const enabledOptionValues = computed(() =>
  * Only available when multiple and withCheckAll are set.
  */
 const checkAll = computed(() => {
-  if (!isMultiple.value || !hasCheckAll.value) return undefined;
+  if (!props.multiple || !props.withCheckAll) return undefined;
   return useCheckAll(enabledOptionValues, arrayValue, (newValues: TValue[]) => {
     // with selectedOptions we verify that the options all still exist
     const selectedOptions: TValue[] = newValues
@@ -384,7 +370,7 @@ const checkAll = computed(() => {
 });
 
 const checkAllLabel = computed<string>(() => {
-  if (!isMultiple.value) {
+  if (!props.multiple) {
     return "";
   }
   const defaultText = t.value("selections.selectAll");
@@ -475,7 +461,7 @@ watch(
             <template v-else>
               <!-- select-all option for "multiple" -->
               <ul
-                v-if="isMultiple && hasCheckAll && !searchTerm"
+                v-if="props.multiple && props.withCheckAll && !searchTerm"
                 class="onyx-select__check-all"
                 v-bind="headlessGroup({ label: checkAllLabel })"
               >
@@ -522,7 +508,7 @@ watch(
                       selected: arrayValue.some((value: TValue) => value === option.value),
                     })
                   "
-                  :multiple="isMultiple"
+                  :multiple="props.multiple"
                   :active="option.value === activeValue"
                   :icon="option.icon"
                   :density="props.density"

--- a/packages/sit-onyx/src/components/OnyxSelect/types.ts
+++ b/packages/sit-onyx/src/components/OnyxSelect/types.ts
@@ -31,23 +31,21 @@ export type OnyxSelectProps<
     /**
      * Allows the selection of multiple options
      */
-    multiple?: TMultiple;
+    multiple?: boolean & TMultiple;
     /**
      * If true, a checkbox will be displayed to check/uncheck all options.
      * Disabled and skeleton checkboxes will be excluded from the check/uncheck behavior.
      * Only available if "multiple" is true and no `searchTerm` is provided.
      */
-    withCheckAll?: TMultiple extends true
-      ?
-          | boolean
-          | {
-              /**
-               * Label for the `select all` checkbox.
-               * If unset, a default label will be shown depending on the current locale/language.
-               */
-              label?: string;
-            }
-      : never;
+    withCheckAll?:
+      | boolean
+      | {
+          /**
+           * Label for the `select all` checkbox.
+           * If unset, a default label will be shown depending on the current locale/language.
+           */
+          label?: string;
+        };
     /**
      * Whether the select should be disabled.
      */

--- a/packages/sit-onyx/src/components/OnyxSelect/types.ts
+++ b/packages/sit-onyx/src/components/OnyxSelect/types.ts
@@ -3,10 +3,9 @@ import type {
   AutofocusProp,
   BaseSelectOption,
   Nullable,
-  NullableBoolean,
   SelectOptionValue,
 } from "../../types/index.js";
-import type { FormInjectedBoolean } from "../OnyxForm/OnyxForm.core.js";
+import type { FormInjected } from "../OnyxForm/OnyxForm.core.js";
 import type { OnyxSelectInputProps } from "../OnyxSelectInput/types.js";
 import type { OnyxSelectOptionProps } from "../OnyxSelectOption/types.js";
 
@@ -52,7 +51,7 @@ export type OnyxSelectProps<
     /**
      * Whether the select should be disabled.
      */
-    disabled?: FormInjectedBoolean;
+    disabled?: FormInjected<boolean>;
     /**
      * Label that will be shown in the input of OnyxSelect.
      * If unset, will be managed internally by comparing `modelValue` with `options`.
@@ -96,7 +95,7 @@ export type OnyxSelectProps<
     /**
      * Whether the flyout is currently open.
      */
-    open?: NullableBoolean;
+    open?: Nullable<boolean>;
     /**
      * Current search term when `withSearch` is enabled.
      */

--- a/packages/sit-onyx/src/components/OnyxSelect/types.ts
+++ b/packages/sit-onyx/src/components/OnyxSelect/types.ts
@@ -31,6 +31,7 @@ export type OnyxSelectProps<
     /**
      * Allows the selection of multiple options
      */
+    // "boolean &" is needed to correctly generate the runtime prop value, see: https://github.com/vuejs/core/issues/13787#issuecomment-3209755164
     multiple?: boolean & TMultiple;
     /**
      * If true, a checkbox will be displayed to check/uncheck all options.

--- a/packages/sit-onyx/src/components/OnyxSelectDialog/OnyxSelectDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxSelectDialog/OnyxSelectDialog.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup generic="TValue extends string">
 import { ref, useId, watchEffect } from "vue";
 import { injectI18n } from "../../i18n/index.js";
-import type { NullableBoolean } from "../../types/index.js";
+import type { Nullable } from "../../types/index.js";
 import OnyxBottomBar from "../OnyxBottomBar/OnyxBottomBar.vue";
 import OnyxButton from "../OnyxButton/OnyxButton.vue";
 import OnyxCard from "../OnyxCard/OnyxCard.vue";
@@ -22,7 +22,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the dialog should be closed.
    */
-  "update:open": [open: NullableBoolean];
+  "update:open": [open: Nullable<boolean>];
 }>();
 
 const slots = defineSlots<{

--- a/packages/sit-onyx/src/components/OnyxSwitch/OnyxSwitch.vue
+++ b/packages/sit-onyx/src/components/OnyxSwitch/OnyxSwitch.vue
@@ -10,7 +10,7 @@ import {
   useSkeletonContext,
 } from "../../composables/useSkeletonState.js";
 import { useVModel } from "../../composables/useVModel.js";
-import type { NullableBoolean } from "../../types/index.js";
+import type { Nullable } from "../../types/index.js";
 import { useRootAttrs } from "../../utils/attrs.js";
 import OnyxErrorTooltip from "../OnyxErrorTooltip/OnyxErrorTooltip.vue";
 import { FORM_INJECTED_SYMBOL, useFormContext } from "../OnyxForm/OnyxForm.core.js";
@@ -31,7 +31,7 @@ const props = withDefaults(defineProps<OnyxSwitchProps>(), {
 
 const emit = defineEmits<{
   /** Emitted when the checked state changes. */
-  "update:modelValue": [value?: NullableBoolean];
+  "update:modelValue": [value?: Nullable<boolean>];
   /**
    * Emitted when the validity state of the input changes.
    */

--- a/packages/sit-onyx/src/components/OnyxSwitch/types.ts
+++ b/packages/sit-onyx/src/components/OnyxSwitch/types.ts
@@ -1,4 +1,4 @@
-import type { BaseSelectOption, NullableBoolean, SelectOptionValue } from "../../types/index.js";
+import type { BaseSelectOption, Nullable, SelectOptionValue } from "../../types/index.js";
 
 export type OnyxSwitchProps<TValue extends SelectOptionValue = SelectOptionValue> = Omit<
   BaseSelectOption<TValue>,
@@ -7,5 +7,5 @@ export type OnyxSwitchProps<TValue extends SelectOptionValue = SelectOptionValue
   /**
    * Whether the switch should be checked or not.
    */
-  modelValue?: NullableBoolean;
+  modelValue?: Nullable<boolean>;
 };

--- a/packages/sit-onyx/src/components/OnyxTooltip/OnyxTooltip.vue
+++ b/packages/sit-onyx/src/components/OnyxTooltip/OnyxTooltip.vue
@@ -45,6 +45,7 @@ const props = withDefaults(defineProps<OnyxTooltipProps>(), {
   trigger: "hover",
   alignment: "auto",
   alignsWithEdge: false,
+  open: undefined,
 });
 
 const emit = defineEmits<{

--- a/packages/sit-onyx/src/components/OnyxTooltip/TestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxTooltip/TestWrapper.ct.vue
@@ -3,7 +3,9 @@
 import OnyxTooltip from "./OnyxTooltip.vue";
 import type { OnyxTooltipProps } from "./types.js";
 
-const props = defineProps<OnyxTooltipProps>();
+const props = withDefaults(defineProps<OnyxTooltipProps>(), {
+  open: undefined,
+});
 </script>
 
 <template>

--- a/packages/sit-onyx/src/types/utils.ts
+++ b/packages/sit-onyx/src/types/utils.ts
@@ -94,10 +94,3 @@ export type PrimitiveType = null | number | string | boolean | symbol;
  * A type that can also be null or undefined.
  */
 export type Nullable<T = never> = T | undefined | null;
-
-/**
- * A boolean type that can also be null or undefined.
- *
- * @deprecated TODO: delete this type and replace with `Nullable<boolean>` once https://github.com/SchwarzIT/onyx/issues/3958 is fixed
- */
-export type NullableBoolean = boolean | undefined | null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,15 +16,15 @@ catalogs:
 overrides:
   '@playwright/experimental-ct-vue': 1.54.2
   '@playwright/test': 1.54.2
-  '@vue/compiler-core': 3.5.18
-  '@vue/compiler-dom': 3.5.18
-  '@vue/compiler-sfc': 3.5.18
-  '@vue/compiler-ssr': 3.5.18
-  '@vue/shared': 3.5.18
+  '@vue/compiler-core': 3.5.19
+  '@vue/compiler-dom': 3.5.19
+  '@vue/compiler-sfc': 3.5.19
+  '@vue/compiler-ssr': 3.5.19
+  '@vue/shared': 3.5.19
   playwright: 1.54.2
   playwright-core: 1.54.2
   vite: 7.1.2
-  vue: 3.5.18
+  vue: 3.5.19
   sass-embedded: 1.90.0
 
 importers:
@@ -63,7 +63,7 @@ importers:
         version: 9.1.2(@types/react@18.3.12)(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))
       '@storybook/vue3-vite':
         specifier: ^9.1.2
-        version: 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       '@tsconfig/node24':
         specifier: ^24.0.1
         version: 24.0.1
@@ -78,7 +78,7 @@ importers:
         version: 24.2.1
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 6.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(jiti@2.5.1)(jsdom@26.1.0)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
@@ -93,7 +93,7 @@ importers:
         version: 14.6.0(eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.33.0(jiti@2.5.1))))(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
       '@vue/tsconfig':
         specifier: ~0.7.0
-        version: 0.7.0(typescript@5.9.2)(vue@3.5.18(typescript@5.9.2))
+        version: 0.7.0(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))
       '@vueless/storybook-dark-mode':
         specifier: ^9.0.7
         version: 9.0.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -177,19 +177,19 @@ importers:
         version: link:../../packages/icons
       '@vueuse/core':
         specifier: ^13.6.0
-        version: 13.6.0(vue@3.5.18(typescript@5.9.2))
+        version: 13.6.0(vue@3.5.19(typescript@5.9.2))
       pinia:
         specifier: ^3.0.3
-        version: 3.0.3(typescript@5.9.2)(vue@3.5.18(typescript@5.9.2))
+        version: 3.0.3(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))
       sit-onyx:
         specifier: workspace:^
         version: link:../../packages/sit-onyx
       vue-i18n:
         specifier: ^11.1.11
-        version: 11.1.11(vue@3.5.18(typescript@5.9.2))
+        version: 11.1.11(vue@3.5.19(typescript@5.9.2))
       vue-router:
         specifier: ^4.5.1
-        version: 4.5.1(vue@3.5.18(typescript@5.9.2))
+        version: 4.5.1(vue@3.5.19(typescript@5.9.2))
     devDependencies:
       '@sit-onyx/shared':
         specifier: workspace:^
@@ -198,8 +198,8 @@ importers:
         specifier: 1.90.0
         version: 1.90.0
       vue:
-        specifier: 3.5.18
-        version: 3.5.18(typescript@5.9.2)
+        specifier: 3.5.19
+        version: 3.5.19(typescript@5.9.2)
 
   apps/docs:
     devDependencies:
@@ -240,11 +240,11 @@ importers:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.35.0)(@types/node@24.2.1)(@types/react@18.3.12)(change-case@5.4.4)(fuse.js@7.1.0)(jiti@2.5.1)(jwt-decode@4.0.0)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.90.0)(sass@1.90.0)(search-insights@2.13.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1)
       vue:
-        specifier: 3.5.18
-        version: 3.5.18(typescript@5.9.2)
+        specifier: 3.5.19
+        version: 3.5.19(typescript@5.9.2)
       vue-chartjs:
         specifier: ^5.3.2
-        version: 5.3.2(chart.js@4.5.0)(vue@3.5.18(typescript@5.9.2))
+        version: 5.3.2(chart.js@4.5.0)(vue@3.5.19(typescript@5.9.2))
 
   apps/playground:
     dependencies:
@@ -256,7 +256,7 @@ importers:
         version: 4.2.1
       '@vueuse/core':
         specifier: ^13.6.0
-        version: 13.6.0(vue@3.5.18(typescript@5.9.2))
+        version: 13.6.0(vue@3.5.19(typescript@5.9.2))
       sit-onyx:
         specifier: workspace:^
         version: link:../../packages/sit-onyx
@@ -265,14 +265,14 @@ importers:
         specifier: workspace:^
         version: link:../../packages/shared
       vue:
-        specifier: 3.5.18
-        version: 3.5.18(typescript@5.9.2)
+        specifier: 3.5.19
+        version: 3.5.19(typescript@5.9.2)
 
   packages/chartjs-plugin:
     devDependencies:
       '@playwright/experimental-ct-vue':
         specifier: 1.54.2
-        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)
+        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)
       '@playwright/test':
         specifier: 1.54.2
         version: 1.54.2
@@ -283,8 +283,8 @@ importers:
         specifier: workspace:^
         version: link:../storybook-utils
       '@vue/compiler-dom':
-        specifier: 3.5.18
-        version: 3.5.18
+        specifier: 3.5.19
+        version: 3.5.19
       chart.js:
         specifier: 'catalog:'
         version: 4.5.0
@@ -292,11 +292,11 @@ importers:
         specifier: workspace:^
         version: link:../sit-onyx
       vue:
-        specifier: 3.5.18
-        version: 3.5.18(typescript@5.9.2)
+        specifier: 3.5.19
+        version: 3.5.19(typescript@5.9.2)
       vue-chartjs:
         specifier: ^5.3.2
-        version: 5.3.2(chart.js@4.5.0)(vue@3.5.18(typescript@5.9.2))
+        version: 5.3.2(chart.js@4.5.0)(vue@3.5.19(typescript@5.9.2))
 
   packages/eslint-plugin:
     dependencies:
@@ -358,7 +358,7 @@ importers:
     dependencies:
       '@playwright/experimental-ct-vue':
         specifier: 1.54.2
-        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)
+        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)
       '@playwright/test':
         specifier: 1.54.2
         version: 1.54.2
@@ -370,11 +370,11 @@ importers:
         specifier: workspace:^
         version: link:../shared
       '@vue/compiler-dom':
-        specifier: 3.5.18
-        version: 3.5.18
+        specifier: 3.5.19
+        version: 3.5.19
       vue:
-        specifier: 3.5.18
-        version: 3.5.18(typescript@5.9.2)
+        specifier: 3.5.19
+        version: 3.5.19(typescript@5.9.2)
 
   packages/icons:
     devDependencies:
@@ -398,13 +398,13 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: ^2.6.2
-        version: 2.6.2(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 2.6.2(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       '@nuxt/kit':
         specifier: ^4.0.3
         version: 4.0.3(magicast@0.3.5)
       '@nuxt/module-builder':
         specifier: ^1.0.2
-        version: 1.0.2(@nuxt/cli@3.27.0(magicast@0.3.5))(@vue/compiler-core@3.5.18)(esbuild@0.25.9)(sass@1.90.0)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
+        version: 1.0.2(@nuxt/cli@3.27.0(magicast@0.3.5))(@vue/compiler-core@3.5.19)(esbuild@0.25.9)(sass@1.90.0)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2))
       '@nuxt/schema':
         specifier: ^4.0.3
         version: 4.0.3
@@ -413,10 +413,10 @@ importers:
         version: 3.19.2(@playwright/test@1.54.2)(@vue/test-utils@2.4.6)(jsdom@26.1.0)(magicast@0.3.5)(playwright-core@1.54.2)(typescript@5.9.2)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(jiti@2.5.1)(jsdom@26.1.0)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
       '@nuxtjs/i18n':
         specifier: ^10.0.5
-        version: 10.0.5(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.18)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.2))
+        version: 10.0.5(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.19)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(rollup@4.46.2)(vue@3.5.19(typescript@5.9.2))
       nuxt:
         specifier: ^4.0.3
-        version: 4.0.3(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.2.1)(@vue/compiler-sfc@3.5.18)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.8.1)
+        version: 4.0.3(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.2.1)(@vue/compiler-sfc@3.5.19)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.8.1)
       sit-onyx:
         specifier: workspace:^
         version: link:../sit-onyx
@@ -425,13 +425,13 @@ importers:
         version: 5.9.2
       vue-i18n:
         specifier: ^11.1.11
-        version: 11.1.11(vue@3.5.18(typescript@5.9.2))
+        version: 11.1.11(vue@3.5.19(typescript@5.9.2))
 
   packages/nuxt-docs:
     dependencies:
       '@nuxtjs/i18n':
         specifier: '>= 10'
-        version: 10.0.3(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.18)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.2))
+        version: 10.0.3(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.19)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(rollup@4.46.2)(vue@3.5.19(typescript@5.9.2))
     devDependencies:
       '@fontsource-variable/source-code-pro':
         specifier: '>= 5'
@@ -441,7 +441,7 @@ importers:
         version: 5.2.8
       '@nuxt/content':
         specifier: '>= 3'
-        version: 3.6.3(better-sqlite3@11.10.0)(magicast@0.3.5)(vue-component-type-helpers@3.0.5)
+        version: 3.6.3(better-sqlite3@11.10.0)(magicast@0.3.5)(vue-component-type-helpers@3.0.6)
       '@nuxt/image':
         specifier: '>= 1'
         version: 1.11.0(@netlify/blobs@9.1.2)(db0@0.3.2(better-sqlite3@11.10.0))(ioredis@5.7.0)(magicast@0.3.5)
@@ -453,7 +453,7 @@ importers:
         version: 3.5.2(magicast@0.3.5)
       '@playwright/experimental-ct-vue':
         specifier: 1.54.2
-        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)
+        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)
       '@playwright/test':
         specifier: 1.54.2
         version: 1.54.2
@@ -468,7 +468,7 @@ importers:
         version: link:../shared
       nuxt:
         specifier: ^4.0.3
-        version: 4.0.3(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.2.1)(@vue/compiler-sfc@3.5.18)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue-tsc@3.0.5(typescript@5.9.2))(yaml@2.8.1)
+        version: 4.0.3(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.2.1)(@vue/compiler-sfc@3.5.19)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue-tsc@3.0.5(typescript@5.9.2))(yaml@2.8.1)
       sass-embedded:
         specifier: 1.90.0
         version: 1.90.0
@@ -479,14 +479,14 @@ importers:
         specifier: 'catalog:'
         version: 5.9.2
       vue:
-        specifier: 3.5.18
-        version: 3.5.18(typescript@5.9.2)
+        specifier: 3.5.19
+        version: 3.5.19(typescript@5.9.2)
 
   packages/playwright-utils:
     dependencies:
       '@playwright/experimental-ct-vue':
         specifier: 1.54.2
-        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)
+        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)
       '@playwright/test':
         specifier: 1.54.2
         version: 1.54.2
@@ -494,8 +494,8 @@ importers:
         specifier: 1.54.2
         version: 1.54.2
       vue:
-        specifier: 3.5.18
-        version: 3.5.18(typescript@5.9.2)
+        specifier: 3.5.19
+        version: 3.5.19(typescript@5.9.2)
       vue-component-type-helpers:
         specifier: '>= 3'
         version: 3.0.5
@@ -514,10 +514,10 @@ importers:
     optionalDependencies:
       '@playwright/experimental-ct-vue':
         specifier: 1.54.2
-        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)
+        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)
       '@vitejs/plugin-vue':
         specifier: '>= 5'
-        version: 6.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 6.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       sass-embedded:
         specifier: 1.90.0
         version: 1.90.0
@@ -542,7 +542,7 @@ importers:
         version: 4.10.2(playwright-core@1.54.2)
       '@playwright/experimental-ct-vue':
         specifier: 1.54.2
-        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)
+        version: 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)
       '@playwright/test':
         specifier: 1.54.2
         version: 1.54.2
@@ -562,8 +562,8 @@ importers:
         specifier: ^9.1.2
         version: 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))
       '@vue/compiler-dom':
-        specifier: 3.5.18
-        version: 3.5.18
+        specifier: 3.5.19
+        version: 3.5.19
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6
@@ -583,17 +583,17 @@ importers:
         specifier: ^4.20.4
         version: 4.20.4
       vue:
-        specifier: 3.5.18
-        version: 3.5.18(typescript@5.9.2)
+        specifier: 3.5.19
+        version: 3.5.19(typescript@5.9.2)
       vue-component-type-helpers:
         specifier: ^3.0.5
         version: 3.0.5
       vue-i18n:
         specifier: ^11.1.11
-        version: 11.1.11(vue@3.5.18(typescript@5.9.2))
+        version: 11.1.11(vue@3.5.19(typescript@5.9.2))
       vue-router:
         specifier: ^4.5.1
-        version: 4.5.1(vue@3.5.18(typescript@5.9.2))
+        version: 4.5.1(vue@3.5.19(typescript@5.9.2))
 
   packages/storybook-utils:
     dependencies:
@@ -602,7 +602,7 @@ importers:
         version: link:../flags
       '@storybook/vue3-vite':
         specifier: '>= 9.0.0'
-        version: 9.1.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+        version: 9.1.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       '@vueless/storybook-dark-mode':
         specifier: '>= 9.0.0'
         version: 9.0.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -623,8 +623,8 @@ importers:
         specifier: ^9.1.2
         version: 9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
       vue:
-        specifier: 3.5.18
-        version: 3.5.18(typescript@5.9.2)
+        specifier: 3.5.19
+        version: 3.5.19(typescript@5.9.2)
       vue-component-type-helpers:
         specifier: ^3.0.5
         version: 3.0.5
@@ -839,6 +839,11 @@ packages:
 
   '@babel/parser@7.28.0':
     resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.3':
+    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1644,7 +1649,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       petite-vue-i18n: '*'
-      vue: 3.5.18
+      vue: 3.5.19
       vue-i18n: '*'
     peerDependenciesMeta:
       petite-vue-i18n:
@@ -1661,8 +1666,8 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       '@intlify/shared': ^9.0.0 || ^10.0.0 || ^11.0.0
-      '@vue/compiler-dom': 3.5.18
-      vue: 3.5.18
+      '@vue/compiler-dom': 3.5.19
+      vue: 3.5.19
       vue-i18n: ^9.0.0 || ^10.0.0 || ^11.0.0
     peerDependenciesMeta:
       '@intlify/shared':
@@ -1936,7 +1941,7 @@ packages:
     resolution: {integrity: sha512-1eKm51V3Ine4DjxLUDnPIKewuIZwJjGh1oMvY3sAJ5RtdSngRonqkaoGV4EWtLH7cO+oTBbbdVg5O95chYYcLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
 
   '@nuxtjs/color-mode@3.5.2':
     resolution: {integrity: sha512-cC6RfgZh3guHBMLLjrBB2Uti5eUoGM9KyauOaYS9ETmxNWBMTvpgjvSiSJp1OFljIXPIqVTJ3xtJpSNZiO3ZaA==}
@@ -2962,14 +2967,14 @@ packages:
     engines: {node: '>=20.0.0'}
     peerDependencies:
       storybook: ^9.1.1
-      vue: 3.5.18
+      vue: 3.5.19
 
   '@storybook/vue3@9.1.2':
     resolution: {integrity: sha512-aYLh6/DZEuoOtsn/qePb9I/kuzwZGy+mS/ELlFoj72vpJc4d21hKZfiepO5bZ3z73XK7nLmdMVQ2tIwvsin4Vw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       storybook: ^9.1.2
-      vue: 3.5.18
+      vue: 3.5.19
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -3191,7 +3196,7 @@ packages:
   '@unhead/vue@2.0.14':
     resolution: {integrity: sha512-Ym9f+Kd2Afqek2FtUHvYvK+j2uZ2vbZ6Rr9NCnNGGBMdmafAuiZpT117YGyh0ARcueL6Znia0U8ySqPsnHOZIg==}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
 
   '@vercel/nft@0.29.4':
     resolution: {integrity: sha512-6lLqMNX3TuycBPABycx7A9F1bHQR7kiQln6abjFbPrf5C/05qHM9M5E4PeTE59c7z8g6vHnx1Ioihb2AQl7BTA==}
@@ -3203,21 +3208,21 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: 7.1.2
-      vue: 3.5.18
+      vue: 3.5.19
 
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: 7.1.2
-      vue: 3.5.18
+      vue: 3.5.19
 
   '@vitejs/plugin-vue@6.0.1':
     resolution: {integrity: sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: 7.1.2
-      vue: 3.5.18
+      vue: 3.5.19
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -3300,7 +3305,7 @@ packages:
     resolution: {integrity: sha512-Pn/AWMTjoMYuquepLZP813BIcq8DTZiNCoaceuNlvaYuOTd8DqBZWc5u0uOMQZMInwME1mdSmmBAcTluiV9Jtg==}
     engines: {node: '>=16.14.0'}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
     peerDependenciesMeta:
       vue:
         optional: true
@@ -3309,7 +3314,7 @@ packages:
     resolution: {integrity: sha512-DMgq/rIh1H20WYNWU7krIbEfJRYDDhy7ix64GlT4AVUJZZWCZ5pxiYVJR3A3GmWQPkn7Pg7i3oIiGqu4JGC65w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
     peerDependenciesMeta:
       vue:
         optional: true
@@ -3318,7 +3323,7 @@ packages:
     resolution: {integrity: sha512-8O2gWxWFiaoNkk7PGi0+p7NPGe/f8xJ3/INUufvje/RZOs7sJvlI1jnR4lydtRFa/mU0ylMXUXXjSK0fHDEYTA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
     peerDependenciesMeta:
       vue:
         optional: true
@@ -3339,17 +3344,17 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@vue/compiler-core@3.5.18':
-    resolution: {integrity: sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==}
+  '@vue/compiler-core@3.5.19':
+    resolution: {integrity: sha512-/afpyvlkrSNYbPo94Qu8GtIOWS+g5TRdOvs6XZNw6pWQQmj5pBgSZvEPOIZlqWq0YvoUhDDQaQ2TnzuJdOV4hA==}
 
-  '@vue/compiler-dom@3.5.18':
-    resolution: {integrity: sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==}
+  '@vue/compiler-dom@3.5.19':
+    resolution: {integrity: sha512-Drs6rPHQZx/pN9S6ml3Z3K/TWCIRPvzG2B/o5kFK9X0MNHt8/E+38tiRfojufrYBfA6FQUFB2qBBRXlcSXWtOA==}
 
-  '@vue/compiler-sfc@3.5.18':
-    resolution: {integrity: sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==}
+  '@vue/compiler-sfc@3.5.19':
+    resolution: {integrity: sha512-YWCm1CYaJ+2RvNmhCwI7t3I3nU+hOrWGWMsn+Z/kmm1jy5iinnVtlmkiZwbLlbV1SRizX7vHsc0/bG5dj0zRTg==}
 
-  '@vue/compiler-ssr@3.5.18':
-    resolution: {integrity: sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==}
+  '@vue/compiler-ssr@3.5.19':
+    resolution: {integrity: sha512-/wx0VZtkWOPdiQLWPeQeqpHWR/LuNC7bHfSX7OayBTtUy8wur6vT6EQIX6Et86aED6J+y8tTw43qo2uoqGg5sw==}
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
@@ -3363,7 +3368,7 @@ packages:
   '@vue/devtools-core@7.7.7':
     resolution: {integrity: sha512-9z9TLbfC+AjAi1PQyWX+OErjIaJmdFlbDHcD+cAMYKY6Bh5VlsAtCeGyRMrXwIlMEQPukvnWt3gZBLwTAIMKzQ==}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
 
   '@vue/devtools-kit@7.7.7':
     resolution: {integrity: sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA==}
@@ -3420,25 +3425,25 @@ packages:
       typescript:
         optional: true
 
-  '@vue/reactivity@3.5.18':
-    resolution: {integrity: sha512-x0vPO5Imw+3sChLM5Y+B6G1zPjwdOri9e8V21NnTnlEvkxatHEH5B5KEAJcjuzQ7BsjGrKtfzuQ5eQwXh8HXBg==}
+  '@vue/reactivity@3.5.19':
+    resolution: {integrity: sha512-4bueZg2qs5MSsK2dQk3sssV0cfvxb/QZntTC8v7J448GLgmfPkQ+27aDjlt40+XFqOwUq5yRxK5uQh14Fc9eVA==}
 
   '@vue/repl@4.2.1':
     resolution: {integrity: sha512-kPpoAp0hQ1sKIGXEHtVdtdh2BgL97SAizEvCqRDB3LmgIYCPbzInwd4mqYkHstAhJPmkNslLd3rwfceMwzwinQ==}
 
-  '@vue/runtime-core@3.5.18':
-    resolution: {integrity: sha512-DUpHa1HpeOQEt6+3nheUfqVXRog2kivkXHUhoqJiKR33SO4x+a5uNOMkV487WPerQkL0vUuRvq/7JhRgLW3S+w==}
+  '@vue/runtime-core@3.5.19':
+    resolution: {integrity: sha512-TaooCr8Hge1sWjLSyhdubnuofs3shhzZGfyD11gFolZrny76drPwBVQj28/z/4+msSFb18tOIg6VVVgf9/IbIA==}
 
-  '@vue/runtime-dom@3.5.18':
-    resolution: {integrity: sha512-YwDj71iV05j4RnzZnZtGaXwPoUWeRsqinblgVJwR8XTXYZ9D5PbahHQgsbmzUvCWNF6x7siQ89HgnX5eWkr3mw==}
+  '@vue/runtime-dom@3.5.19':
+    resolution: {integrity: sha512-qmahqeok6ztuUTmV8lqd7N9ymbBzctNF885n8gL3xdCC1u2RnM/coX16Via0AiONQXUoYpxPojL3U1IsDgSWUQ==}
 
-  '@vue/server-renderer@3.5.18':
-    resolution: {integrity: sha512-PvIHLUoWgSbDG7zLHqSqaCoZvHi6NNmfVFOqO+OnwvqMz/tqQr3FuGWS8ufluNddk7ZLBJYMrjcw1c6XzR12mA==}
+  '@vue/server-renderer@3.5.19':
+    resolution: {integrity: sha512-ZJ/zV9SQuaIO+BEEVq/2a6fipyrSYfjKMU3267bPUk+oTx/hZq3RzV7VCh0Unlppt39Bvh6+NzxeopIFv4HJNg==}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
 
-  '@vue/shared@3.5.18':
-    resolution: {integrity: sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==}
+  '@vue/shared@3.5.19':
+    resolution: {integrity: sha512-IhXCOn08wgKrLQxRFKKlSacWg4Goi1BolrdEeLYn6tgHjJNXVrWJ5nzoxZqNwl5p88aLlQ8LOaoMa3AYvaKJ/Q==}
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
@@ -3447,7 +3452,7 @@ packages:
     resolution: {integrity: sha512-ku2uNz5MaZ9IerPPUyOHzyjhXoX2kVJaVf7hL315DC17vS6IiZRmmCPfggNbU16QTvM80+uYYy3eYJB59WCtvg==}
     peerDependencies:
       typescript: 5.x
-      vue: 3.5.18
+      vue: 3.5.19
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3468,7 +3473,7 @@ packages:
   '@vueuse/core@13.6.0':
     resolution: {integrity: sha512-DJbD5fV86muVmBgS9QQPddVX7d9hWYswzlf4bIyUD2dj8GC46R1uNClZhVAmsdVts4xb2jwp1PbpuiA50Qee1A==}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
 
   '@vueuse/integrations@12.8.2':
     resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
@@ -3523,7 +3528,7 @@ packages:
   '@vueuse/shared@13.6.0':
     resolution: {integrity: sha512-pDykCSoS2T3fsQrYqf9SyF0QXWHmcGPQ+qiOVjlYSzlWd9dgppB2bFSM1GgKKkt7uzn0BBMV3IbJsUfHG2+BCg==}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
 
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
@@ -6080,7 +6085,7 @@ packages:
     peerDependencies:
       sass: ^1.85.0
       typescript: '>=5.7.3'
-      vue: 3.5.18
+      vue: 3.5.19
       vue-sfc-transformer: ^0.1.1
       vue-tsc: ^1.8.27 || ^2.0.21
     peerDependenciesMeta:
@@ -6548,7 +6553,7 @@ packages:
     resolution: {integrity: sha512-ttXO/InUULUXkMHpTdp9Fj4hLpD/2AoJdmAbAeW2yu1iy1k+pkFekQXw5VpC0/5p51IOR/jDaDRfRWRnMMsGOA==}
     peerDependencies:
       typescript: '>=4.4.4'
-      vue: 3.5.18
+      vue: 3.5.19
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -8018,7 +8023,7 @@ packages:
   unplugin-vue-router@0.14.0:
     resolution: {integrity: sha512-ipjunvS5e2aFHBAUFuLbHl2aHKbXXXBhTxGT9wZx66fNVPdEQzVVitF8nODr1plANhTTa3UZ+DQu9uyLngMzoQ==}
     peerDependencies:
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.19
       vue-router: ^4.5.1
     peerDependenciesMeta:
       vue-router:
@@ -8027,7 +8032,7 @@ packages:
   unplugin-vue-router@0.15.0:
     resolution: {integrity: sha512-PyGehCjd9Ny9h+Uer4McbBjjib3lHihcyUEILa7pHKl6+rh8N7sFyw4ZkV+N30Oq2zmIUG7iKs3qpL0r+gXAaQ==}
     peerDependencies:
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.19
       vue-router: ^4.5.1
     peerDependenciesMeta:
       vue-router:
@@ -8232,7 +8237,7 @@ packages:
     resolution: {integrity: sha512-a+UB9IwGx5uwS4uG/a9kM6fCMnxONDkOTbgCUbhFpiGhqfxrrC1+9BibV7sWwUnwj1Dg6MnRxG0trLgUZslDXA==}
     peerDependencies:
       vite: 7.1.2
-      vue: 3.5.18
+      vue: 3.5.19
 
   vite@7.1.2:
     resolution: {integrity: sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==}
@@ -8331,7 +8336,7 @@ packages:
     resolution: {integrity: sha512-NrkbRRoYshbXbWqJkTN6InoDVwVb90C0R7eAVgMWcB9dPikbruaOoTFjFYHE/+tNPdIe6qdLCDjfjPHQ0fw4jw==}
     peerDependencies:
       chart.js: ^4.1.1
-      vue: 3.5.18
+      vue: 3.5.19
 
   vue-component-meta@2.2.12:
     resolution: {integrity: sha512-dQU6/obNSNbennJ1xd+rhDid4g3vQro+9qUBBIg8HMZH2Zs1jTpkFNxuQ3z77bOlU+ew08Qck9sbYkdSePr0Pw==}
@@ -8353,13 +8358,16 @@ packages:
   vue-component-type-helpers@3.0.5:
     resolution: {integrity: sha512-uoNZaJ+a1/zppa/Vgmi8zIOP2PHXDN2rT8NyF+zQRK6ZG94lNB9prcV0GdLJbY9i9lrD47JOVIH92SaiA7oJ1A==}
 
+  vue-component-type-helpers@3.0.6:
+    resolution: {integrity: sha512-6CRM8X7EJqWCJOiKPvSLQG+hJPb/Oy2gyJx3pLjUEhY7PuaCthQu3e0zAGI1lqUBobrrk9IT0K8sG2GsCluxoQ==}
+
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
 
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
 
   vue-eslint-parser@10.2.0:
     resolution: {integrity: sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==}
@@ -8377,25 +8385,25 @@ packages:
     resolution: {integrity: sha512-LvyteQoXeQiuILbzqv13LbyBna/TEv2Ha+4ZWK2AwGHUzZ8+IBaZS0TJkCgn5izSPLcgZwXy9yyTrewCb2u/MA==}
     engines: {node: '>= 16'}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
 
   vue-inbrowser-compiler-independent-utils@4.71.1:
     resolution: {integrity: sha512-K3wt3iVmNGaFEOUR4JIThQRWfqokxLfnPslD41FDZB2ajXp789+wCqJyGYlIFsvEQ2P61PInw6/ph5iiqg51gg==}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
 
   vue-router@4.5.1:
     resolution: {integrity: sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==}
     peerDependencies:
-      vue: 3.5.18
+      vue: 3.5.19
 
   vue-sfc-transformer@0.1.16:
     resolution: {integrity: sha512-pXx4pkHigOJCzGPXhGA9Rdou1oIuNiF9n4n5GQ7C4QehTXFEpKUjcpvc3PZ6LvC6ccUL021qor8j1153Y7/6Ig==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@vue/compiler-core': 3.5.18
+      '@vue/compiler-core': 3.5.19
       esbuild: '*'
-      vue: 3.5.18
+      vue: 3.5.19
 
   vue-tsc@2.2.10:
     resolution: {integrity: sha512-jWZ1xSaNbabEV3whpIDMbjVSVawjAyW+x1n3JeGQo7S0uv2n9F/JMgWW90tGWNFRKya4YwKMZgCtr0vRAM7DeQ==}
@@ -8409,8 +8417,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.5.18:
-    resolution: {integrity: sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA==}
+  vue@3.5.19:
+    resolution: {integrity: sha512-ZRh0HTmw6KChRYWgN8Ox/wi7VhpuGlvMPrHjIsdRbzKNgECFLzy+dKL5z9yGaBSjCpmcfJCbh3I1tNSRmBz2tg==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -8886,6 +8894,10 @@ snapshots:
       '@babel/types': 7.28.2
 
   '@babel/parser@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.2
+
+  '@babel/parser@7.28.3':
     dependencies:
       '@babel/types': 7.28.2
 
@@ -9523,7 +9535,7 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@intlify/bundle-utils@10.0.1(vue-i18n@11.1.11(vue@3.5.18(typescript@5.9.2)))':
+  '@intlify/bundle-utils@10.0.1(vue-i18n@11.1.11(vue@3.5.19(typescript@5.9.2)))':
     dependencies:
       '@intlify/message-compiler': 11.1.11
       '@intlify/shared': 11.1.11
@@ -9535,7 +9547,7 @@ snapshots:
       source-map-js: 1.2.1
       yaml-eslint-parser: 1.3.0
     optionalDependencies:
-      vue-i18n: 11.1.11(vue@3.5.18(typescript@5.9.2))
+      vue-i18n: 11.1.11(vue@3.5.19(typescript@5.9.2))
 
   '@intlify/core-base@11.1.11':
     dependencies:
@@ -9559,12 +9571,12 @@ snapshots:
 
   '@intlify/shared@11.1.11': {}
 
-  '@intlify/unplugin-vue-i18n@6.0.8(@vue/compiler-dom@3.5.18)(eslint@9.33.0(jiti@2.5.1))(rollup@4.46.2)(typescript@5.9.2)(vue-i18n@11.1.11(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))':
+  '@intlify/unplugin-vue-i18n@6.0.8(@vue/compiler-dom@3.5.19)(eslint@9.33.0(jiti@2.5.1))(rollup@4.46.2)(typescript@5.9.2)(vue-i18n@11.1.11(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.33.0(jiti@2.5.1))
-      '@intlify/bundle-utils': 10.0.1(vue-i18n@11.1.11(vue@3.5.18(typescript@5.9.2)))
+      '@intlify/bundle-utils': 10.0.1(vue-i18n@11.1.11(vue@3.5.19(typescript@5.9.2)))
       '@intlify/shared': 11.1.11
-      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.11)(@vue/compiler-dom@3.5.18)(vue-i18n@11.1.11(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.11)(@vue/compiler-dom@3.5.19)(vue-i18n@11.1.11(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2))
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
       '@typescript-eslint/scope-manager': 8.39.1
       '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.9.2)
@@ -9576,9 +9588,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
       unplugin: 1.16.1
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
     optionalDependencies:
-      vue-i18n: 11.1.11(vue@3.5.18(typescript@5.9.2))
+      vue-i18n: 11.1.11(vue@3.5.19(typescript@5.9.2))
     transitivePeerDependencies:
       - '@vue/compiler-dom'
       - eslint
@@ -9588,14 +9600,14 @@ snapshots:
 
   '@intlify/utils@0.13.0': {}
 
-  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.11)(@vue/compiler-dom@3.5.18)(vue-i18n@11.1.11(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))':
+  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.11)(@vue/compiler-dom@3.5.19)(vue-i18n@11.1.11(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@babel/parser': 7.28.0
     optionalDependencies:
       '@intlify/shared': 11.1.11
-      '@vue/compiler-dom': 3.5.18
-      vue: 3.5.18(typescript@5.9.2)
-      vue-i18n: 11.1.11(vue@3.5.18(typescript@5.9.2))
+      '@vue/compiler-dom': 3.5.19
+      vue: 3.5.19(typescript@5.9.2)
+      vue-i18n: 11.1.11(vue@3.5.19(typescript@5.9.2))
 
   '@ioredis/commands@1.3.0': {}
 
@@ -9892,7 +9904,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/content@3.6.3(better-sqlite3@11.10.0)(magicast@0.3.5)(vue-component-type-helpers@3.0.5)':
+  '@nuxt/content@3.6.3(better-sqlite3@11.10.0)(magicast@0.3.5)(vue-component-type-helpers@3.0.6)':
     dependencies:
       '@nuxt/kit': 3.18.1(magicast@0.3.5)
       '@nuxtjs/mdc': 0.17.0(magicast@0.3.5)
@@ -9920,7 +9932,7 @@ snapshots:
       micromatch: 4.0.8
       minimark: 0.2.0
       minimatch: 10.0.3
-      nuxt-component-meta: 0.12.2(magicast@0.3.5)(vue-component-type-helpers@3.0.5)
+      nuxt-component-meta: 0.12.2(magicast@0.3.5)(vue-component-type-helpers@3.0.6)
       nypm: 0.6.1
       ohash: 2.0.11
       pathe: 2.0.3
@@ -9971,12 +9983,12 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.2
 
-  '@nuxt/devtools@2.6.2(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
+  '@nuxt/devtools@2.6.2(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@nuxt/devtools-kit': 2.6.2(magicast@0.3.5)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
       '@nuxt/devtools-wizard': 2.6.2
       '@nuxt/kit': 3.18.1(magicast@0.3.5)
-      '@vue/devtools-core': 7.7.7(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+      '@vue/devtools-core': 7.7.7(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       '@vue/devtools-kit': 7.7.7
       birpc: 2.5.0
       consola: 3.4.2
@@ -10003,7 +10015,7 @@ snapshots:
       tinyglobby: 0.2.14
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
       vite-plugin-inspect: 11.3.2(@nuxt/kit@3.18.1(magicast@0.3.5))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
-      vite-plugin-vue-tracer: 1.0.0(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+      vite-plugin-vue-tracer: 1.0.0(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       which: 5.0.0
       ws: 8.18.3
     transitivePeerDependencies:
@@ -10101,7 +10113,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.27.0(magicast@0.3.5))(@vue/compiler-core@3.5.18)(esbuild@0.25.9)(sass@1.90.0)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))':
+  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.27.0(magicast@0.3.5))(@vue/compiler-core@3.5.19)(esbuild@0.25.9)(sass@1.90.0)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@nuxt/cli': 3.27.0(magicast@0.3.5)
       citty: 0.1.6
@@ -10109,14 +10121,14 @@ snapshots:
       defu: 6.1.4
       jiti: 2.5.1
       magic-regexp: 0.10.0
-      mkdist: 2.3.0(sass@1.90.0)(typescript@5.9.2)(vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.18)(esbuild@0.25.9)(vue@3.5.18(typescript@5.9.2)))(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
+      mkdist: 2.3.0(sass@1.90.0)(typescript@5.9.2)(vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.19)(esbuild@0.25.9)(vue@3.5.19(typescript@5.9.2)))(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2))
       mlly: 1.7.4
       pathe: 2.0.3
       pkg-types: 2.2.0
       tsconfck: 3.1.6(typescript@5.9.2)
       typescript: 5.9.2
-      unbuild: 3.6.0(sass@1.90.0)(typescript@5.9.2)(vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.18)(esbuild@0.25.9)(vue@3.5.18(typescript@5.9.2)))(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
-      vue-sfc-transformer: 0.1.16(@vue/compiler-core@3.5.18)(esbuild@0.25.9)(vue@3.5.18(typescript@5.9.2))
+      unbuild: 3.6.0(sass@1.90.0)(typescript@5.9.2)(vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.19)(esbuild@0.25.9)(vue@3.5.19(typescript@5.9.2)))(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2))
+      vue-sfc-transformer: 0.1.16(@vue/compiler-core@3.5.19)(esbuild@0.25.9)(vue@3.5.19(typescript@5.9.2))
     transitivePeerDependencies:
       - '@vue/compiler-core'
       - esbuild
@@ -10126,7 +10138,7 @@ snapshots:
 
   '@nuxt/schema@4.0.3':
     dependencies:
-      '@vue/shared': 3.5.18
+      '@vue/shared': 3.5.19
       consola: 3.4.2
       defu: 6.1.4
       pathe: 2.0.3
@@ -10175,7 +10187,7 @@ snapshots:
       ufo: 1.6.1
       unplugin: 2.3.5
       vitest-environment-nuxt: 1.0.1(@playwright/test@1.54.2)(@vue/test-utils@2.4.6)(jsdom@26.1.0)(magicast@0.3.5)(playwright-core@1.54.2)(typescript@5.9.2)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(jiti@2.5.1)(jsdom@26.1.0)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
     optionalDependencies:
       '@playwright/test': 1.54.2
       '@vue/test-utils': 2.4.6
@@ -10186,12 +10198,12 @@ snapshots:
       - magicast
       - typescript
 
-  '@nuxt/vite-builder@4.0.3(@types/node@24.2.1)(eslint@9.33.0(jiti@2.5.1))(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)':
+  '@nuxt/vite-builder@4.0.3(@types/node@24.2.1)(eslint@9.33.0(jiti@2.5.1))(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 4.0.3(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.46.2)
-      '@vitejs/plugin-vue': 6.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
-      '@vitejs/plugin-vue-jsx': 5.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+      '@vitejs/plugin-vue': 6.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
+      '@vitejs/plugin-vue-jsx': 5.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       autoprefixer: 10.4.21(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.0(postcss@8.5.6)
@@ -10216,7 +10228,7 @@ snapshots:
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
       vite-node: 3.2.4(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
       vite-plugin-checker: 0.10.2(eslint@9.33.0(jiti@2.5.1))(meow@13.2.0)(optionator@0.9.4)(stylelint@16.23.1(typescript@5.9.2))(typescript@5.9.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue-tsc@2.2.10(typescript@5.9.2))
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
       vue-bundle-renderer: 2.1.2
     transitivePeerDependencies:
       - '@biomejs/biome'
@@ -10243,12 +10255,12 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.0.3(@types/node@24.2.1)(eslint@9.33.0(jiti@2.5.1))(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)':
+  '@nuxt/vite-builder@4.0.3(@types/node@24.2.1)(eslint@9.33.0(jiti@2.5.1))(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 4.0.3(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.46.2)
-      '@vitejs/plugin-vue': 6.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
-      '@vitejs/plugin-vue-jsx': 5.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+      '@vitejs/plugin-vue': 6.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
+      '@vitejs/plugin-vue-jsx': 5.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       autoprefixer: 10.4.21(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.0(postcss@8.5.6)
@@ -10273,7 +10285,7 @@ snapshots:
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
       vite-node: 3.2.4(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
       vite-plugin-checker: 0.10.2(eslint@9.33.0(jiti@2.5.1))(meow@13.2.0)(optionator@0.9.4)(stylelint@16.23.1(typescript@5.9.2))(typescript@5.9.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue-tsc@3.0.5(typescript@5.9.2))
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
       vue-bundle-renderer: 2.1.2
     transitivePeerDependencies:
       - '@biomejs/biome'
@@ -10309,17 +10321,17 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxtjs/i18n@10.0.3(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.18)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.2))':
+  '@nuxtjs/i18n@10.0.3(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.19)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(rollup@4.46.2)(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@intlify/core': 11.1.11
       '@intlify/h3': 0.7.1
       '@intlify/shared': 11.1.11
-      '@intlify/unplugin-vue-i18n': 6.0.8(@vue/compiler-dom@3.5.18)(eslint@9.33.0(jiti@2.5.1))(rollup@4.46.2)(typescript@5.9.2)(vue-i18n@11.1.11(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+      '@intlify/unplugin-vue-i18n': 6.0.8(@vue/compiler-dom@3.5.19)(eslint@9.33.0(jiti@2.5.1))(rollup@4.46.2)(typescript@5.9.2)(vue-i18n@11.1.11(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2))
       '@intlify/utils': 0.13.0
       '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.46.2)
       '@nuxt/kit': 4.0.3(magicast@0.3.5)
       '@rollup/plugin-yaml': 4.1.2(rollup@4.46.2)
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.19
       cookie-es: 2.0.0
       defu: 6.1.4
       devalue: 5.1.1
@@ -10335,10 +10347,10 @@ snapshots:
       typescript: 5.9.2
       ufo: 1.6.1
       unplugin: 2.3.5
-      unplugin-vue-router: 0.12.0(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+      unplugin-vue-router: 0.12.0(vue-router@4.5.1(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2))
       unstorage: 1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(better-sqlite3@11.10.0))(ioredis@5.7.0)
-      vue-i18n: 11.1.11(vue@3.5.18(typescript@5.9.2))
-      vue-router: 4.5.1(vue@3.5.18(typescript@5.9.2))
+      vue-i18n: 11.1.11(vue@3.5.19(typescript@5.9.2))
+      vue-router: 4.5.1(vue@3.5.19(typescript@5.9.2))
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -10366,17 +10378,17 @@ snapshots:
       - uploadthing
       - vue
 
-  '@nuxtjs/i18n@10.0.5(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.18)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(rollup@4.46.2)(vue@3.5.18(typescript@5.9.2))':
+  '@nuxtjs/i18n@10.0.5(@netlify/blobs@9.1.2)(@vue/compiler-dom@3.5.19)(db0@0.3.2(better-sqlite3@11.10.0))(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(rollup@4.46.2)(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@intlify/core': 11.1.11
       '@intlify/h3': 0.7.1
       '@intlify/shared': 11.1.11
-      '@intlify/unplugin-vue-i18n': 6.0.8(@vue/compiler-dom@3.5.18)(eslint@9.33.0(jiti@2.5.1))(rollup@4.46.2)(typescript@5.9.2)(vue-i18n@11.1.11(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+      '@intlify/unplugin-vue-i18n': 6.0.8(@vue/compiler-dom@3.5.19)(eslint@9.33.0(jiti@2.5.1))(rollup@4.46.2)(typescript@5.9.2)(vue-i18n@11.1.11(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2))
       '@intlify/utils': 0.13.0
       '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.46.2)
       '@nuxt/kit': 4.0.3(magicast@0.3.5)
       '@rollup/plugin-yaml': 4.1.2(rollup@4.46.2)
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.19
       cookie-es: 2.0.0
       defu: 6.1.4
       devalue: 5.1.1
@@ -10392,10 +10404,10 @@ snapshots:
       typescript: 5.9.2
       ufo: 1.6.1
       unplugin: 2.3.5
-      unplugin-vue-router: 0.14.0(@vue/compiler-sfc@3.5.18)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+      unplugin-vue-router: 0.14.0(@vue/compiler-sfc@3.5.19)(vue-router@4.5.1(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2))
       unstorage: 1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(better-sqlite3@11.10.0))(ioredis@5.7.0)
-      vue-i18n: 11.1.11(vue@3.5.18(typescript@5.9.2))
-      vue-router: 4.5.1(vue@3.5.18(typescript@5.9.2))
+      vue-i18n: 11.1.11(vue@3.5.19(typescript@5.9.2))
+      vue-router: 4.5.1(vue@3.5.19(typescript@5.9.2))
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -10431,7 +10443,7 @@ snapshots:
       '@shikijs/transformers': 3.9.2
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@vue/compiler-core': 3.5.18
+      '@vue/compiler-core': 3.5.19
       consola: 3.4.2
       debug: 4.4.0
       defu: 6.1.4
@@ -10846,10 +10858,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-vue@1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)':
+  '@playwright/experimental-ct-vue@1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)':
     dependencies:
       '@playwright/experimental-ct-core': 1.54.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
-      '@vitejs/plugin-vue': 5.2.4(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+      '@vitejs/plugin-vue': 5.2.4(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -11198,49 +11210,49 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       storybook: 9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
 
-  '@storybook/vue3-vite@9.1.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
+  '@storybook/vue3-vite@9.1.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@storybook/builder-vite': 9.1.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
-      '@storybook/vue3': 9.1.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vue@3.5.18(typescript@5.9.2))
+      '@storybook/vue3': 9.1.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vue@3.5.19(typescript@5.9.2))
       find-package-json: 1.2.0
       magic-string: 0.30.17
       storybook: 9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
       typescript: 5.9.2
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
       vue-component-meta: 2.2.12(typescript@5.9.2)
-      vue-docgen-api: 4.79.2(vue@3.5.18(typescript@5.9.2))
+      vue-docgen-api: 4.79.2(vue@3.5.19(typescript@5.9.2))
     transitivePeerDependencies:
       - vue
 
-  '@storybook/vue3-vite@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
+  '@storybook/vue3-vite@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@storybook/builder-vite': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
-      '@storybook/vue3': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vue@3.5.18(typescript@5.9.2))
+      '@storybook/vue3': 9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vue@3.5.19(typescript@5.9.2))
       find-package-json: 1.2.0
       magic-string: 0.30.17
       storybook: 9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
       typescript: 5.9.2
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
       vue-component-meta: 2.2.12(typescript@5.9.2)
-      vue-docgen-api: 4.79.2(vue@3.5.18(typescript@5.9.2))
+      vue-docgen-api: 4.79.2(vue@3.5.19(typescript@5.9.2))
     transitivePeerDependencies:
       - vue
 
-  '@storybook/vue3@9.1.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vue@3.5.18(typescript@5.9.2))':
+  '@storybook/vue3@9.1.1(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@storybook/global': 5.0.0
       storybook: 9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
       type-fest: 2.19.0
-      vue: 3.5.18(typescript@5.9.2)
-      vue-component-type-helpers: 3.0.5
+      vue: 3.5.19(typescript@5.9.2)
+      vue-component-type-helpers: 3.0.6
 
-  '@storybook/vue3@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vue@3.5.18(typescript@5.9.2))':
+  '@storybook/vue3@9.1.2(storybook@9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@storybook/global': 5.0.0
       storybook: 9.1.2(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
       type-fest: 2.19.0
-      vue: 3.5.18(typescript@5.9.2)
-      vue-component-type-helpers: 3.0.5
+      vue: 3.5.19(typescript@5.9.2)
+      vue-component-type-helpers: 3.0.6
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -11514,11 +11526,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@unhead/vue@2.0.14(vue@3.5.18(typescript@5.9.2))':
+  '@unhead/vue@2.0.14(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       hookable: 5.5.3
       unhead: 2.0.14
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
   '@vercel/nft@0.29.4(encoding@0.1.13)(rollup@4.46.2)':
     dependencies:
@@ -11539,27 +11551,27 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
+  '@vitejs/plugin-vue-jsx@5.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@rolldown/pluginutils': 1.0.0-beta.31
       '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.28.0)
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.2.4(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
-  '@vitejs/plugin-vue@6.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(jiti@2.5.1)(jsdom@26.1.0)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))':
     dependencies:
@@ -11671,36 +11683,36 @@ snapshots:
       vscode-uri: 3.1.0
     optional: true
 
-  '@vue-macros/common@1.16.1(vue@3.5.18(typescript@5.9.2))':
+  '@vue-macros/common@1.16.1(vue@3.5.19(typescript@5.9.2))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.19
       ast-kit: 1.4.3
       local-pkg: 1.1.1
       magic-string-ast: 0.7.1
       pathe: 2.0.3
       picomatch: 4.0.3
     optionalDependencies:
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
-  '@vue-macros/common@3.0.0-beta.15(vue@3.5.18(typescript@5.9.2))':
+  '@vue-macros/common@3.0.0-beta.15(vue@3.5.19(typescript@5.9.2))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.19
       ast-kit: 2.1.2
       local-pkg: 1.1.1
       magic-string-ast: 1.0.2
       unplugin-utils: 0.2.5
     optionalDependencies:
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
-  '@vue-macros/common@3.0.0-beta.16(vue@3.5.18(typescript@5.9.2))':
+  '@vue-macros/common@3.0.0-beta.16(vue@3.5.19(typescript@5.9.2))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.19
       ast-kit: 2.1.1
       local-pkg: 1.1.1
       magic-string-ast: 1.0.0
       unplugin-utils: 0.2.5
     optionalDependencies:
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
   '@vue/babel-helper-vue-transform-on@1.4.0': {}
 
@@ -11714,7 +11726,7 @@ snapshots:
       '@babel/types': 7.28.2
       '@vue/babel-helper-vue-transform-on': 1.4.0
       '@vue/babel-plugin-resolve-type': 1.4.0(@babel/core@7.28.0)
-      '@vue/shared': 3.5.18
+      '@vue/shared': 3.5.19
     optionalDependencies:
       '@babel/core': 7.28.0
     transitivePeerDependencies:
@@ -11727,39 +11739,39 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/parser': 7.28.0
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.19
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/compiler-core@3.5.18':
+  '@vue/compiler-core@3.5.19':
     dependencies:
-      '@babel/parser': 7.28.0
-      '@vue/shared': 3.5.18
+      '@babel/parser': 7.28.3
+      '@vue/shared': 3.5.19
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.18':
+  '@vue/compiler-dom@3.5.19':
     dependencies:
-      '@vue/compiler-core': 3.5.18
-      '@vue/shared': 3.5.18
+      '@vue/compiler-core': 3.5.19
+      '@vue/shared': 3.5.19
 
-  '@vue/compiler-sfc@3.5.18':
+  '@vue/compiler-sfc@3.5.19':
     dependencies:
-      '@babel/parser': 7.28.0
-      '@vue/compiler-core': 3.5.18
-      '@vue/compiler-dom': 3.5.18
-      '@vue/compiler-ssr': 3.5.18
-      '@vue/shared': 3.5.18
+      '@babel/parser': 7.28.3
+      '@vue/compiler-core': 3.5.19
+      '@vue/compiler-dom': 3.5.19
+      '@vue/compiler-ssr': 3.5.19
+      '@vue/shared': 3.5.19
       estree-walker: 2.0.2
       magic-string: 0.30.17
       postcss: 8.5.6
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.18':
+  '@vue/compiler-ssr@3.5.19':
     dependencies:
-      '@vue/compiler-dom': 3.5.18
-      '@vue/shared': 3.5.18
+      '@vue/compiler-dom': 3.5.19
+      '@vue/shared': 3.5.19
 
   '@vue/compiler-vue2@2.7.16':
     dependencies:
@@ -11772,7 +11784,7 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.7.7
 
-  '@vue/devtools-core@7.7.7(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))':
+  '@vue/devtools-core@7.7.7(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
@@ -11780,7 +11792,7 @@ snapshots:
       nanoid: 5.1.5
       pathe: 2.0.3
       vite-hot-client: 2.1.0(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
     transitivePeerDependencies:
       - vite
 
@@ -11823,9 +11835,9 @@ snapshots:
   '@vue/language-core@2.2.0(typescript@5.9.2)':
     dependencies:
       '@volar/language-core': 2.4.22
-      '@vue/compiler-dom': 3.5.18
+      '@vue/compiler-dom': 3.5.19
       '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.18
+      '@vue/shared': 3.5.19
       alien-signals: 0.4.14
       minimatch: 9.0.5
       muggle-string: 0.4.1
@@ -11836,9 +11848,9 @@ snapshots:
   '@vue/language-core@2.2.10(typescript@5.9.2)':
     dependencies:
       '@volar/language-core': 2.4.23
-      '@vue/compiler-dom': 3.5.18
+      '@vue/compiler-dom': 3.5.19
       '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.18
+      '@vue/shared': 3.5.19
       alien-signals: 1.0.13
       minimatch: 9.0.5
       muggle-string: 0.4.1
@@ -11850,9 +11862,9 @@ snapshots:
   '@vue/language-core@2.2.12(typescript@5.9.2)':
     dependencies:
       '@volar/language-core': 2.4.15
-      '@vue/compiler-dom': 3.5.18
+      '@vue/compiler-dom': 3.5.19
       '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.18
+      '@vue/shared': 3.5.19
       alien-signals: 1.0.13
       minimatch: 9.0.5
       muggle-string: 0.4.1
@@ -11863,9 +11875,9 @@ snapshots:
   '@vue/language-core@3.0.5(typescript@5.9.2)':
     dependencies:
       '@volar/language-core': 2.4.22
-      '@vue/compiler-dom': 3.5.18
+      '@vue/compiler-dom': 3.5.19
       '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.18
+      '@vue/shared': 3.5.19
       alien-signals: 2.0.6
       muggle-string: 0.4.1
       path-browserify: 1.0.1
@@ -11873,41 +11885,41 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  '@vue/reactivity@3.5.18':
+  '@vue/reactivity@3.5.19':
     dependencies:
-      '@vue/shared': 3.5.18
+      '@vue/shared': 3.5.19
 
   '@vue/repl@4.2.1': {}
 
-  '@vue/runtime-core@3.5.18':
+  '@vue/runtime-core@3.5.19':
     dependencies:
-      '@vue/reactivity': 3.5.18
-      '@vue/shared': 3.5.18
+      '@vue/reactivity': 3.5.19
+      '@vue/shared': 3.5.19
 
-  '@vue/runtime-dom@3.5.18':
+  '@vue/runtime-dom@3.5.19':
     dependencies:
-      '@vue/reactivity': 3.5.18
-      '@vue/runtime-core': 3.5.18
-      '@vue/shared': 3.5.18
+      '@vue/reactivity': 3.5.19
+      '@vue/runtime-core': 3.5.19
+      '@vue/shared': 3.5.19
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@5.9.2))':
+  '@vue/server-renderer@3.5.19(vue@3.5.19(typescript@5.9.2))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.18
-      '@vue/shared': 3.5.18
-      vue: 3.5.18(typescript@5.9.2)
+      '@vue/compiler-ssr': 3.5.19
+      '@vue/shared': 3.5.19
+      vue: 3.5.19(typescript@5.9.2)
 
-  '@vue/shared@3.5.18': {}
+  '@vue/shared@3.5.19': {}
 
   '@vue/test-utils@2.4.6':
     dependencies:
       js-beautify: 1.15.4
       vue-component-type-helpers: 2.2.12
 
-  '@vue/tsconfig@0.7.0(typescript@5.9.2)(vue@3.5.18(typescript@5.9.2))':
+  '@vue/tsconfig@0.7.0(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2))':
     optionalDependencies:
       typescript: 5.9.2
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
   '@vueless/storybook-dark-mode@9.0.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
@@ -11934,22 +11946,22 @@ snapshots:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
       '@vueuse/shared': 12.8.2(typescript@5.9.2)
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/core@13.6.0(vue@3.5.18(typescript@5.9.2))':
+  '@vueuse/core@13.6.0(vue@3.5.19(typescript@5.9.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 13.6.0
-      '@vueuse/shared': 13.6.0(vue@3.5.18(typescript@5.9.2))
-      vue: 3.5.18(typescript@5.9.2)
+      '@vueuse/shared': 13.6.0(vue@3.5.19(typescript@5.9.2))
+      vue: 3.5.19(typescript@5.9.2)
 
   '@vueuse/integrations@12.8.2(change-case@5.4.4)(focus-trap@7.6.5)(fuse.js@7.1.0)(jwt-decode@4.0.0)(typescript@5.9.2)':
     dependencies:
       '@vueuse/core': 12.8.2(typescript@5.9.2)
       '@vueuse/shared': 12.8.2(typescript@5.9.2)
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
     optionalDependencies:
       change-case: 5.4.4
       focus-trap: 7.6.5
@@ -11964,13 +11976,13 @@ snapshots:
 
   '@vueuse/shared@12.8.2(typescript@5.9.2)':
     dependencies:
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/shared@13.6.0(vue@3.5.18(typescript@5.9.2))':
+  '@vueuse/shared@13.6.0(vue@3.5.19(typescript@5.9.2))':
     dependencies:
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
   '@webcontainer/env@1.1.1': {}
 
@@ -12839,7 +12851,7 @@ snapshots:
   detective-vue2@2.2.0(typescript@5.9.2):
     dependencies:
       '@dependents/detective-less': 5.0.1
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-sfc': 3.5.19
       detective-es6: 5.0.1
       detective-sass: 6.0.1
       detective-scss: 5.0.1
@@ -14925,7 +14937,7 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
-  mkdist@2.3.0(sass@1.90.0)(typescript@5.9.2)(vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.18)(esbuild@0.25.9)(vue@3.5.18(typescript@5.9.2)))(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2)):
+  mkdist@2.3.0(sass@1.90.0)(typescript@5.9.2)(vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.19)(esbuild@0.25.9)(vue@3.5.19(typescript@5.9.2)))(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2)):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.6)
       citty: 0.1.6
@@ -14943,8 +14955,8 @@ snapshots:
     optionalDependencies:
       sass: 1.90.0
       typescript: 5.9.2
-      vue: 3.5.18(typescript@5.9.2)
-      vue-sfc-transformer: 0.1.16(@vue/compiler-core@3.5.18)(esbuild@0.25.9)(vue@3.5.18(typescript@5.9.2))
+      vue: 3.5.19(typescript@5.9.2)
+      vue-sfc-transformer: 0.1.16(@vue/compiler-core@3.5.19)(esbuild@0.25.9)(vue@3.5.19(typescript@5.9.2))
       vue-tsc: 2.2.10(typescript@5.9.2)
 
   mlly@1.7.4:
@@ -15179,7 +15191,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-component-meta@0.12.2(magicast@0.3.5)(vue-component-type-helpers@3.0.5):
+  nuxt-component-meta@0.12.2(magicast@0.3.5)(vue-component-type-helpers@3.0.6):
     dependencies:
       '@nuxt/kit': 4.0.3(magicast@0.3.5)
       citty: 0.1.6
@@ -15189,24 +15201,24 @@ snapshots:
       scule: 1.3.0
       typescript: 5.9.2
       ufo: 1.6.1
-      vue-component-meta: 3.0.5(typescript@5.9.2)(vue-component-type-helpers@3.0.5)
+      vue-component-meta: 3.0.5(typescript@5.9.2)(vue-component-type-helpers@3.0.6)
     transitivePeerDependencies:
       - magicast
       - vue-component-type-helpers
 
   nuxt-define@1.0.0: {}
 
-  nuxt@4.0.3(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.2.1)(@vue/compiler-sfc@3.5.18)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.8.1):
+  nuxt@4.0.3(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.2.1)(@vue/compiler-sfc@3.5.19)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue-tsc@2.2.10(typescript@5.9.2))(yaml@2.8.1):
     dependencies:
       '@nuxt/cli': 3.27.0(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.6.2(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+      '@nuxt/devtools': 2.6.2(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       '@nuxt/kit': 4.0.3(magicast@0.3.5)
       '@nuxt/schema': 4.0.3
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 4.0.3(@types/node@24.2.1)(eslint@9.33.0(jiti@2.5.1))(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)
-      '@unhead/vue': 2.0.14(vue@3.5.18(typescript@5.9.2))
-      '@vue/shared': 3.5.18
+      '@nuxt/vite-builder': 4.0.3(@types/node@24.2.1)(eslint@9.33.0(jiti@2.5.1))(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)
+      '@unhead/vue': 2.0.14(vue@3.5.19(typescript@5.9.2))
+      '@vue/shared': 3.5.19
       c12: 3.2.0(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
@@ -15255,13 +15267,13 @@ snapshots:
       unctx: 2.4.1
       unimport: 5.2.0
       unplugin: 2.3.5
-      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.18)(typescript@5.9.2)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.19)(typescript@5.9.2)(vue-router@4.5.1(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2))
       unstorage: 1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(better-sqlite3@11.10.0))(ioredis@5.7.0)
       untyped: 2.0.0
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
       vue-bundle-renderer: 2.1.2
       vue-devtools-stub: 0.1.0
-      vue-router: 4.5.1(vue@3.5.18(typescript@5.9.2))
+      vue-router: 4.5.1(vue@3.5.19(typescript@5.9.2))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
       '@types/node': 24.2.1
@@ -15319,17 +15331,17 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.0.3(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.2.1)(@vue/compiler-sfc@3.5.18)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue-tsc@3.0.5(typescript@5.9.2))(yaml@2.8.1):
+  nuxt@4.0.3(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.2.1)(@vue/compiler-sfc@3.5.19)(better-sqlite3@11.10.0)(db0@0.3.2(better-sqlite3@11.10.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue-tsc@3.0.5(typescript@5.9.2))(yaml@2.8.1):
     dependencies:
       '@nuxt/cli': 3.27.0(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.6.2(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+      '@nuxt/devtools': 2.6.2(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       '@nuxt/kit': 4.0.3(magicast@0.3.5)
       '@nuxt/schema': 4.0.3
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 4.0.3(@types/node@24.2.1)(eslint@9.33.0(jiti@2.5.1))(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))(yaml@2.8.1)
-      '@unhead/vue': 2.0.14(vue@3.5.18(typescript@5.9.2))
-      '@vue/shared': 3.5.18
+      '@nuxt/vite-builder': 4.0.3(@types/node@24.2.1)(eslint@9.33.0(jiti@2.5.1))(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.46.2)(sass-embedded@1.90.0)(sass@1.90.0)(stylelint@16.23.1(typescript@5.9.2))(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(typescript@5.9.2)(vue-tsc@3.0.5(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2))(yaml@2.8.1)
+      '@unhead/vue': 2.0.14(vue@3.5.19(typescript@5.9.2))
+      '@vue/shared': 3.5.19
       c12: 3.2.0(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
@@ -15378,13 +15390,13 @@ snapshots:
       unctx: 2.4.1
       unimport: 5.2.0
       unplugin: 2.3.5
-      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.18)(typescript@5.9.2)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2))
+      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.19)(typescript@5.9.2)(vue-router@4.5.1(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2))
       unstorage: 1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(better-sqlite3@11.10.0))(ioredis@5.7.0)
       untyped: 2.0.0
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
       vue-bundle-renderer: 2.1.2
       vue-devtools-stub: 0.1.0
-      vue-router: 4.5.1(vue@3.5.18(typescript@5.9.2))
+      vue-router: 4.5.1(vue@3.5.19(typescript@5.9.2))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
       '@types/node': 24.2.1
@@ -15795,10 +15807,10 @@ snapshots:
 
   pify@4.0.1: {}
 
-  pinia@3.0.3(typescript@5.9.2)(vue@3.5.18(typescript@5.9.2)):
+  pinia@3.0.3(typescript@5.9.2)(vue@3.5.19(typescript@5.9.2)):
     dependencies:
       '@vue/devtools-api': 7.7.7
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
 
@@ -17380,7 +17392,7 @@ snapshots:
 
   ultrahtml@1.6.0: {}
 
-  unbuild@3.6.0(sass@1.90.0)(typescript@5.9.2)(vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.18)(esbuild@0.25.9)(vue@3.5.18(typescript@5.9.2)))(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2)):
+  unbuild@3.6.0(sass@1.90.0)(typescript@5.9.2)(vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.19)(esbuild@0.25.9)(vue@3.5.19(typescript@5.9.2)))(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2)):
     dependencies:
       '@rollup/plugin-alias': 5.1.1(rollup@4.46.2)
       '@rollup/plugin-commonjs': 28.0.6(rollup@4.46.2)
@@ -17396,7 +17408,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.5.1
       magic-string: 0.30.17
-      mkdist: 2.3.0(sass@1.90.0)(typescript@5.9.2)(vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.18)(esbuild@0.25.9)(vue@3.5.18(typescript@5.9.2)))(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.18(typescript@5.9.2))
+      mkdist: 2.3.0(sass@1.90.0)(typescript@5.9.2)(vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.19)(esbuild@0.25.9)(vue@3.5.19(typescript@5.9.2)))(vue-tsc@2.2.10(typescript@5.9.2))(vue@3.5.19(typescript@5.9.2))
       mlly: 1.7.4
       pathe: 2.0.3
       pkg-types: 2.2.0
@@ -17520,10 +17532,10 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.3
 
-  unplugin-vue-router@0.12.0(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2)):
+  unplugin-vue-router@0.12.0(vue-router@4.5.1(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2)):
     dependencies:
       '@babel/types': 7.28.2
-      '@vue-macros/common': 1.16.1(vue@3.5.18(typescript@5.9.2))
+      '@vue-macros/common': 1.16.1(vue@3.5.19(typescript@5.9.2))
       ast-walker-scope: 0.6.2
       chokidar: 4.0.3
       fast-glob: 3.3.3
@@ -17538,14 +17550,14 @@ snapshots:
       unplugin-utils: 0.2.4
       yaml: 2.8.1
     optionalDependencies:
-      vue-router: 4.5.1(vue@3.5.18(typescript@5.9.2))
+      vue-router: 4.5.1(vue@3.5.19(typescript@5.9.2))
     transitivePeerDependencies:
       - vue
 
-  unplugin-vue-router@0.14.0(@vue/compiler-sfc@3.5.18)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2)):
+  unplugin-vue-router@0.14.0(@vue/compiler-sfc@3.5.19)(vue-router@4.5.1(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2)):
     dependencies:
-      '@vue-macros/common': 3.0.0-beta.15(vue@3.5.18(typescript@5.9.2))
-      '@vue/compiler-sfc': 3.5.18
+      '@vue-macros/common': 3.0.0-beta.15(vue@3.5.19(typescript@5.9.2))
+      '@vue/compiler-sfc': 3.5.19
       ast-walker-scope: 0.8.1
       chokidar: 4.0.3
       fast-glob: 3.3.3
@@ -17560,14 +17572,14 @@ snapshots:
       unplugin-utils: 0.2.5
       yaml: 2.8.1
     optionalDependencies:
-      vue-router: 4.5.1(vue@3.5.18(typescript@5.9.2))
+      vue-router: 4.5.1(vue@3.5.19(typescript@5.9.2))
     transitivePeerDependencies:
       - vue
 
-  unplugin-vue-router@0.15.0(@vue/compiler-sfc@3.5.18)(typescript@5.9.2)(vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)))(vue@3.5.18(typescript@5.9.2)):
+  unplugin-vue-router@0.15.0(@vue/compiler-sfc@3.5.19)(typescript@5.9.2)(vue-router@4.5.1(vue@3.5.19(typescript@5.9.2)))(vue@3.5.19(typescript@5.9.2)):
     dependencies:
-      '@vue-macros/common': 3.0.0-beta.16(vue@3.5.18(typescript@5.9.2))
-      '@vue/compiler-sfc': 3.5.18
+      '@vue-macros/common': 3.0.0-beta.16(vue@3.5.19(typescript@5.9.2))
+      '@vue/compiler-sfc': 3.5.19
       '@vue/language-core': 3.0.5(typescript@5.9.2)
       ast-walker-scope: 0.8.1
       chokidar: 4.0.3
@@ -17584,7 +17596,7 @@ snapshots:
       unplugin-utils: 0.2.4
       yaml: 2.8.1
     optionalDependencies:
-      vue-router: 4.5.1(vue@3.5.18(typescript@5.9.2))
+      vue-router: 4.5.1(vue@3.5.19(typescript@5.9.2))
     transitivePeerDependencies:
       - typescript
       - vue
@@ -17798,7 +17810,7 @@ snapshots:
       tinyglobby: 0.2.14
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
 
-  vite-plugin-vue-tracer@1.0.0(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2)):
+  vite-plugin-vue-tracer@1.0.0(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.7
@@ -17806,7 +17818,7 @@ snapshots:
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
   vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1):
     dependencies:
@@ -17836,9 +17848,9 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.18(typescript@5.9.2))
+      '@vitejs/plugin-vue': 5.2.4(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1))(vue@3.5.19(typescript@5.9.2))
       '@vue/devtools-api': 7.7.7
-      '@vue/shared': 3.5.18
+      '@vue/shared': 3.5.19
       '@vueuse/core': 12.8.2(typescript@5.9.2)
       '@vueuse/integrations': 12.8.2(change-case@5.4.4)(focus-trap@7.6.5)(fuse.js@7.1.0)(jwt-decode@4.0.0)(typescript@5.9.2)
       focus-trap: 7.6.5
@@ -17846,7 +17858,7 @@ snapshots:
       minisearch: 7.1.2
       shiki: 2.5.0
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(sass-embedded@1.90.0)(sass@1.90.0)(stylus@0.57.0)(terser@5.43.1)(tsx@4.20.4)(yaml@2.8.1)
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
     optionalDependencies:
       postcss: 8.5.6
     transitivePeerDependencies:
@@ -17947,10 +17959,10 @@ snapshots:
     dependencies:
       ufo: 1.6.1
 
-  vue-chartjs@5.3.2(chart.js@4.5.0)(vue@3.5.18(typescript@5.9.2)):
+  vue-chartjs@5.3.2(chart.js@4.5.0)(vue@3.5.19(typescript@5.9.2)):
     dependencies:
       chart.js: 4.5.0
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
   vue-component-meta@2.2.12(typescript@5.9.2):
     dependencies:
@@ -17961,26 +17973,28 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
 
-  vue-component-meta@3.0.5(typescript@5.9.2)(vue-component-type-helpers@3.0.5):
+  vue-component-meta@3.0.5(typescript@5.9.2)(vue-component-type-helpers@3.0.6):
     dependencies:
       '@volar/typescript': 2.4.22
       '@vue/language-core': 3.0.5(typescript@5.9.2)
       path-browserify: 1.0.1
       typescript: 5.9.2
-      vue-component-type-helpers: 3.0.5
+      vue-component-type-helpers: 3.0.6
 
   vue-component-type-helpers@2.2.12: {}
 
   vue-component-type-helpers@3.0.5: {}
 
+  vue-component-type-helpers@3.0.6: {}
+
   vue-devtools-stub@0.1.0: {}
 
-  vue-docgen-api@4.79.2(vue@3.5.18(typescript@5.9.2)):
+  vue-docgen-api@4.79.2(vue@3.5.19(typescript@5.9.2)):
     dependencies:
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.2
-      '@vue/compiler-dom': 3.5.18
-      '@vue/compiler-sfc': 3.5.18
+      '@vue/compiler-dom': 3.5.19
+      '@vue/compiler-sfc': 3.5.19
       ast-types: 0.16.1
       esm-resolve: 1.0.11
       hash-sum: 2.0.0
@@ -17988,8 +18002,8 @@ snapshots:
       pug: 3.0.3
       recast: 0.23.11
       ts-map: 1.0.3
-      vue: 3.5.18(typescript@5.9.2)
-      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.18(typescript@5.9.2))
+      vue: 3.5.19(typescript@5.9.2)
+      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.19(typescript@5.9.2))
 
   vue-eslint-parser@10.2.0(eslint@9.33.0(jiti@2.5.1)):
     dependencies:
@@ -18016,28 +18030,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-i18n@11.1.11(vue@3.5.18(typescript@5.9.2)):
+  vue-i18n@11.1.11(vue@3.5.19(typescript@5.9.2)):
     dependencies:
       '@intlify/core-base': 11.1.11
       '@intlify/shared': 11.1.11
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
-  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.18(typescript@5.9.2)):
+  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.19(typescript@5.9.2)):
     dependencies:
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
-  vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)):
+  vue-router@4.5.1(vue@3.5.19(typescript@5.9.2)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
-  vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.18)(esbuild@0.25.9)(vue@3.5.18(typescript@5.9.2)):
+  vue-sfc-transformer@0.1.16(@vue/compiler-core@3.5.19)(esbuild@0.25.9)(vue@3.5.19(typescript@5.9.2)):
     dependencies:
       '@babel/parser': 7.28.0
-      '@vue/compiler-core': 3.5.18
+      '@vue/compiler-core': 3.5.19
       esbuild: 0.25.9
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.19(typescript@5.9.2)
 
   vue-tsc@2.2.10(typescript@5.9.2):
     dependencies:
@@ -18052,13 +18066,13 @@ snapshots:
       '@vue/language-core': 3.0.5(typescript@5.9.2)
       typescript: 5.9.2
 
-  vue@3.5.18(typescript@5.9.2):
+  vue@3.5.19(typescript@5.9.2):
     dependencies:
-      '@vue/compiler-dom': 3.5.18
-      '@vue/compiler-sfc': 3.5.18
-      '@vue/runtime-dom': 3.5.18
-      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@5.9.2))
-      '@vue/shared': 3.5.18
+      '@vue/compiler-dom': 3.5.19
+      '@vue/compiler-sfc': 3.5.19
+      '@vue/runtime-dom': 3.5.19
+      '@vue/server-renderer': 3.5.19(vue@3.5.19(typescript@5.9.2))
+      '@vue/shared': 3.5.19
     optionalDependencies:
       typescript: 5.9.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,18 +5,18 @@ packages:
 catalog:
   "@playwright/experimental-ct-vue": 1.54.2
   "@playwright/test": 1.54.2
-  "@vue/compiler-core": 3.5.18
-  "@vue/compiler-dom": 3.5.18
-  "@vue/compiler-sfc": 3.5.18
-  "@vue/compiler-ssr": 3.5.18
-  "@vue/shared": 3.5.18
+  "@vue/compiler-core": 3.5.19
+  "@vue/compiler-dom": 3.5.19
+  "@vue/compiler-sfc": 3.5.19
+  "@vue/compiler-ssr": 3.5.19
+  "@vue/shared": 3.5.19
   chart.js: 4.5.0
   playwright: 1.54.2
   playwright-core: 1.54.2
   sass-embedded: 1.90.0
   typescript: 5.9.2
   vite: 7.1.2
-  vue: 3.5.18
+  vue: 3.5.19
 
 onlyBuiltDependencies:
   - "@parcel/watcher"


### PR DESCRIPTION
Relates to #3958

The issue has been fixed with Vue version 3.5.19 so we can remove our workaround in onyx.

## Checklist

<!-- If bullet points below do not apply to your changes (e.g. no documentation needed), just remove it. -->

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
