### PR TITLE
fix: correctly apply density when using `.onyx-density-*` classes

### DIFF
--- a/.changeset/eight-jokes-like.md
+++ b/.changeset/eight-jokes-like.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix: correctly apply density when using `.onyx-density-*` classes

--- a/.changeset/eight-jokes-like.md
+++ b/.changeset/eight-jokes-like.md
@@ -3,3 +3,5 @@
 ---
 
 fix: correctly apply density when using `.onyx-density-*` classes
+
+When using CSS classes to set densities, the `compact` density was not applied due to CSS selector specificity which caused the default density to be always used

--- a/.github/workflows/import-figma.yml
+++ b/.github/workflows/import-figma.yml
@@ -30,12 +30,12 @@ jobs:
 
       - name: 🛠️ Import default density variables
         run: |
-          pnpm run @sit-onyx/figma-utils import-variables -k "${{ vars.FIGMA_FILE_KEY }}" -t "${{ secrets.FIGMA_TOKEN }}" -d "../sit-onyx/src/styles/variables" -m default -s ":where(:root), :where(.onyx-density-{mode})" -n density-
+          pnpm run @sit-onyx/figma-utils import-variables -k "${{ vars.FIGMA_FILE_KEY }}" -t "${{ secrets.FIGMA_TOKEN }}" -d "../sit-onyx/src/styles/variables" -m default -s ":where(:root), .onyx-density-{mode}" -n density-
         working-directory: packages/figma-utils
 
       - name: 🛠️ Import remaining densities
         run: |
-          pnpm run @sit-onyx/figma-utils import-variables -k "${{ vars.FIGMA_FILE_KEY }}" -t "${{ secrets.FIGMA_TOKEN }}" -d "../sit-onyx/src/styles/variables" -m compact cozy -s ":where(.onyx-density-{mode})" -n density-
+          pnpm run @sit-onyx/figma-utils import-variables -k "${{ vars.FIGMA_FILE_KEY }}" -t "${{ secrets.FIGMA_TOKEN }}" -d "../sit-onyx/src/styles/variables" -m compact cozy -s ".onyx-density-{mode}" -n density-
         working-directory: packages/figma-utils
 
       - name: Create pull request

--- a/apps/demo-app/app/components/DensitySwitch.vue
+++ b/apps/demo-app/app/components/DensitySwitch.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { iconToolRuler } from "@sit-onyx/icons";
-import { DENSITIES, type SelectDialogOption } from "sit-onyx";
+import { DENSITIES, type Density, type SelectDialogOption } from "sit-onyx";
 import { capitalize } from "vue";
 
 const settingsStore = useSettingsStore();
@@ -21,13 +21,15 @@ const options = DENSITIES.map((density) => {
   } satisfies SelectDialogOption;
 });
 
