### PR TITLE
fix(demo-app): correctly display trailing input select in compact density

### DIFF
--- a/apps/demo-app/app/pages/forms/index.vue
+++ b/apps/demo-app/app/pages/forms/index.vue
@@ -240,6 +240,7 @@ const handleDelete = () => {
 
     :deep(.onyx-select-input__wrapper) {
       border: none;
+      background-color: transparent;
 
       .onyx-select-input__native {
         width: 6ch;


### PR DESCRIPTION
Relates to #4230

Fix display of OnyxSelect shown inside the leading slot of the OnyxInput in our demo app by removing the background color from the select which overlapped/covered the input border

## Checklist

- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
