### PR TITLE
feat(useStickyColumns): support passing refs as options

### DIFF
--- a/.changeset/young-ghosts-begin.md
+++ b/.changeset/young-ghosts-begin.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(useStickyColumns): support passing refs as options

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/stickyColumns.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/stickyColumns.ts
@@ -1,4 +1,4 @@
-import { computed, nextTick, onMounted, onUnmounted, ref, useId, watch } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref, toValue, useId, watch } from "vue";
 import { createFeature, type ModifyColumns } from "../index.js";
 
 import { mergeVueProps } from "../../../../utils/attrs.js";
@@ -13,8 +13,8 @@ export const useStickyColumns = <TEntry extends DataGridEntry>(
   options?: StickyColumnsOptions<TEntry>,
 ) =>
   createFeature(() => {
-    const stickyColumns = computed(() => options?.columns ?? []);
-    const position = computed(() => options?.position ?? "left");
+    const stickyColumns = computed(() => toValue(options?.columns) ?? []);
+    const position = computed(() => toValue(options?.position) ?? "left");
     const elementWidths = ref<Record<PropertyKey, number>>({});
     const elementsToStyle = ref<Record<PropertyKey, HTMLElement>>({});
     const stickyId = useId();

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/types.ts
@@ -1,3 +1,4 @@
+import type { MaybeRef } from "vue";
 import type { DataGridEntry } from "../../types.js";
 /*
  * The configuration options for the stickyColumn feature in the OnyxDataGrid component.
@@ -6,10 +7,11 @@ export type StickyColumnsOptions<TEntry extends DataGridEntry> = {
   /**
    * Defines the columns that should remain sticky.
    */
-  columns: (keyof TEntry)[];
+  columns: MaybeRef<(keyof TEntry)[]>;
   /**
-   * * Determines the side to which the columns are sticked.
-   * @default `left`
+   * Determines the side to which the columns are sticked.
+   *
+   * @default "left"
    */
-  position?: "left" | "right";
+  position?: MaybeRef<"left" | "right">;
 };


### PR DESCRIPTION
Support passing refs to the useStickyColumns data grid feature so the project can e.g. implement a custom feature where the user can pin/unpin columns

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
