### PR TITLE
fix(dependabot-dedupe.yml): add necessary checkout step

### DIFF
--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: "🛒 Checkout Repository"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - uses: ./.github/templates/node-setup
         with:
           pnpm_install_command: "pnpm install --frozen-lockfile --ignore-scripts"


### PR DESCRIPTION
Should fix the `Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '...'. Did you forget to run actions/checkout before running your local action?` (e.g. https://github.com/SchwarzIT/onyx/actions/runs/21734845838/job/62724508074?pr=4789#step:4:1)