### PR TITLE
Larsrickert/4222 datepicker empty string

### DIFF
--- a/.changeset/thick-glasses-create.md
+++ b/.changeset/thick-glasses-create.md
@@ -3,3 +3,5 @@
 ---
 
 fix(OnyxDatePicker): empty undefined instead of empty string when value is cleared
+
+Also the type for the `update:modelValue` event has been fixed to be `string | undefined` instead of `DateValue | undefined` since its always a string timestamp if a date is selected.

--- a/.changeset/thick-glasses-create.md
+++ b/.changeset/thick-glasses-create.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxDatePicker): empty undefined instead of empty string when value is cleared

--- a/packages/sit-onyx/src/components/OnyxDatePicker/OnyxDatePicker.vue
+++ b/packages/sit-onyx/src/components/OnyxDatePicker/OnyxDatePicker.vue
@@ -9,7 +9,6 @@ import {
   useSkeletonContext,
 } from "../../composables/useSkeletonState.js";
 import { useVModel } from "../../composables/useVModel.js";
-import type { Nullable } from "../../types/index.js";
 import { useRootAttrs } from "../../utils/attrs.js";
 import { isValidDate } from "../../utils/date.js";
 import { FORM_INJECTED_SYMBOL, useFormContext } from "../OnyxForm/OnyxForm.core.js";
@@ -32,7 +31,7 @@ const emit = defineEmits<{
   /**
    * Emitted when the current value changes. Will be a ISO timestamp created by `new Date().toISOString()`.
    */
-  "update:modelValue": [value?: Nullable<DateValue>];
+  "update:modelValue": [value?: string];
   /**
    * Emitted when the validity state of the input changes.
    */
@@ -84,7 +83,7 @@ const value = computed({
   get: () => getNormalizedDate.value(modelValue.value),
   set: (value) => {
     const newDate = new Date(value ?? "");
-    modelValue.value = isValidDate(newDate) ? newDate.toISOString() : "";
+    modelValue.value = isValidDate(newDate) ? newDate.toISOString() : undefined;
   },
 });
 const input = useTemplateRef("inputRef");


### PR DESCRIPTION
closes #4222

fix(OnyxDatePicker): empty undefined instead of empty string when value is cleared

Also the type for the `update:modelValue` event has been fixed to be `string | undefined` instead of `DateValue | undefined` since its always a string timestamp if a date is selected.

## Checklist

- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
