### PR TITLE
docs: update "new" badges

### DIFF
--- a/packages/sit-onyx/src/components/OnyxCard/OnyxCard.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxCard/OnyxCard.stories.ts
@@ -43,7 +43,6 @@ export const Clickable = {
 } satisfies Story;
 
 export const Link = {
-  tags: ["new:feature"],
   args: {
     ...Default.args,
     link: {

--- a/packages/sit-onyx/src/components/OnyxDialog/OnyxDialog.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxDialog/OnyxDialog.stories.ts
@@ -10,7 +10,6 @@ import OnyxDialog from "./OnyxDialog.vue";
  */
 const meta: Meta<typeof OnyxDialog> = {
   title: "Feedback/Dialog",
-  tags: ["new:component"],
   component: OnyxDialog,
   argTypes: {
     default: { control: { disable: true } },

--- a/packages/sit-onyx/src/components/OnyxProgressItem/OnyxProgressItem.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxProgressItem/OnyxProgressItem.stories.ts
@@ -72,6 +72,5 @@ export const Skeleton = {
 } satisfies Story;
 
 export const CustomLabel = {
-  tags: ["new:feature"],
   ...createAdvancedStoryExample("OnyxProgressItem", "CustomContentExample"),
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxProgressSteps/OnyxProgressSteps.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxProgressSteps/OnyxProgressSteps.stories.ts
@@ -26,6 +26,5 @@ export const Skeleton = createAdvancedStoryExample(
 ) satisfies Story;
 
 export const CustomContent = {
-  tags: ["new:feature"],
   ...createAdvancedStoryExample("OnyxProgressSteps", "CustomContentExample"),
 } satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxSegmentedControl/OnyxSegmentedControl.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxSegmentedControl/OnyxSegmentedControl.stories.ts
@@ -8,7 +8,6 @@ import OnyxSegmentedControl from "./OnyxSegmentedControl.vue";
  */
 const meta: Meta<typeof OnyxSegmentedControl> = {
   title: "Navigation/SegmentedControl",
-  tags: ["new:component"],
   component: OnyxSegmentedControl,
 };
 

--- a/packages/sit-onyx/src/components/OnyxSegmentedControlElement/OnyxSegmentedControlElement.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxSegmentedControlElement/OnyxSegmentedControlElement.stories.ts
@@ -7,7 +7,6 @@ import OnyxSegmentedControlElement from "./OnyxSegmentedControlElement.vue";
  */
 const meta: Meta<typeof OnyxSegmentedControlElement> = {
   title: "Support/SegmentedControlElement",
-  tags: ["new:component"],
   component: OnyxSegmentedControlElement,
   argTypes: {},
 };


### PR DESCRIPTION
Remove "new" Storybook badges for components/features that already exists for > 2 months