### PR TITLE
chore: fix eslint warnings

### DIFF
--- a/packages/sit-onyx/src/components/OnyxBasicPopover/OnyxBasicPopover.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxBasicPopover/OnyxBasicPopover.ct.tsx
@@ -71,6 +71,7 @@ test.describe("OnyxBasicPopover", () => {
     expect(box.y + box.height).toBeLessThanOrEqual(viewportHeight);
   });
 });
+
 test.describe("OnyxBasicPopover  Screenshot Tests", () => {
   test.describe("Alignment screenshot tests", () => {
     executeMatrixScreenshotTest({

--- a/packages/sit-onyx/src/components/OnyxBreadcrumb/OnyxBreadcrumb.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxBreadcrumb/OnyxBreadcrumb.ct.tsx
@@ -73,6 +73,7 @@ test("should be aligned with the grid when in container mode", async ({ page, mo
 
   await expect(page).toHaveScreenshot("grid-max-width.png");
 });
+
 test("should show more button, when there is not enough space", async ({ page, mount }) => {
   // ARRANGE
   await page.addStyleTag({

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/filtering/filtering.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/filtering/filtering.ct.tsx
@@ -17,6 +17,7 @@ const getTestData = () => [
 const expectRowCount = (dataGrid: Locator, count: number) => {
   return expect(dataGrid.getByRole("row")).toHaveCount(count + 1);
 };
+
 test("should filter by single column", async ({ mount }) => {
   // ARRANGE
   const data = getTestData();

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/selection/selection.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/selection/selection.ct.tsx
@@ -59,6 +59,7 @@ test("useSelection", async ({ page, mount }) => {
     expect(selectionEvents.at(-1)?.selectMode).toBe("include");
     expect(selectionEvents.at(-1)?.contingent).toMatchObject([]);
   });
+
   await test.step("select all manually", async () => {
     const selectAllCheckbox = page.getByRole("checkbox", { name: "Select all rows" });
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/stickyColumns.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/stickyColumns.ct.tsx
@@ -49,6 +49,7 @@ test("sticky Column should stay in View", async ({ page, mount }) => {
 
   await expect(component).toHaveScreenshot("data-grid-one-sticky-column.png");
 });
+
 const positions = ["left", "right"] as const;
 
 positions.forEach((position) => {
@@ -77,6 +78,7 @@ positions.forEach((position) => {
     await expect(component).toHaveScreenshot(`data-grid-sticky-columns-${position}.png`);
   });
 });
+
 test("multiple stickyColumns", async ({ page, mount }) => {
   await page.setViewportSize({ width: 400, height: 1000 });
   const data = getTestData();

--- a/packages/sit-onyx/src/components/OnyxInput/OnyxInput.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxInput/OnyxInput.ct.tsx
@@ -456,6 +456,7 @@ test("should hide/show password", async ({ mount }) => {
   await expect(eyeClosedIcon).toBeVisible();
   await expect(component).toHaveScreenshot(`input-password-shown.png`);
 });
+
 testMaxLengthBehavior(OnyxInput);
 
 test.describe("Screenshot test (slots dark mode)", () => {

--- a/packages/sit-onyx/src/components/OnyxLink/OnyxLink.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxLink/OnyxLink.ct.tsx
@@ -4,6 +4,7 @@ import OnyxLink from "./OnyxLink.vue";
 
 // we do not want to actually make requests to live external applications so we mock them here
 const EXTERNAL_HREF = "https://example.com";
+
 test.beforeEach(async ({ page }) => {
   await page.route(EXTERNAL_HREF, (route) => route.fulfill({ body: "Test page" }));
 });

--- a/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxPageLayout/OnyxPageLayout.ct.tsx
@@ -300,6 +300,7 @@ test("should not have inline margin for onyx grid container when sidebar exists"
   expect(pageMarginInline).toBe("0px");
   expect(footerMarginInline).toBe("0px");
 });
+
 test("should have inline margin for onyx grid container when sidebar is temporary", async ({
   page,
   mount,

--- a/packages/sit-onyx/src/components/OnyxRouterLink/OnyxRouterLink.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxRouterLink/OnyxRouterLink.ct.tsx
@@ -3,6 +3,7 @@ import TestWrapper from "./TestWrapper.ct.vue";
 
 // we do not want to actually make requests to live external applications so we mock them here
 const EXTERNAL_HREF = "https://example.com";
+
 test.beforeEach(async ({ page }) => {
   await page.route(EXTERNAL_HREF, (route) => route.fulfill({ body: "Test page" }));
 });

--- a/packages/sit-onyx/src/components/OnyxSidebar/OnyxSidebar.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxSidebar/OnyxSidebar.ct.tsx
@@ -220,6 +220,7 @@ test("should render fab on small screens (left Sidebar)", async ({ mount, page }
   // ASSERT
   await expect(leftSidebar).toBeVisible();
 });
+
 test("should render fab on small screens (right Sidebar)", async ({ mount, page }) => {
   // ARRANGE
   await page.setViewportSize({ height: ONYX_BREAKPOINTS.sm, width: 320 });
@@ -237,6 +238,7 @@ test("should render fab on small screens (right Sidebar)", async ({ mount, page 
   // ASSERT
   await expect(sidebar).toBeVisible();
 });
+
 test("should render fab on small screens (left & right Sidebar)", async ({ mount, page }) => {
   // ARRANGE
   await page.setViewportSize({ height: ONYX_BREAKPOINTS.sm, width: 320 });

--- a/packages/sit-onyx/src/components/OnyxTag/OnyxTag.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxTag/OnyxTag.ct.tsx
@@ -67,6 +67,7 @@ test("should truncate text", async ({ mount }) => {
   // ASSERT
   await expect(component).toHaveScreenshot("truncation.png");
 });
+
 test("should render non-interactive tag without event", async ({ mount }) => {
   const component = await mount(<OnyxTag label="Tag" />);
   await expect(component).not.toContainClass("onyx-tag--interactive");

--- a/packages/sit-onyx/src/components/OnyxTimepicker/OnyxTimepicker.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxTimepicker/OnyxTimepicker.ct.tsx
@@ -2,6 +2,7 @@ import { DENSITIES } from "../../composables/density.js";
 import { expect, test } from "../../playwright/a11y.js";
 import { executeMatrixScreenshotTest } from "../../playwright/screenshots.js";
 import OnyxTimepicker from "./OnyxTimepicker.vue";
+
 test.describe("Screenshot tests", () => {
   executeMatrixScreenshotTest({
     name: `TimePicker`,

--- a/packages/sit-onyx/src/styles/grid.ct.tsx
+++ b/packages/sit-onyx/src/styles/grid.ct.tsx
@@ -259,6 +259,7 @@ Object.entries(ONYX_MAX_WIDTHS).forEach(([breakpoint, size]) => {
 
 Object.entries(ONYX_MAX_WIDTHS).forEach(([breakpoint, size]) => {
   const className = `onyx-grid-max-${breakpoint}`;
+
   test(`page content with max width and centering should be positioned correctly for ${className}`, async ({
     mount,
     page,


### PR DESCRIPTION
Run `pnpm lint:fix:all` to fix [current eslint warnings](https://github.com/SchwarzIT/onyx/security/code-scanning) (probably introduced by an dependency update)