### PR TITLE
feat(OnyxDataGrid): introduce `columnWidths` option for the `useResizing` feature

### DIFF
--- a/.changeset/tangy-crabs-lie.md
+++ b/.changeset/tangy-crabs-lie.md
@@ -2,4 +2,4 @@
 "sit-onyx": minor
 ---
 
-feat(OnyxDataGrid): introduce controllable `columnWidths` option for the `useResizing` feature
+feat(OnyxDataGrid): introduce controllable `resizeState` option for the `useResizing` feature

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/resizing/TestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/resizing/TestCase.ct.vue
@@ -1,40 +1,35 @@
 <script setup lang="ts">
-import { computed, ref, toRefs, unref, watchEffect } from "vue";
+import { ref, watch, watchEffect } from "vue";
 import type { DataGridEntry, OnyxDataGridProps } from "../../../../index.js";
 import { DataGridFeatures, OnyxDataGrid } from "../../../../index.js";
-import type { ResizingOptions } from "./types.js";
+import type { ResizeState } from "./types.js";
 
 const props = defineProps<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
   Pick<OnyxDataGridProps<any, any, any, any, any, any>, "columns" | "data"> & {
-    resizingOptions?: ResizingOptions<DataGridEntry>;
-    controlledColumnWidths?: boolean;
+    resizeState?: Record<keyof DataGridEntry, string>;
   }
 >();
 
-const {
-  columns,
-  data,
-  resizingOptions: resizingOptionsProp,
-  controlledColumnWidths,
-} = toRefs(props);
+const emit = defineEmits<{
+  "update:resizeState": [state: Record<keyof DataGridEntry, string>];
+}>();
 
-const columnWidths = ref<Partial<Record<keyof DataGridEntry, string>>>({});
-
+const state = ref<ResizeState<DataGridEntry>>(new Map());
 watchEffect(() => {
-  if (resizingOptionsProp.value?.columnWidths) {
-    const widths = unref(resizingOptionsProp.value.columnWidths);
-    columnWidths.value = { ...widths };
-  }
+  if (props.resizeState) state.value = new Map(Object.entries(props.resizeState));
 });
 
-const finalResizingOptions = computed<ResizingOptions<DataGridEntry>>(() => ({
-  ...resizingOptionsProp.value,
-  columnWidths: controlledColumnWidths.value ? columnWidths.value : undefined,
-}));
+watch(
+  state,
+  (newState) => {
+    emit("update:resizeState", Object.fromEntries(newState.entries()));
+  },
+  { deep: true },
+);
 
-const withResizing = computed(() => DataGridFeatures.useResizing(finalResizingOptions.value));
-const features = computed(() => [withResizing.value]);
+const withResizing = DataGridFeatures.useResizing({ resizeState: state });
+const features = [withResizing];
 </script>
 
 <template>

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/resizing/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/resizing/types.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from "vue";
+import type { Ref } from "vue";
 import type { DataGridEntry } from "../../types.js";
 import { type DataGridFeatureOptions } from "../index.js";
 
@@ -11,8 +11,14 @@ export type ResizingOptions<TEntry extends DataGridEntry> = DataGridFeatureOptio
   object
 > & {
   /**
-   * Controllable column widths.
-   * If provided, the resizing feature will use these widths as the source of truth.
+   * The current column resizing state.
+   * Can be used to e.g. save the user resized columns and restore them on page load.
    */
-  columnWidths?: MaybeRef<Partial<Record<keyof TEntry, string>>>;
+  resizeState?: Ref<ResizeState<TEntry>>;
 };
+
+/**
+ * Defines the current column resizing state.
+ * Key = Column key, value = resized width.
+ */
+export type ResizeState<TEntry> = Map<keyof TEntry, string>;


### PR DESCRIPTION
closes #4143

Introduce controllable `resizeState` option for the `useResizing` feature

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) or functional test is added
- [x] A changeset is added with `npx changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
