### PR TITLE
chore: Try to fix unwanted dependabot `github-actions` version bump by using exact hash of latest tagged version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,7 +57,7 @@ jobs:
         continue-on-error: true
 
       - name: ⬆️ Upload eslint results to GitHub
-        uses: github/codeql-action/upload-sarif@cfa77c6b134886357b1c716fbe58a7708833bf31 # v4.31.10
+        uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true
@@ -115,12 +115,12 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@cfa77c6b134886357b1c716fbe58a7708833bf31 # v4.31.10
+        uses: github/codeql-action/init@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@cfa77c6b134886357b1c716fbe58a7708833bf31 # v4.31.10
+        uses: github/codeql-action/analyze@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
         with:
           category: "/tool:CodeQL"
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@cfa77c6b134886357b1c716fbe58a7708833bf31 # v4.31.10
+        uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
         with:
           sarif_file: results.sarif
           category: "/tool:ossf-scorecard"


### PR DESCRIPTION
The comment in https://github.com/dependabot/dependabot-core/issues/13466#issuecomment-3551969625 prompted me to check if we use the correct hash for the specified tag. Apparently not, so hopefully this fixes the issue.