### PR TITLE
feat(useMoreList, OnyxMoreList): support "ltr" hiding direction 

### DIFF
--- a/.changeset/fair-cooks-unite.md
+++ b/.changeset/fair-cooks-unite.md
@@ -3,3 +3,4 @@
 ---
 
 feat(useMoreList, OnyxMoreList): support "ltr" hiding direction
+fix(useMoreListChild): fix `useMoreListChild` ResizeObserver only considering border-box instead of content-box

--- a/.changeset/fair-cooks-unite.md
+++ b/.changeset/fair-cooks-unite.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(useMoreList, OnyxMoreList): support "ltr" hiding direction

--- a/.changeset/fair-cooks-unite.md
+++ b/.changeset/fair-cooks-unite.md
@@ -2,5 +2,5 @@
 "sit-onyx": minor
 ---
 
-feat(useMoreList, OnyxMoreList): support "ltr" hiding direction
-fix(useMoreListChild): fix `useMoreListChild` ResizeObserver only considering border-box instead of content-box
+- feat(useMoreList, OnyxMoreList): support "ltr" hiding direction
+- fix(useMoreListChild): fix `useMoreListChild` ResizeObserver only considering border-box instead of content-box

--- a/.changeset/few-ears-peel.md
+++ b/.changeset/few-ears-peel.md
@@ -1,5 +1,0 @@
----
-"sit-onyx": patch
----
-
-fix(useMoreListChild): use border-box instead of content-box

--- a/.changeset/few-ears-peel.md
+++ b/.changeset/few-ears-peel.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(useMoreListChild): use border-box instead of content-box

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.ct.tsx
@@ -2,7 +2,7 @@ import { expect, test } from "../../playwright/a11y.js";
 import TestWrapperCt from "./TestWrapper.ct.vue";
 import type { MoreListSlotBindings } from "./types.js";
 
