### PR TITLE
chore: fix missing artifact during demo app deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,9 @@ jobs:
         with:
           name: demo-app
           path: apps/demo-app/.output
+          # we need to include hidden files because the folder name starts with a dot
+          # see: https://github.com/actions/upload-artifact?tab=readme-ov-file#uploading-hidden-files
+          include-hidden-files: true
 
   deploy_storybook:
     name: Deploy Storybook


### PR DESCRIPTION
The [last demo app deployment ](https://github.com/SchwarzIT/onyx/actions/runs/17318053222/job/49164803663)failed because the build artifact could not be found

The artifact upload action excludes hidden files by default. Since the ".output" folder starts with a dot, it is considered a hidden file so we need to explicitly allow it