### PR TITLE
chore(@sit-onyx/shared): bump Vite peerDependency range

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -32,6 +32,6 @@
     "@playwright/experimental-ct-vue": "catalog:",
     "@vitejs/plugin-vue": ">= 5",
     "sass-embedded": ">= 1.74.0",
-    "vite": ">= 6"
+    "vite": ">= 6.3.6"
   }
 }


### PR DESCRIPTION
Bump the Vite dependency range for our shared package to `>= 6.3.6` to fix the current [3 vulnerability alerts](https://github.com/SchwarzIT/onyx/security/dependabot) in GitHub.