### PR TITLE
chore: re-enable check pipeline for main branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,6 +81,7 @@ jobs:
           path: coverage
 
   screenshots:
+    if: github.ref != 'refs/heads/main'
     needs: build
     name: Component tests
     uses: ./.github/workflows/playwright.yml


### PR DESCRIPTION
- Our [code scanning results](https://github.com/SchwarzIT/onyx/security/code-scanning) are out of date. Seems like the main branch trigger was (accidentally?) removed in https://github.com/SchwarzIT/onyx/commit/4eee8390a651cc76021a6fa24e0f923642599b93

- Added explicit permissions