### PR TITLE
chore: resolve active code scanning issues

### DIFF
--- a/packages/figma-utils/src/commands/import-variables.spec.ts
+++ b/packages/figma-utils/src/commands/import-variables.spec.ts
@@ -62,12 +62,13 @@ describe("import-variables.ts", () => {
     expect(functions.generateAsCSS).toHaveBeenCalledTimes(2);
     expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
 
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
+    expect(fs.writeFileSync).toHaveBeenNthCalledWith(
+      1,
       "test-cwd/test-file-name-test-mode-1.css",
       "mock-css-file-content",
     );
 
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
+    expect(fs.writeFileSync).toHaveBeenLastCalledWith(
       "test-cwd/test-file-name-test-mode-2.css",
       "mock-css-file-content",
     );

--- a/packages/headless/src/composables/helpers/useTypeAhead.spec.ts
+++ b/packages/headless/src/composables/helpers/useTypeAhead.spec.ts
@@ -10,12 +10,10 @@ test("useTypeAhead", () => {
   const typeAhead = useTypeAhead(spy);
 
   typeAhead({ key: "a" });
-  expect(spy).toHaveBeenCalledOnce();
-  expect(spy).toHaveBeenLastCalledWith("a");
+  expect(spy).toHaveBeenCalledExactlyOnceWith("a");
 
   typeAhead({ key: "Alt" });
-  expect(spy).toHaveBeenCalledOnce();
-  expect(spy).toHaveBeenLastCalledWith("a");
+  expect(spy).toHaveBeenCalledExactlyOnceWith("a");
 
   typeAhead({ key: "b" });
   expect(spy).toHaveBeenCalledTimes(2);

--- a/packages/icons/scripts/generate-changeset.spec.ts
+++ b/packages/icons/scripts/generate-changeset.spec.ts
@@ -46,7 +46,7 @@ describe("generate-changeset.ts", () => {
     });
 
     // ASSERT
-    expect(writeChangesetSpy).toHaveBeenCalledWith(
+    expect(writeChangesetSpy).toHaveBeenCalledExactlyOnceWith(
       {
         releases: [{ name: "@sit-onyx/test", type: "major" }],
         summary: `Example title
@@ -101,7 +101,7 @@ describe("generate-changeset.ts", () => {
     });
 
     // ASSERT
-    expect(writeChangesetSpy).toHaveBeenCalledWith(
+    expect(writeChangesetSpy).toHaveBeenCalledExactlyOnceWith(
       {
         releases: [{ name: "@sit-onyx/test", type: releaseType }],
         summary: expect.any(String),
@@ -123,7 +123,7 @@ describe("generate-changeset.ts", () => {
     });
 
     // ASSERT
-    expect(writeChangesetSpy).toHaveBeenCalledWith(
+    expect(writeChangesetSpy).toHaveBeenCalledExactlyOnceWith(
       {
         releases: [{ name: "@sit-onyx/test", type: "minor" }],
         summary: `Example title

--- a/packages/sit-onyx/src/composables/scrollEnd.spec.ts
+++ b/packages/sit-onyx/src/composables/scrollEnd.spec.ts
@@ -18,7 +18,7 @@ describe("scrollEnd.ts", () => {
 
     vScrollEnd.mounted(mockElement);
 
-    expect(addEventListenerSpy, "should add scroll listener").toHaveBeenCalledWith(
+    expect(addEventListenerSpy, "should add scroll listener").toHaveBeenCalledExactlyOnceWith(
       "scroll",
       expect.any(Function),
     );
@@ -40,10 +40,10 @@ describe("scrollEnd.ts", () => {
 
     loading.value = true;
     await nextTick();
-    expect(removeEventListenerSpy, "should remove event listener if loading").toHaveBeenCalledWith(
-      "scroll",
-      expect.any(Function),
-    );
+    expect(
+      removeEventListenerSpy,
+      "should remove event listener if loading",
+    ).toHaveBeenCalledExactlyOnceWith("scroll", expect.any(Function));
     loading.value = false;
 
     removeEventListenerSpy.mockClear();
@@ -51,10 +51,10 @@ describe("scrollEnd.ts", () => {
 
     enabled.value = false;
     await nextTick();
-    expect(removeEventListenerSpy, "should remove event listener if disabled").toHaveBeenCalledWith(
-      "scroll",
-      expect.any(Function),
-    );
+    expect(
+      removeEventListenerSpy,
+      "should remove event listener if disabled",
+    ).toHaveBeenCalledExactlyOnceWith("scroll", expect.any(Function));
     enabled.value = true;
   });
 

--- a/packages/sit-onyx/src/composables/useCustomValidity.spec.ts
+++ b/packages/sit-onyx/src/composables/useCustomValidity.spec.ts
@@ -67,7 +67,7 @@ describe("useCustomValidity", () => {
     await nextTick();
 
     // ASSERT
-    expect(mockInput.setCustomValidity).toHaveBeenCalledWith("Test error");
+    expect(mockInput.setCustomValidity).toHaveBeenCalledExactlyOnceWith("Test error");
     expect(validityState.value).toEqual({
       ...getDefaultValidityState(),
       customError: true,
@@ -84,7 +84,7 @@ describe("useCustomValidity", () => {
     // ACT
     vCustomValidity.mounted(mockInput);
     await nextTick();
-    expect(mockInput.setCustomValidity).toHaveBeenCalledWith("Initial error");
+    expect(mockInput.setCustomValidity).toHaveBeenCalledExactlyOnceWith("Initial error");
     expect(validityState.value).toEqual({
       ...getDefaultValidityState(),
       customError: true,
@@ -94,7 +94,7 @@ describe("useCustomValidity", () => {
     await nextTick();
 
     // ASSERT
-    expect(mockInput.setCustomValidity).toHaveBeenCalledWith("Updated error");
+    expect(mockInput.setCustomValidity).toHaveBeenLastCalledWith("Updated error");
     expect(validityState.value).toEqual({
       ...getDefaultValidityState(),
       customError: true,
@@ -116,7 +116,7 @@ describe("useCustomValidity", () => {
     await nextTick();
 
     // ASSERT
-    expect(mockInput.setCustomValidity).toHaveBeenCalledWith("");
+    expect(mockInput.setCustomValidity).toHaveBeenLastCalledWith("");
     expect(validityState.value).toEqual({
       ...getDefaultValidityState(),
       customError: false,

--- a/packages/sit-onyx/src/composables/useFormElementError.spec.ts
+++ b/packages/sit-onyx/src/composables/useFormElementError.spec.ts
@@ -73,7 +73,7 @@ describe("useFormElementError", () => {
     await nextTick();
 
     // ASSERT
-    expect(mockInput.setCustomValidity).toHaveBeenCalledWith("This is a custom error.");
+    expect(mockInput.setCustomValidity).toHaveBeenCalledExactlyOnceWith("This is a custom error.");
     expect(errorMessages.value).toEqual({
       shortMessage: "This is a custom error.",
       longMessage: "This is a custom error.",

--- a/packages/sit-onyx/src/composables/useIntersectionObserver.spec.ts
+++ b/packages/sit-onyx/src/composables/useIntersectionObserver.spec.ts
@@ -42,6 +42,6 @@ describe("useIntersectionObserver", () => {
 
     expect(isIntersecting.value).toBe(false);
 
-    expect(spy.observe).toHaveBeenCalledWith(component.value);
+    expect(spy.observe).toHaveBeenCalledExactlyOnceWith(component.value);
   });
 });

--- a/packages/sit-onyx/src/composables/useResizeObserver.spec.ts
+++ b/packages/sit-onyx/src/composables/useResizeObserver.spec.ts
@@ -30,7 +30,7 @@ describe("useResizeObserver", () => {
     const { height, width } = useResizeObserver(component);
 
     expect(ResizeObserver).toHaveBeenCalledOnce();
-    expect(spy.observe).toHaveBeenCalledWith(toValue(component), { box: "content-box" });
+    expect(spy.observe).toHaveBeenCalledExactlyOnceWith(toValue(component), { box: "content-box" });
     expect(callback).toBeDefined();
 
     callback!([{ contentBoxSize: [{ blockSize: 42, inlineSize: 100 }] }]);

--- a/packages/sit-onyx/src/composables/useVModel.spec.ts
+++ b/packages/sit-onyx/src/composables/useVModel.spec.ts
@@ -35,11 +35,11 @@ test("should emit the 'update' event with the new value when the computed value 
 
   modelValue.value = "new value";
   await nextTick();
-  expect(emit).toHaveBeenCalledWith("update:modelValue", "new value");
+  expect(emit).toHaveBeenCalledExactlyOnceWith("update:modelValue", "new value");
 
   modelValue.value = undefined;
   await nextTick();
-  expect(emit).toHaveBeenCalledWith("update:modelValue", undefined);
+  expect(emit).toHaveBeenLastCalledWith("update:modelValue", undefined);
 });
 
 test("should return the internal state value if the prop is controlled, otherwise return the prop value", async () => {
@@ -70,7 +70,7 @@ test("should handle null prop values correctly", async () => {
 
   modelValue.value = "new value";
   await nextTick();
-  expect(emit).toHaveBeenCalledWith("update:modelValue", "new value");
+  expect(emit).toHaveBeenCalledExactlyOnceWith("update:modelValue", "new value");
 
   props.modelValue = "updated value";
   await nextTick();
@@ -89,7 +89,7 @@ test("should handle undefined prop values correctly", async () => {
 
   modelValue.value = "new value";
   await nextTick();
-  expect(emit).toHaveBeenCalledWith("update:modelValue", "new value");
+  expect(emit).toHaveBeenCalledExactlyOnceWith("update:modelValue", "new value");
 
   props.modelValue = "updated value";
   await nextTick();

--- a/packages/sit-onyx/src/utils/attrs.spec.ts
+++ b/packages/sit-onyx/src/utils/attrs.spec.ts
@@ -79,7 +79,7 @@ describe("mergeVueProps", () => {
     expect(targetRef.value).toBe(newValue);
     expect(ref1.value).toBe(newValue);
     expect(ref2.value).toBe(newValue);
-    expect(fnRef).toHaveBeenCalledWith(newValue, []);
+    expect(fnRef).toHaveBeenCalledExactlyOnceWith(newValue, []);
   });
 
   test("should be able to merge and track reactive dependencies", async () => {
@@ -96,7 +96,7 @@ describe("mergeVueProps", () => {
     expect(sourceRef.value).toBe(newValue);
     expect(ref1.value).toBe(newValue);
     expect(ref2.value).toBe(newValue);
-    expect(fnRef).toHaveBeenCalledWith(newValue, []);
+    expect(fnRef).toHaveBeenCalledExactlyOnceWith(newValue, []);
   });
 
   test("should be able to merge proxied", async () => {


### PR DESCRIPTION
Resolves current [code scanning issues ](https://github.com/SchwarzIT/onyx/security/code-scanning) related to the `vitest/prefer-called-exactly-once-with` rule