### PR TITLE
fix(demo-app): correctly apply density to whole app

### DIFF
--- a/apps/demo-app/app/app.vue
+++ b/apps/demo-app/app/app.vue
@@ -2,8 +2,16 @@
 import App from "#layers/blueprint/app/app.vue";
 
 const settingsStore = useSettingsStore();
+
+// we need to apply the CSS class to the `<html>` element so the density is correctly defined for all components
+// otherwise (if we would e.g. just bind it to the app below), global styles (e.g. the vertical grid margin etc. would not consider the corresponding density)
+useHead({
+  htmlAttrs: {
+    class: computed(() => `onyx-density-${settingsStore.settings.density}`),
+  },
+});
 </script>
 
 <template>
-  <App :class="`onyx-density-${settingsStore.settings.density}`" />
+  <App />
 </template>


### PR DESCRIPTION
Relates to #4663

Correctly apply demo app density to `<html>` element so it also affects global styles

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
