### PR TITLE
chore: fix eslint issues

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -140,6 +140,8 @@ const vitestConfig = {
   extends: [pluginVitest.configs.recommended],
   rules: {
     "vue/no-ref-object-reactivity-loss": "off",
+    // enforce using "test" instead of mixed "it"
+    "vitest/consistent-test-it": ["error", { fn: "test", withinDescribe: "test" }],
   },
 };
 

--- a/packages/headless/src/composables/calendar/createCalendar.spec.ts
+++ b/packages/headless/src/composables/calendar/createCalendar.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { nextTick, ref, type Ref } from "vue";
 import type { DateRange, DateValue } from "../../utils/dates.js";
 import {
@@ -59,7 +59,7 @@ const triggerKey = async (elements: any, key: string, opts: KeyboardEventInit = 
 describe("createCalendar (Headless)", () => {
   const initialDate = createDate(2025, 8, 15);
 
-  it("should initialize with correct default values", () => {
+  test("should initialize with correct default values", () => {
     const today = createDate(new Date().getFullYear(), new Date().getMonth(), new Date().getDate());
     const { state, modelValue } = setupCalendar({});
 
@@ -79,7 +79,7 @@ describe("createCalendar (Headless)", () => {
     ]);
   });
 
-  it("should respect min and max dates", () => {
+  test("should respect min and max dates", () => {
     const min = createDate(2025, 8, 10);
     const max = createDate(2025, 8, 20);
     const { internals } = setupCalendar({ min, max });
@@ -89,7 +89,7 @@ describe("createCalendar (Headless)", () => {
     expect(internals.isDisabled.value(createDate(2025, 8, 21))).toBe(true);
   });
 
-  it("should disable all dates when disabled is true", () => {
+  test("should disable all dates when disabled is true", () => {
     const { internals } = setupCalendar({
       disabled: true,
     });
@@ -99,7 +99,7 @@ describe("createCalendar (Headless)", () => {
     expect(internals.isDisabled.value(new Date())).toBe(true);
   });
 
-  it("should only disable days specified by the disabled function", () => {
+  test("should only disable days specified by the disabled function", () => {
     const disableMondays = (date: Date) => date.getDay() === 1;
     const mondayDate = createDate(2025, 8, 15);
     const tuesdayDate = createDate(2025, 8, 16);
@@ -111,7 +111,7 @@ describe("createCalendar (Headless)", () => {
     expect(internals.isDisabled.value(tuesdayDate)).toBe(false);
   });
 
-  it("should navigate months correctly", () => {
+  test("should navigate months correctly", () => {
     const { state, internals, viewMonth } = setupCalendar({ viewMonth: initialDate });
 
     // viewMonth is initialized, state reflects this
@@ -125,7 +125,7 @@ describe("createCalendar (Headless)", () => {
     expect((viewMonth.value as Date).getMonth()).toBe(8);
   });
 
-  it("should handle goToToday correctly", () => {
+  test("should handle goToToday correctly", () => {
     const today = createDate(new Date().getFullYear(), new Date().getMonth(), new Date().getDate());
     const { internals, viewMonth } = setupCalendar({ viewMonth: createDate(2020, 0, 1) });
 
@@ -134,7 +134,7 @@ describe("createCalendar (Headless)", () => {
     expect(internals.isToday(today)).toBe(true);
   });
 
-  it("should correctly identify selection states (Single Mode)", () => {
+  test("should correctly identify selection states (Single Mode)", () => {
     const selectedDate = createDate(2025, 8, 15);
     const { internals, modelValue } = setupCalendar({ selection: "single" });
 
@@ -143,7 +143,7 @@ describe("createCalendar (Headless)", () => {
     expect(internals.isSelected.value(createDate(2025, 8, 16))).toBe(false);
   });
 
-  it("should correctly handle date selection (Single Mode)", () => {
+  test("should correctly handle date selection (Single Mode)", () => {
     const { internals, modelValue } = setupCalendar({
       viewMonth: initialDate,
       selection: "single",
@@ -161,7 +161,7 @@ describe("createCalendar (Headless)", () => {
     const dateA = createDate(2025, 8, 15); // Mon
     const dateB = createDate(2025, 8, 16); // Tue
 
-    it("should add dates to the array when selecting multiple", () => {
+    test("should add dates to the array when selecting multiple", () => {
       const { internals, modelValue } = setupCalendar({ selection: "multiple" });
 
       // 1. Select dateA
@@ -177,7 +177,7 @@ describe("createCalendar (Headless)", () => {
       expect(((modelValue.value as DateValue[])[1] as Date).getTime()).toBe(dateB.getTime());
     });
 
-    it("should remove (toggle off) dates that are already selected", () => {
+    test("should remove (toggle off) dates that are already selected", () => {
       const initialSelection: DateValue[] = [dateA, dateB];
       const { internals, modelValue } = setupCalendar({
         selection: "multiple",
@@ -197,7 +197,7 @@ describe("createCalendar (Headless)", () => {
   });
 
   describe("Range Selection Mode", () => {
-    it("should correctly set the start and end points", () => {
+    test("should correctly set the start and end points", () => {
       const { internals, modelValue } = setupCalendar({ selection: "range" });
       const start = createDate(2025, 8, 15);
       const end = createDate(2025, 8, 20);
@@ -215,7 +215,7 @@ describe("createCalendar (Headless)", () => {
       expect(internals.isSelected.value(end)).toBe(true);
     });
 
-    it("should correct the order if the end date is before the start date", () => {
+    test("should correct the order if the end date is before the start date", () => {
       const { internals, modelValue } = setupCalendar({ selection: "range" });
       const start = createDate(2025, 8, 20);
       const end = createDate(2025, 8, 15);
@@ -235,7 +235,7 @@ describe("createCalendar (Headless)", () => {
     });
   });
 
-  it("should handle keyboard navigation correctly", async () => {
+  test("should handle keyboard navigation correctly", async () => {
     const { elements, state, viewMonth } = setupCalendar({ viewMonth: initialDate });
     const startFocusedDate = initialDate; // Mon, Sept 15, 2025
     state.focusedDate.value = startFocusedDate;

--- a/packages/headless/src/composables/helpers/useGlobalListener.spec.ts
+++ b/packages/headless/src/composables/helpers/useGlobalListener.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ref, type Ref } from "vue";
 import { mockVueLifecycle } from "../../utils/vitest.js";
 import { useGlobalEventListener } from "./useGlobalListener.js";
@@ -15,11 +15,11 @@ describe("useGlobalEventListener", () => {
     document.body.appendChild(target.value);
   });
 
-  it("should be defined", () => {
+  test("should be defined", () => {
     expect(useGlobalEventListener).toBeDefined();
   });
 
-  it("should listen to global events", () => {
+  test("should listen to global events", () => {
     // ARRANGE
     const listener = vi.fn();
     useGlobalEventListener({ type: "click", listener });
@@ -31,7 +31,7 @@ describe("useGlobalEventListener", () => {
     expect(listener).toBeCalledWith(event);
   });
 
-  it("should stop to listen to global events after unmount", async () => {
+  test("should stop to listen to global events after unmount", async () => {
     // ARRANGE
     const listener = vi.fn();
     useGlobalEventListener({ type: "click", listener });
@@ -43,7 +43,7 @@ describe("useGlobalEventListener", () => {
     expect(listener).toHaveBeenCalledTimes(0);
   });
 
-  it("should allow for multiple of the same listener types", async () => {
+  test("should allow for multiple of the same listener types", async () => {
     // ARRANGE
     vi.useFakeTimers();
     const listener = vi.fn();
@@ -66,7 +66,7 @@ describe("useGlobalEventListener", () => {
     expect(listener2).toHaveBeenCalledTimes(2);
   });
 
-  it("should not listen to events when disabled", async () => {
+  test("should not listen to events when disabled", async () => {
     // ARRANGE
     vi.useFakeTimers();
     const disabled = ref(false);

--- a/packages/headless/src/composables/helpers/useOutsideClick.spec.ts
+++ b/packages/headless/src/composables/helpers/useOutsideClick.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ref } from "vue";
 import { mockVueLifecycle } from "../../utils/vitest.js";
 import { useOutsideClick } from "./useOutsideClick.js";
@@ -9,11 +9,11 @@ describe("useOutsideClick", () => {
     mockVueLifecycle();
   });
 
-  it("should be defined", () => {
+  test("should be defined", () => {
     expect(useOutsideClick).toBeDefined();
   });
 
-  it("should detect outside clicks", async () => {
+  test("should detect outside clicks", async () => {
     // ARRANGE
     vi.useFakeTimers();
     const inside = ref(document.createElement("button"));
@@ -43,7 +43,7 @@ describe("useOutsideClick", () => {
     ).toHaveBeenCalledTimes(1);
   });
 
-  it("should detect outside clicks correctly for multiple inside elements", () => {
+  test("should detect outside clicks correctly for multiple inside elements", () => {
     // ARRANGE
     const inside = [document.createElement("button"), document.createElement("button")];
     inside.forEach((e) => document.body.appendChild(e));
@@ -66,7 +66,7 @@ describe("useOutsideClick", () => {
     expect(onOutsideClick).toBeCalledWith(event);
   });
 
-  it("should ignore outside clicks when disabled", async () => {
+  test("should ignore outside clicks when disabled", async () => {
     // ARRANGE
     vi.useFakeTimers();
     const inside = ref(document.createElement("button"));
@@ -94,7 +94,7 @@ describe("useOutsideClick", () => {
     expect(onOutsideClick).toHaveBeenCalledTimes(1);
   });
 
-  it("should detect outside tab via keyboard", async () => {
+  test("should detect outside tab via keyboard", async () => {
     // ARRANGE
     vi.useFakeTimers();
     const inside = ref(document.createElement("button"));

--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.spec.ts
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.core.spec.ts
@@ -1,4 +1,4 @@
-import { expect, it, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 import { reactive } from "vue";
 import {
   FORM_INJECTED_SYMBOL,
@@ -19,7 +19,7 @@ vi.mock("vue", async (importOriginal) => {
   };
 });
 
-it.for([
+test.for([
   {
     formProps: { disabled: true, showError: true, requiredMarker: "optional" },
     localProps: { disabled: true, showError: true, requiredMarker: "optional" },
@@ -77,7 +77,7 @@ it.for([
     expected: { disabled: false, showError: false, requiredMarker: "required" },
   },
 ] as const)(
-  "it should derive expected state when correctly",
+  "should derive expected state when correctly",
   ({ formProps, localProps, expected }) => {
     provideFormContext(formProps);
     const result = useFormContext(localProps);
@@ -92,7 +92,7 @@ it.for([
   },
 );
 
-it("should update when changed", async () => {
+test("should update when changed", async () => {
   const formProps = reactive({ disabled: false, showError: true });
   provideFormContext(formProps);
 

--- a/packages/sit-onyx/src/composables/useAnchorPositionPolyfill.spec.ts
+++ b/packages/sit-onyx/src/composables/useAnchorPositionPolyfill.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import { ref } from "vue";
 import { useAnchorPositionPolyfill, type AnchorPosition } from "./useAnchorPositionPolyfill.js";
 import type { OpenAlignment } from "./useOpenAlignment.js";
@@ -26,7 +26,7 @@ describe("useAnchorPositionPolyfill", () => {
     };
   });
 
-  it("should initialize positions to -1000px", () => {
+  test("should initialize positions to -1000px", () => {
     const { leftPosition, topPosition } = useAnchorPositionPolyfill({
       positionedRef,
       targetRef,
@@ -40,7 +40,7 @@ describe("useAnchorPositionPolyfill", () => {
     expect(topPosition.value).toBe("-1000px");
   });
 
-  it("should update positions correctly", () => {
+  test("should update positions correctly", () => {
     const { leftPosition, topPosition, updateAnchorPositionPolyfill } = useAnchorPositionPolyfill({
       positionedRef,
       targetRef,

--- a/packages/sit-onyx/src/composables/useSkeletonState.spec.ts
+++ b/packages/sit-onyx/src/composables/useSkeletonState.spec.ts
@@ -1,4 +1,4 @@
-import { expect, it, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 import { reactive, toValue } from "vue";
 import {
   SKELETON_INJECTED_SYMBOL,
@@ -18,7 +18,7 @@ vi.mock("vue", async (importOriginal) => {
   };
 });
 
-it.for([
+test.for([
   {
     pageLayoutProps: { skeleton: true },
     localProps: { skeleton: true },
@@ -65,7 +65,7 @@ it.for([
     expected: false,
   },
 ] as const)(
-  "it should derive expected state when correctly",
+  "should derive expected state when correctly",
   ({ pageLayoutProps, localProps, expected }) => {
     provideSkeletonContext(pageLayoutProps);
     const result = useSkeletonContext(localProps);
@@ -80,7 +80,7 @@ it.for([
   },
 );
 
-it("should update when changed", async () => {
+test("should update when changed", async () => {
   const pageLayoutProps = reactive({ skeleton: false });
   provideSkeletonContext(pageLayoutProps);
 

--- a/packages/sit-onyx/src/utils/feature.spec.ts
+++ b/packages/sit-onyx/src/utils/feature.spec.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { applyMapping, prepareMapping, type SingleOrderableMapping } from "./feature.js";
 
 describe("prepareMapping", () => {
   const func = <T>(a: T) => a;
 
-  it.each([
+  test.each([
     {
       title: "should work for no features",
       features: [],
@@ -104,13 +104,13 @@ describe("prepareMapping", () => {
 });
 
 describe("applyMapping", () => {
-  it("should work for no mapping", () => {
+  test("should work for no mapping", () => {
     const input = {};
     const mappings = [] as SingleOrderableMapping<unknown, unknown, unknown>[];
     expect(applyMapping(mappings, input)).toBe(input);
   });
 
-  it("should work for a single mapping", () => {
+  test("should work for a single mapping", () => {
     const input = {};
     const func = vi.fn((a) => a);
     const mappings = [{ func }];
@@ -118,7 +118,7 @@ describe("applyMapping", () => {
     expect(func).toBeCalledTimes(1);
   });
 
-  it("should work for a multiple mappings", () => {
+  test("should work for a multiple mappings", () => {
     const input = {};
     const func = vi.fn((a) => a);
     const mappings = [{ func }, { func }];

--- a/packages/sit-onyx/src/utils/file.spec.ts
+++ b/packages/sit-onyx/src/utils/file.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import type { FileType } from "../components/OnyxFileUpload/types.js";
 import { validateFileType } from "./file.js";
 
@@ -6,7 +6,7 @@ const jpegFile = { name: "example.jpg", type: "image/jpeg" };
 
 describe("validateFileType", () => {
   describe("valid cases", () => {
-    it.each([
+    test.each([
       {
         title: "should be valid for no accept list",
         accept: undefined,
@@ -52,7 +52,7 @@ describe("validateFileType", () => {
   });
 
   describe("invalid cases", () => {
-    it.each([
+    test.each([
       {
         title: "should be invalid for non-matching media type",
         accept: ["image/png"],

--- a/packages/sit-onyx/src/utils/numbers.spec.ts
+++ b/packages/sit-onyx/src/utils/numbers.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import {
   applyLimits,
   convertBinaryPrefixToBytes,
@@ -9,61 +9,61 @@ import {
 
 // Tests for applyLimits function
 describe("applyLimits", () => {
-  it("returns the number if within the limits", () => {
+  test("returns the number if within the limits", () => {
     expect(applyLimits(5, 0, 10)).toBe(5);
     expect(applyLimits(-3, -5, 5)).toBe(-3);
   });
 
-  it("returns the minimum limit if number is below min", () => {
+  test("returns the minimum limit if number is below min", () => {
     expect(applyLimits(-10, 0, 10)).toBe(0);
     expect(applyLimits(1, 5, 10)).toBe(5);
   });
 
-  it("returns the maximum limit if number is above max", () => {
+  test("returns the maximum limit if number is above max", () => {
     expect(applyLimits(20, 0, 10)).toBe(10);
     expect(applyLimits(15, 0, 10)).toBe(10);
   });
 
-  it("returns the number if no min or max is provided", () => {
+  test("returns the number if no min or max is provided", () => {
     expect(applyLimits(20, undefined, undefined)).toBe(20);
   });
 
-  it("returns the number constrained only by max if min is undefined", () => {
+  test("returns the number constrained only by max if min is undefined", () => {
     expect(applyLimits(20, undefined, 15)).toBe(15);
   });
 
-  it("returns the number constrained only by min if max is undefined", () => {
+  test("returns the number constrained only by min if max is undefined", () => {
     expect(applyLimits(5, 10, undefined)).toBe(10);
   });
 });
 
 // Tests for roundToPrecision function
 describe("roundToPrecision", () => {
-  it("rounds to specified decimal places when precision is positive", () => {
+  test("rounds to specified decimal places when precision is positive", () => {
     expect(roundToPrecision(5.6789, 2)).toBe("5.68");
     expect(roundToPrecision(1.2344, 3)).toBe("1.234");
   });
 
-  it("rounds to specified whole number places when precision is negative", () => {
+  test("rounds to specified whole number places when precision is negative", () => {
     expect(roundToPrecision(1234, -1)).toBe("1230");
     expect(roundToPrecision(56789, -2)).toBe("56800");
   });
 
-  it("returns the number as a string without rounding if precision is zero", () => {
+  test("returns the number as a string without rounding if precision is zero", () => {
     expect(roundToPrecision(1234, 0)).toBe("1234");
   });
 
-  it("returns empty string if value is undefined", () => {
+  test("returns empty string if value is undefined", () => {
     expect(roundToPrecision(undefined, 2)).toBe("");
   });
 
-  it("rounds zero value when precision is set", () => {
+  test("rounds zero value when precision is set", () => {
     expect(roundToPrecision(0, 2)).toBe("0.00");
   });
 });
 
 describe("convertBinaryPrefixToBytes", () => {
-  it.each<{ value: BinaryPrefixedSize; expected: number }>([
+  test.each<{ value: BinaryPrefixedSize; expected: number }>([
     { value: "4.25KiB", expected: 4.25 * 1024 ** 1 },
     { value: "4.25MiB", expected: 4.25 * 1024 ** 2 },
     { value: "4.25GiB", expected: 4.25 * 1024 ** 3 },
@@ -81,7 +81,7 @@ describe("convertBinaryPrefixToBytes", () => {
 });
 
 describe("formatBytesToString", () => {
-  it.each<{ value: number; expected: string }>([
+  test.each<{ value: number; expected: string }>([
     { value: 0, expected: "0B" },
     { value: 1, expected: "1B" },
     { value: 1024, expected: "1kB" },


### PR DESCRIPTION
We currently have two [eslint findings](https://github.com/SchwarzIT/onyx/security/code-scanning) for some test files.
They are fixed in this PR and I also enabled a eslint rule to force consistent usage of Vitest "test" function instead of mixing "test" and "it". We are mostly already using "test" but there a a few files that used it.
