### PR TITLE
chore: bump insecure node-forge version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
       "@vue/compiler-ssr": "catalog:",
       "@vue/shared": "catalog:",
       "nuxt": "catalog:",
+      "node-forge": "1.3.3",
       "playwright": "catalog:",
       "playwright-core": "catalog:",
       "vite": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   '@vue/compiler-ssr': 3.5.25
   '@vue/shared': 3.5.25
   nuxt: 4.2.1
+  node-forge: 1.3.3
   playwright: 1.57.0
   playwright-core: 1.57.0
   vite: 7.2.6
@@ -5913,8 +5914,8 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  node-forge@1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+  node-forge@1.3.3:
+    resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
     engines: {node: '>= 6.13.0'}
 
   node-gyp-build@4.8.4:
@@ -13610,7 +13611,7 @@ snapshots:
       http-shutdown: 1.2.2
       jiti: 2.6.1
       mlly: 1.8.0
-      node-forge: 1.3.1
+      node-forge: 1.3.3
       pathe: 1.1.2
       std-env: 3.10.0
       ufo: 1.6.1
@@ -14322,7 +14323,7 @@ snapshots:
       formdata-polyfill: 4.0.10
     optional: true
 
-  node-forge@1.3.1: {}
+  node-forge@1.3.3: {}
 
   node-gyp-build@4.8.4: {}
 


### PR DESCRIPTION
The currently by `nuxt` and other packages used patch version of `node-forge` has a security issue, we override the patch version to resolve this.