+const getCSSClassName = (density: Density) => `onyx-density-${density}`;
+
 onMounted(() => {
   watch(
     density,
     (newValue, oldValue) => {
       const classList = document.documentElement.classList;
-      classList.remove(`onyx-density-${oldValue}`);
-      classList.add(`onyx-density-${newValue}`);
+      if (oldValue) classList.remove(getCSSClassName(oldValue));
+      classList.add(getCSSClassName(newValue));
     },
     { immediate: true },
   );

--- a/packages/sit-onyx/src/styles/variables/density-compact.css
+++ b/packages/sit-onyx/src/styles/variables/density-compact.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "compact" theme.
- * Imported from Figma API on Tue, 29 Jul 2025 06:23:58 GMT
+ * Imported from Figma API on Mon, 08 Sep 2025 12:35:33 GMT
  */
 .onyx-density-compact {
   --onyx-density-2xl: var(--onyx-number-spacing-600);

--- a/packages/sit-onyx/src/styles/variables/density-compact.css
+++ b/packages/sit-onyx/src/styles/variables/density-compact.css
@@ -3,7 +3,7 @@
  * This file contains the specific variables for the "compact" theme.
  * Imported from Figma API on Tue, 29 Jul 2025 06:23:58 GMT
  */
-:where(.onyx-density-compact) {
+.onyx-density-compact {
   --onyx-density-2xl: var(--onyx-number-spacing-600);
   --onyx-density-2xs: var(--onyx-number-spacing-100);
   --onyx-density-3xl: var(--onyx-number-spacing-700);

--- a/packages/sit-onyx/src/styles/variables/density-cozy.css
+++ b/packages/sit-onyx/src/styles/variables/density-cozy.css
@@ -3,7 +3,7 @@
  * This file contains the specific variables for the "cozy" theme.
  * Imported from Figma API on Tue, 29 Jul 2025 06:23:58 GMT
  */
-:where(.onyx-density-cozy) {
+.onyx-density-cozy {
   --onyx-density-2xl: var(--onyx-number-spacing-800);
   --onyx-density-2xs: var(--onyx-number-spacing-300);
   --onyx-density-3xl: var(--onyx-number-spacing-900);

--- a/packages/sit-onyx/src/styles/variables/density-cozy.css
+++ b/packages/sit-onyx/src/styles/variables/density-cozy.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "cozy" theme.
- * Imported from Figma API on Tue, 29 Jul 2025 06:23:58 GMT
+ * Imported from Figma API on Mon, 08 Sep 2025 12:35:33 GMT
  */
 .onyx-density-cozy {
   --onyx-density-2xl: var(--onyx-number-spacing-800);

--- a/packages/sit-onyx/src/styles/variables/density-default.css
+++ b/packages/sit-onyx/src/styles/variables/density-default.css
@@ -4,7 +4,7 @@
  * Imported from Figma API on Tue, 29 Jul 2025 06:23:24 GMT
  */
 :where(:root),
-:where(.onyx-density-default) {
+.onyx-density-default {
   --onyx-density-2xl: var(--onyx-number-spacing-700);
   --onyx-density-2xs: var(--onyx-number-spacing-200);
   --onyx-density-3xl: var(--onyx-number-spacing-800);

--- a/packages/sit-onyx/src/styles/variables/density-default.css
+++ b/packages/sit-onyx/src/styles/variables/density-default.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "default" theme.
- * Imported from Figma API on Tue, 29 Jul 2025 06:23:24 GMT
+ * Imported from Figma API on Mon, 08 Sep 2025 12:35:08 GMT
  */
 :where(:root),
 .onyx-density-default {

--- a/packages/sit-onyx/src/styles/variables/spacing.css
+++ b/packages/sit-onyx/src/styles/variables/spacing.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "spacing" theme.
- * Imported from Figma API on Tue, 29 Jul 2025 06:22:39 GMT
+ * Imported from Figma API on Mon, 08 Sep 2025 12:34:44 GMT
  */
 :where(:root) {
   --onyx-spacing-2xl: var(--onyx-number-spacing-700);

--- a/packages/sit-onyx/src/styles/variables/themes/onyx.css
+++ b/packages/sit-onyx/src/styles/variables/themes/onyx.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "onyx" theme.
- * Imported from Figma API on Tue, 29 Jul 2025 06:22:05 GMT
+ * Imported from Figma API on Mon, 08 Sep 2025 12:34:16 GMT
  */
 :where(:root),
 .onyx-theme-default {

--- a/packages/sit-onyx/src/styles/variables/themes/value.css
+++ b/packages/sit-onyx/src/styles/variables/themes/value.css
@@ -1,7 +1,7 @@
 /**
  * Do not edit directly.
  * This file contains the specific variables for the "value" theme.
- * Imported from Figma API on Tue, 29 Jul 2025 06:22:05 GMT
+ * Imported from Figma API on Mon, 08 Sep 2025 12:34:16 GMT
  */
 :where(:root),
 .onyx-theme-default {


### PR DESCRIPTION
When using CSS classes to set densities, the `compact` density was not applied due to CSS selector specificity which caused the default density to be always used.

This also fixes the issue in our demo app that the compact density switch is not working

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
