### PR TITLE
docs: fix build due to invalid changelog

### DIFF
--- a/.changeset/good-webs-serve.md
+++ b/.changeset/good-webs-serve.md
@@ -11,19 +11,19 @@ The following events are updated:
 
 For reference: `type Nullable<T> = T | null | undefined`
 
-| Component         | Event name            | New type | Old type           |
-| ----------------- | --------------------- | -------- | ------------------ |
-| OnyxAccordion     | "update:modelValue"   | TValue[] | Nullable<TValue[]> |
-| OnyxBasicDialog   | "update:open"         | boolean  | Nullable<boolean>  |
-| OnyxCheckboxGroup | "update:modelValue"   | TValue[] | Nullable<TValue[]> |
-| OnyxFAB           | "update:open"         | boolean  | Nullable<boolean>  |
-| OnyxFilterTag     | "update:active"       | boolean  | Nullable<boolean>  |
-| OnyxInput         | "update:modelValue"   | string   | Nullable<string>   |
-| OnyxMiniSearch    | "update:modelValue"   | string   | Nullable<string>   |
-| OnyxFlyoutMenu    | "update:open"         | boolean  | Nullable<boolean>  |
-| OnyxMenuItem      | "update:open"         | boolean  | Nullable<boolean>  |
-| OnyxNavItem       | "update:open"         | boolean  | Nullable<boolean>  |
-| OnyxUserMenu      | "update:flyoutOpen"   | boolean  | Nullable<boolean>  |
-| OnyxProgressSteps | "update:highestValue" | number   | Nullable<number>   |
-| OnyxSwitch        | "update:modelValue"   | boolean  | Nullable<boolean>  |
-| OnyxTextarea      | "update:modelValue"   | string   | Nullable<string>   |
+| Component         | Event name            | New type   | Old type             |
+| ----------------- | --------------------- | ---------- | -------------------- |
+| OnyxAccordion     | "update:modelValue"   | `TValue[]` | `Nullable<TValue[]>` |
+| OnyxBasicDialog   | "update:open"         | `boolean`  | `Nullable<boolean>`  |
+| OnyxCheckboxGroup | "update:modelValue"   | `TValue[]` | `Nullable<TValue[]>` |
+| OnyxFAB           | "update:open"         | `boolean`  | `Nullable<boolean>`  |
+| OnyxFilterTag     | "update:active"       | `boolean`  | `Nullable<boolean>`  |
+| OnyxInput         | "update:modelValue"   | `string`   | `Nullable<string>`   |
+| OnyxMiniSearch    | "update:modelValue"   | `string`   | `Nullable<string>`   |
+| OnyxFlyoutMenu    | "update:open"         | `boolean`  | `Nullable<boolean>`  |
+| OnyxMenuItem      | "update:open"         | `boolean`  | `Nullable<boolean>`  |
+| OnyxNavItem       | "update:open"         | `boolean`  | `Nullable<boolean>`  |
+| OnyxUserMenu      | "update:flyoutOpen"   | `boolean`  | `Nullable<boolean>`  |
+| OnyxProgressSteps | "update:highestValue" | `number`   | `Nullable<number>`   |
+| OnyxSwitch        | "update:modelValue"   | `boolean`  | `Nullable<boolean>`  |
+| OnyxTextarea      | "update:modelValue"   | `string`   | `Nullable<string>`   |

--- a/packages/sit-onyx/CHANGELOG.md
+++ b/packages/sit-onyx/CHANGELOG.md
@@ -13,22 +13,22 @@
 
   For reference: `type Nullable<T> = T | null | undefined`
 
-  | Component         | Event name            | New type | Old type           |
-  | ----------------- | --------------------- | -------- | ------------------ |
-  | OnyxAccordion     | "update:modelValue"   | TValue[] | Nullable<TValue[]> |
-  | OnyxBasicDialog   | "update:open"         | boolean  | Nullable<boolean>  |
-  | OnyxCheckboxGroup | "update:modelValue"   | TValue[] | Nullable<TValue[]> |
-  | OnyxFAB           | "update:open"         | boolean  | Nullable<boolean>  |
-  | OnyxFilterTag     | "update:active"       | boolean  | Nullable<boolean>  |
-  | OnyxInput         | "update:modelValue"   | string   | Nullable<string>   |
-  | OnyxMiniSearch    | "update:modelValue"   | string   | Nullable<string>   |
-  | OnyxFlyoutMenu    | "update:open"         | boolean  | Nullable<boolean>  |
-  | OnyxMenuItem      | "update:open"         | boolean  | Nullable<boolean>  |
-  | OnyxNavItem       | "update:open"         | boolean  | Nullable<boolean>  |
-  | OnyxUserMenu      | "update:flyoutOpen"   | boolean  | Nullable<boolean>  |
-  | OnyxProgressSteps | "update:highestValue" | number   | Nullable<number>   |
-  | OnyxSwitch        | "update:modelValue"   | boolean  | Nullable<boolean>  |
-  | OnyxTextarea      | "update:modelValue"   | string   | Nullable<string>   |
+  | Component         | Event name            | New type   | Old type             |
+  | ----------------- | --------------------- | ---------- | -------------------- |
+  | OnyxAccordion     | "update:modelValue"   | `TValue[]` | `Nullable<TValue[]>` |
+  | OnyxBasicDialog   | "update:open"         | `boolean`  | `Nullable<boolean>`  |
+  | OnyxCheckboxGroup | "update:modelValue"   | `TValue[]` | `Nullable<TValue[]>` |
+  | OnyxFAB           | "update:open"         | `boolean`  | `Nullable<boolean>`  |
+  | OnyxFilterTag     | "update:active"       | `boolean`  | `Nullable<boolean>`  |
+  | OnyxInput         | "update:modelValue"   | `string`   | `Nullable<string>`   |
+  | OnyxMiniSearch    | "update:modelValue"   | `string`   | `Nullable<string>`   |
+  | OnyxFlyoutMenu    | "update:open"         | `boolean`  | `Nullable<boolean>`  |
+  | OnyxMenuItem      | "update:open"         | `boolean`  | `Nullable<boolean>`  |
+  | OnyxNavItem       | "update:open"         | `boolean`  | `Nullable<boolean>`  |
+  | OnyxUserMenu      | "update:flyoutOpen"   | `boolean`  | `Nullable<boolean>`  |
+  | OnyxProgressSteps | "update:highestValue" | `number`   | `Nullable<number>`   |
+  | OnyxSwitch        | "update:modelValue"   | `boolean`  | `Nullable<boolean>`  |
+  | OnyxTextarea      | "update:modelValue"   | `string`   | `Nullable<string>`   |
 
 ## 1.0.0-beta.302
 


### PR DESCRIPTION
Currently the [release pipeline](https://github.com/SchwarzIT/onyx/actions/runs/17149340258) is failing because the docs can not be build due to an invalid changelog.
The changelog is fixed with this PR.