### PR TITLE
chore: fix dependabot pipeline by adding exception to trust-policy issues

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,9 @@ catalog:
 
 # Security settings (See: https://pnpm.io/supply-chain-security)
 trustPolicy: "no-downgrade"
+trustPolicyExclude:
+  - "chokidar@4.0.3" # See https://github.com/paulmillr/chokidar/issues/1440
+  - "semver@6.3.1" # See https://github.com/npm/node-semver/issues/838
 minimumReleaseAge: 2880 # Wait two days after a new version release - This is in sync with the `dependabot.yml` `cooldown` config
 blockExoticSubdeps: true
 allowBuilds:


### PR DESCRIPTION
This fixes the currently failing dependabot pipeline runs, e.g. [Run 21573624381](https://github.com/SchwarzIT/onyx/actions/runs/21573624381/job/62156869056).

These seems to be caused by trust issue with older release (pipelines):
  - "chokidar@4.0.3" # See https://github.com/paulmillr/chokidar/issues/1440
  - "semver@6.3.1" # See https://github.com/npm/node-semver/issues/838

We now explicitly define [`trustPolicyExclude`](https://pnpm.io/settings#trustpolicyexclude) for these package versions.
If this happens more often we can consider to use [`trustPolicyIgnoreAfter`](https://pnpm.io/settings#trustpolicyignoreafter).