### PR TITLE
fix(OnyxBreadcrumb): Fix `can't access property "nodeType", container is null` hydration error

### DIFF
--- a/.changeset/ready-teeth-drop.md
+++ b/.changeset/ready-teeth-drop.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxBreadcrumb): Fix `can't access property "nodeType", container is null` hydration error

--- a/packages/sit-onyx/src/components/OnyxBreadcrumbItem/OnyxBreadcrumbItem.vue
+++ b/packages/sit-onyx/src/components/OnyxBreadcrumbItem/OnyxBreadcrumbItem.vue
@@ -75,7 +75,7 @@ const isActive = computed(() => {
       <slot></slot>
     </ButtonOrLinkLayout>
   </li>
-  <Teleport :to="moreListTargetRef" :disabled="!moreListTargetRef">
+  <Teleport v-if="moreListTargetRef" :to="moreListTargetRef">
     <OnyxMenuItem v-if="!isVisible" :link="props.href" :active="isActive" v-bind="restAttrs">
       <slot></slot>
     </OnyxMenuItem>

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
@@ -177,11 +177,7 @@ const { componentRef, isVisible } = isTopLevel
   </OnyxNavItemFacade>
 
   <!-- Desktop top-level nav item in more list -->
-  <Teleport
-    v-if="isTopLevel && !isMobile && moreListTargetRef"
-    :disabled="!moreListTargetRef"
-    :to="moreListTargetRef"
-  >
+  <Teleport v-if="isTopLevel && !isMobile && moreListTargetRef" :to="moreListTargetRef">
     <!-- 
       We even render the Teleport when there is nothing to teleport,
       so that the original order of the OnyxNavItem's is preserved.


### PR DESCRIPTION
Closes #4137

- Fixed by only performing teleport on client
- Added SSR testing for components