### PR TITLE
feat(OnyxNotifications): return notification id after creation

### DIFF
--- a/.changeset/tough-jeans-fly.md
+++ b/.changeset/tough-jeans-fly.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxNotifications): return notification id after it is created

--- a/packages/sit-onyx/src/components/OnyxNotifications/useNotification.spec.ts
+++ b/packages/sit-onyx/src/components/OnyxNotifications/useNotification.spec.ts
@@ -40,4 +40,9 @@ describe("useNotification", () => {
 
     expect(provider.notifications.value).toStrictEqual([]);
   });
+  test("should return item id", () => {
+    const provider = createNotificationsProvider();
+    expect(provider.show({ headline: "Test 1", description: "Description 1" })).toBe(1);
+    expect(provider.show({ headline: "Test 2", description: "Description 2" })).toBe(2);
+  });
 });

--- a/packages/sit-onyx/src/components/OnyxNotifications/useNotification.ts
+++ b/packages/sit-onyx/src/components/OnyxNotifications/useNotification.ts
@@ -10,8 +10,9 @@ export type NotificationsProvider = {
   notifications: ComputedRef<ProvidedNotification[]>;
   /**
    * Shows a single notification.
+   * @returns the id of the newly created notification.
    */
-  show: (notification: ShowNotificationOptions) => void;
+  show: (notification: ShowNotificationOptions) => number;
   /**
    * Removes the notification with the given `id`.
    */
@@ -71,6 +72,8 @@ export const createNotificationsProvider = (): NotificationsProvider => {
       id,
       onClose: () => remove(id),
     });
+
+    return id;
   };
 
   const remove: NotificationsProvider["remove"] = (id) => {
@@ -99,7 +102,10 @@ export const useNotification = () => {
     () => {
       return {
         notifications: computed(() => []),
-        show: logWarning,
+        show: () => {
+          logWarning();
+          return 0;
+        },
         remove: logWarning,
       } satisfies NotificationsProvider;
     },


### PR DESCRIPTION
Return notification `id` after it is created

## Checklist

- [ ] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [ ] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) or functional test is added
- [ ] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [ ] I have performed a self review of my code ("Files changed" tab in the pull request)
- [ ] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
