### PR TITLE
fix(OnyxSidebar): Fix scrollbar in temporary mode

### DIFF
--- a/packages/sit-onyx/src/components/OnyxSidebar/OnyxSidebar.vue
+++ b/packages/sit-onyx/src/components/OnyxSidebar/OnyxSidebar.vue
@@ -226,6 +226,7 @@ onUnmounted(() => {
 
     &:has(.onyx-resize-handle) {
       position: relative;
+      overflow: hidden;
     }
 
     &--temporary {


### PR DESCRIPTION
Closes #4135 

Cause: For `temporary` mode the Dialog uses `container-type: inline-size` to enable container-queries. This collides with the resizehandle which increases the width. Usually it is supposed to overflow, but here it can't work because of the `container-type`.

Fix: Set `overflow: hidden` when the resizehandle exists 