### PR TITLE
chore: bump pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onyx-monorepo",
   "type": "module",
-  "packageManager": "pnpm@10.26.2",
+  "packageManager": "pnpm@10.27.0",
   "author": "Schwarz IT KG",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Bump `pnpm` to the secure `10.27.0` version (see https://github.com/pnpm/pnpm/security).