### PR TITLE
feat(demo-app): add nav bar context area slot

### DIFF
--- a/apps/demo-app/app/components/BackgroundImageCard.vue
+++ b/apps/demo-app/app/components/BackgroundImageCard.vue
@@ -2,10 +2,12 @@
 // we are using an JavaScript import here instead of putting it into the CSS
 // so the image is correctly resolved when this demo app is used/extended as Nuxt layer
 import coverUrl from "~/assets/images/news-cover.webp";
+
+const backgroundImage = `url("${coverUrl}")`;
 </script>
 
 <template>
-  <OnyxCard class="card" :style="{ backgroundImage: `url(${coverUrl})` }">
+  <OnyxCard class="card">
     <div class="card__overlay">
       <OnyxHeadline is="h2" class="card__headline">
         Lorem ipsum dolor: sit amet consetetur sadipscing
@@ -24,6 +26,7 @@ import coverUrl from "~/assets/images/news-cover.webp";
 <style lang="scss" scoped>
 .card {
   --onyx-card-gap: var(--onyx-density-md);
+  background-image: v-bind("backgroundImage");
   background-position: center;
   background-size: cover;
   color: var(--onyx-color-base-grayscale-white);

--- a/apps/demo-app/app/components/BackgroundImageCard.vue
+++ b/apps/demo-app/app/components/BackgroundImageCard.vue
@@ -1,5 +1,11 @@
+<script lang="ts" setup>
+// we are using an JavaScript import here instead of putting it into the CSS
+// so the image is correctly resolved when this demo app is used/extended as Nuxt layer
+import coverUrl from "~/assets/images/news-cover.webp";
+</script>
+
 <template>
-  <OnyxCard class="card">
+  <OnyxCard class="card" :style="{ backgroundImage: `url(${coverUrl})` }">
     <div class="card__overlay">
       <OnyxHeadline is="h2" class="card__headline">
         Lorem ipsum dolor: sit amet consetetur sadipscing
@@ -18,7 +24,6 @@
 <style lang="scss" scoped>
 .card {
   --onyx-card-gap: var(--onyx-density-md);
-  background-image: url("~/assets/images/news-cover.webp");
   background-position: center;
   background-size: cover;
   color: var(--onyx-color-base-grayscale-white);

--- a/apps/demo-app/app/components/NavBar.vue
+++ b/apps/demo-app/app/components/NavBar.vue
@@ -1,6 +1,9 @@
 <script lang="ts" setup>
 import NavBar from "#layers/blueprint/app/components/NavBar.vue";
+import type { OnyxNavBarSlots } from "sit-onyx";
 import logoUrl from "~/assets/images/onyx-logo.svg";
+
+defineSlots<Pick<OnyxNavBarSlots, "contextArea">>();
 
 const localePath = useLocalePath();
 </script>
@@ -13,6 +16,9 @@ const localePath = useLocalePath();
     <OnyxNavItem :label="$t('charts')" :link="localePath('/charts')" />
 
     <template #contextArea>
+      <!-- eslint-disable-next-line vue/require-explicit-slots -- slots type is imported from onyx but eslint does not seem to be able to handle this -->
+      <slot name="contextArea"></slot>
+
       <ColorSchemeSwitch />
       <DensitySwitch />
       <LocaleSwitch />


### PR DESCRIPTION
Relates to #3986

Add context area slot to the demo app nav bar so we can add a brand theme switch for our internal demo app deployment