-test("should render", async ({ mount, makeAxeBuilder, page }) => {
+test("should behave correctly", async ({ mount, makeAxeBuilder, page }) => {
   const events: MoreListSlotBindings[] = [];
 
   page.setViewportSize({ width: 1200, height: 200 });
@@ -20,10 +20,10 @@ test("should render", async ({ mount, makeAxeBuilder, page }) => {
   });
 
   const expectVisible = (name: string) =>
-    expect(component.getByRole("menuitem", { name, exact: true })).toBeVisible();
+    expect(component.getByText(name, { exact: true })).toBeVisible();
 
   const expectHidden = (name: string) =>
-    expect(component.getByRole("menuitem", { name, exact: true })).toBeHidden();
+    expect(component.getByText(name, { exact: true })).toBeHidden();
 
   // ACT
   const accessibilityScanResults = await makeAxeBuilder().analyze();
@@ -52,5 +52,19 @@ test("should render", async ({ mount, makeAxeBuilder, page }) => {
   await expectVisible("Element 3");
   await expectVisible("Element 4");
   await expectHidden("Element 5");
+  expect(events.at(-1)).toStrictEqual({ visibleElements: 4, hiddenElements: 20 });
+
+  // ACT
+  await component.update({
+    props: { count: 4.25, passThroughProps: { direction: "ltr" } },
+    on: eventHandlers,
+  });
+
+  // ASSERT
+  await expectHidden("Element 20");
+  await expectVisible("Element 21");
+  await expectVisible("Element 22");
+  await expectVisible("Element 23");
+  await expectVisible("Element 24");
   expect(events.at(-1)).toStrictEqual({ visibleElements: 4, hiddenElements: 20 });
 });

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.stories.ts
@@ -40,3 +40,19 @@ export const Default = {
       ),
   },
 } satisfies Story;
+
+export const LeftToRight = {
+  args: {
+    ...Default.args,
+    direction: "ltr",
+    more: ({ hiddenElements, attributes }) =>
+      h(
+        "span",
+        {
+          style: `font-family: var(--onyx-font-family); color: var(--onyx-color-text-icons-neutral-soft)`,
+          ...attributes,
+        },
+        `${hiddenElements} before`,
+      ),
+  },
+} satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/OnyxMoreList.vue
@@ -1,10 +1,10 @@
 <script lang="ts" setup>
-import { provide, ref, useTemplateRef, watch } from "vue";
+import { provide, ref, toRef, useTemplateRef, watch } from "vue";
 import { useMoreList } from "../../composables/useMoreList.js";
 import type { VueTemplateRefElement } from "../../composables/useResizeObserver.js";
 import type { MoreListSlotBindings, OnyxMoreListProps } from "./types.js";
 
-const props = withDefaults(defineProps<OnyxMoreListProps>(), { is: "div" });
+const props = withDefaults(defineProps<OnyxMoreListProps>(), { is: "div", direction: "rtl" });
 
 const emit = defineEmits<{
   /**
@@ -28,7 +28,12 @@ const parentRef = useTemplateRef<HTMLElement>("parentRefEl");
 const listRef = ref<VueTemplateRefElement>();
 const moreIndicatorRef = ref<VueTemplateRefElement>();
 
-const more = useMoreList({ parentRef, listRef, moreIndicatorRef });
+const more = useMoreList({
+  parentRef,
+  listRef,
+  moreIndicatorRef,
+  direction: toRef(() => props.direction),
+});
 
 // eslint-disable-next-line vue/no-setup-props-reactivity-loss -- provide does not support reactive symbols, this reactivity loss is mentioned in the property docs
 provide(props.injectionKey, more);
@@ -44,6 +49,7 @@ watch(
 <template>
   <component :is="props.is" ref="parentRefEl" class="onyx-component onyx-more-list">
     <slot
+      v-if="props.direction === 'rtl'"
       :attributes="{
         ref: (el?: VueTemplateRefElement) => (listRef = el),
         class: 'onyx-more-list__elements',
@@ -59,6 +65,14 @@ watch(
       }"
       :hidden-elements="more.hiddenElements.value?.length"
       :visible-elements="more.visibleElements.value?.length"
+    ></slot>
+
+    <slot
+      v-if="props.direction === 'ltr'"
+      :attributes="{
+        ref: (el?: VueTemplateRefElement) => (listRef = el),
+        class: 'onyx-more-list__elements',
+      }"
     ></slot>
   </component>
 </template>

--- a/packages/sit-onyx/src/components/OnyxMoreList/TestChild.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/TestChild.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+import { useMoreListChild } from "../../composables/useMoreList.js";
+import { TEST_MORE_LIST_INJECTION_KEY } from "./TestWrapper.ct.vue";
+
+defineSlots<{
+  /**
+   * Content.
+   */
+  default?(): unknown;
+}>();
+
+const { componentRef, isVisible } = useMoreListChild(TEST_MORE_LIST_INJECTION_KEY);
+</script>
+
+<template>
+  <span v-show="isVisible" ref="componentRef" class="onyx-component onyx-text"><slot></slot></span>
+</template>

--- a/packages/sit-onyx/src/components/OnyxMoreList/TestWrapper.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxMoreList/TestWrapper.ct.vue
@@ -1,15 +1,19 @@
+<script lang="ts">
+export const TEST_MORE_LIST_INJECTION_KEY = Symbol("TEST_MORE_LIST_INJECTION_KEY");
+</script>
+
 <script lang="ts" setup>
 import { ref } from "vue";
-import OnyxNavItem from "../OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue";
-import { NAV_BAR_MORE_LIST_INJECTION_KEY } from "../OnyxNavBar/types.js";
 import OnyxMoreList from "./OnyxMoreList.vue";
-import type { MoreListSlotBindings } from "./types.js";
+import TestChild from "./TestChild.vue";
+import type { MoreListSlotBindings, OnyxMoreListProps } from "./types.js";
 
 const props = defineProps<{
   /**
    * Number of components to show. Can also be decimal.
    */
   count?: number;
+  passThroughProps?: Partial<OnyxMoreListProps>;
 }>();
 
 const emit = defineEmits<{
@@ -23,35 +27,32 @@ const handleVisibilityChange = (event: MoreListSlotBindings) => {
   emit("visibilityChange", event);
 };
 
-const COMPONENT_WIDTH = "8rem";
+const COMPONENT_WIDTH = "100px";
 </script>
 
 <template>
   <OnyxMoreList
     class="list"
-    :injection-key="NAV_BAR_MORE_LIST_INJECTION_KEY"
+    :injection-key="TEST_MORE_LIST_INJECTION_KEY"
     :style="{
       width: props.count ? `calc(${props.count} * ${COMPONENT_WIDTH})` : undefined,
     }"
+    v-bind="props.passThroughProps"
     @visibility-change="handleVisibilityChange"
   >
     <template #default="{ attributes }">
-      <ul v-bind="attributes" role="menu">
-        <OnyxNavItem
+      <div v-bind="attributes">
+        <TestChild
           v-for="i in 24"
           :key="i"
-          :label="`Element ${i}`"
-          :style="{ minWidth: COMPONENT_WIDTH, display: i <= visible ? 'block' : 'none' }"
-        />
-      </ul>
+          :style="{
+            minWidth: COMPONENT_WIDTH,
+            maxWidth: COMPONENT_WIDTH,
+          }"
+        >
+          {{ `Element ${i}` }}
+        </TestChild>
+      </div>
     </template>
   </OnyxMoreList>
 </template>
-
-<!-- eslint-disable-next-line vue-scoped-css/enforce-style-type -->
-<style scoped>
-:deep(.onyx-more-list__elements),
-:deep(.onyx-more-list__indicator) {
-  padding: 0;
-}
-</style>

--- a/packages/sit-onyx/src/components/OnyxMoreList/types.ts
+++ b/packages/sit-onyx/src/components/OnyxMoreList/types.ts
@@ -11,6 +11,10 @@ export type OnyxMoreListProps = {
    * What the component should render as. Defaults to `div`.
    */
   is?: Component | string;
+  /**
+   * From which direction the more list items should be collapsed. Defaults to `rtl`.
+   */
+  direction?: "rtl" | "ltr";
 };
 
 export type MoreListSlotBindings = {

--- a/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxNavBar/OnyxNavBar.stories.ts
@@ -132,8 +132,9 @@ export const Nested = {
 } satisfies Story;
 
 export const WithMoreListItem = {
-  parameters: {
-    viewport: { defaultViewport: "sm" },
+  globals: {
+    // Set viewport to sm to show the more menu
+    viewport: { value: "sm" },
   },
   args: {
     logoUrl: "/onyx-logo.svg",
@@ -146,9 +147,9 @@ export const WithMoreListItem = {
       h(OnyxNavItem, { label: "Menuitem 4" }),
       h(
         OnyxNavItem,
-        { label: "Item 2" },
+        { label: "Menuitem 5" },
         {
-          default: () => ["Item 2", h(OnyxBadge, { dot: true, color: "warning" })],
+          default: () => ["Menuitem 5", h(OnyxBadge, { dot: true, color: "warning" })],
           children: () => [
             h(
               OnyxNavItem,

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
@@ -122,7 +122,9 @@ const { componentRef, isVisible } = isTopLevel
     @click="hasChildren && (open = true)"
   >
     <slot></slot>
-    <template v-if="slots.children" #children><slot name="children"></slot></template>
+    <template v-if="slots.children" #children>
+      <slot name="children"></slot>
+    </template>
   </OnyxNavItemFacade>
 
   <!-- Desktop parent item in navbar with children in a flyout -->
@@ -139,7 +141,9 @@ const { componentRef, isVisible } = isTopLevel
         context="navbar"
       >
         <slot></slot>
-        <template v-if="slots.children" #children><slot name="children"></slot></template>
+        <template v-if="slots.children" #children>
+          <slot name="children"></slot>
+        </template>
       </OnyxNavItemFacade>
     </template>
 
@@ -167,7 +171,9 @@ const { componentRef, isVisible } = isTopLevel
     context="list"
   >
     <slot></slot>
-    <template v-if="slots.children" #children><slot name="children"></slot></template>
+    <template v-if="slots.children" #children>
+      <slot name="children"></slot>
+    </template>
   </OnyxNavItemFacade>
 
   <!-- Desktop top-level nav item in more list -->
@@ -187,8 +193,10 @@ const { componentRef, isVisible } = isTopLevel
       :active
       context="list"
     >
-<slot></slot>
-        <template v-if="slots.children" #children> <slot name="children"></slot> </template>
+      <slot></slot>
+      <template v-if="slots.children" #children>
+        <slot name="children"></slot>
+      </template>
     </OnyxNavItemFacade>
   </Teleport>
 </template>

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
@@ -171,14 +171,21 @@ const { componentRef, isVisible } = isTopLevel
   </OnyxNavItemFacade>
 
   <!-- Desktop top-level nav item in more list -->
-  <template v-else>
-    <Teleport :disabled="!moreListTargetRef" :to="moreListTargetRef">
-      <OnyxNavItemFacade v-bind="mergeVueProps(props, $attrs)" :active context="list">
-        <slot></slot>
+  <Teleport
+    v-if="isTopLevel && !isMobile && moreListTargetRef"
+    :disabled="!moreListTargetRef"
+    :to="moreListTargetRef"
+  >
+    <OnyxNavItemFacade
+      v-if="!isVisible"
+      v-bind="mergeVueProps(props, $attrs)"
+      :active
+      context="list"
+    >
+<slot></slot>
         <template v-if="slots.children" #children> <slot name="children"></slot> </template>
-      </OnyxNavItemFacade>
-    </Teleport>
-  </template>
+    </OnyxNavItemFacade>
+  </Teleport>
 </template>
 
 <style lang="scss">

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
@@ -176,6 +176,11 @@ const { componentRef, isVisible } = isTopLevel
     :disabled="!moreListTargetRef"
     :to="moreListTargetRef"
   >
+    <!-- 
+      We even render the Teleport when there is nothing to teleport,
+      so that the original order of the OnyxNavItem's is preserved.
+      Otherwise the order would be based on the time when an OnyxNavItem becomes invisible.
+    -->
     <OnyxNavItemFacade
       v-if="!isVisible"
       v-bind="mergeVueProps(props, $attrs)"

--- a/packages/sit-onyx/src/composables/useMoreList.ts
+++ b/packages/sit-onyx/src/composables/useMoreList.ts
@@ -202,7 +202,6 @@ export const useMoreListChild = (injectionKey: MoreListInjectionKey) => {
   const componentRef = ref<VueTemplateRefElement>();
   const moreContext = inject(injectionKey, undefined);
   const { width } = useResizeObserver(componentRef, { box: "border-box" });
-  const wasMounted = ref(false);
 
   watch(
     width,
@@ -217,7 +216,6 @@ export const useMoreListChild = (injectionKey: MoreListInjectionKey) => {
   );
 
   onBeforeUnmount(() => moreContext?.componentMap.delete(id));
-  onMounted(() => (wasMounted.value = true));
 
   const isVisible = computed(() => moreContext?.visibleElements.value?.includes(id) ?? true);
 

--- a/packages/sit-onyx/src/composables/useMoreList.ts
+++ b/packages/sit-onyx/src/composables/useMoreList.ts
@@ -147,7 +147,10 @@ export const useMoreList = (options: UseMoreListOptions) => {
           }
         });
       },
-      { flush: "post" },
+      {
+        // The rendering should happen before we calculated the visible elements. This way we can ensure, that the widths are already up-to-date.
+        flush: "post",
+      },
     );
   });
 


### PR DESCRIPTION
Relates to #3059

- feat(useMoreList, OnyxMoreList): support "ltr" hiding direction
  - Will be used for OnyxBreadCrumb(Item) truncation
- fix(useMoreListChild): fix `useMoreListChild` ResizeObserver only considering border-box instead of content-box
