### PR TITLE
docs: prevent toasts from hiding when hovering

### DIFF
--- a/packages/sit-onyx/src/components/OnyxForm/OnyxForm.stories.ts
+++ b/packages/sit-onyx/src/components/OnyxForm/OnyxForm.stories.ts
@@ -1,10 +1,8 @@
 import { withNativeEventLogging } from "@sit-onyx/storybook-utils";
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
-import { h } from "vue";
 import { ShowErrorModes } from "../../composables/useErrorClass.js";
 import { createAdvancedStoryExample } from "../../utils/storybook.js";
-import OnyxButton from "../OnyxButton/OnyxButton.vue";
-import OnyxInput from "../OnyxInput/OnyxInput.vue";
+import OnyxToast from "../OnyxToast/OnyxToast.vue";
 import OnyxForm from "./OnyxForm.vue";
 
 /**
@@ -22,30 +20,26 @@ const meta: Meta<typeof OnyxForm> = {
     default: { control: { disable: true } },
     ["$slots" as string]: { table: { disable: true } },
   },
+  decorators: [
+    // provide the OnyxToast so toasts are shown correctly in the examples
+    (story) => ({
+      components: { story, OnyxToast },
+      template: `<story /> <OnyxToast />`,
+    }),
+  ],
 };
 
 export default meta;
 type Story = StoryObj<typeof OnyxForm>;
 
-/**
- * This example shows an OnyxForm with some inputs.
- * Play around with the properties of the OnyxForm to see their effect.
- */
-export const Default = {
-  args: {
-    class: "form",
-    style:
-      "display: flex; flex-direction: column; max-width: 20rem; gap: var(--onyx-grid-gutter); ",
-    onSubmit: (e: SubmitEvent) => e.preventDefault(),
-    default: () => [
-      h(OnyxInput, { label: "Favorite band", pattern: "/[A-Za-z ]+/" }),
-      h(OnyxInput, { label: "Favorite password", type: "password", required: true }),
-      h(OnyxInput, { label: "Number of hairs", min: 0 }),
-      h(OnyxButton, { label: "Submit", type: "submit" }),
-    ],
-  },
-} satisfies Story;
+export const Default = createAdvancedStoryExample("OnyxForm", "DefaultExample") satisfies Story;
 
-export const AdvancedExample = createAdvancedStoryExample("OnyxForm", "AdvancedExample");
+export const AdvancedExample = createAdvancedStoryExample(
+  "OnyxForm",
+  "AdvancedExample",
+) satisfies Story;
 
-export const FileUploadExample = createAdvancedStoryExample("OnyxForm", "FileUploadExample");
+export const FileUploadExample = createAdvancedStoryExample(
+  "OnyxForm",
+  "FileUploadExample",
+) satisfies Story;

--- a/packages/sit-onyx/src/components/OnyxForm/examples/DefaultExample.vue
+++ b/packages/sit-onyx/src/components/OnyxForm/examples/DefaultExample.vue
@@ -1,0 +1,32 @@
+<script lang="ts" setup>
+import { OnyxButton, OnyxForm, OnyxInput, useToast } from "../../../index.js";
+
+const toast = useToast();
+
+const handleSubmit = () => {
+  // your submit logic here
+  // this function is only called when all validations passed so you can be sure that e.g. required fields are filled etc.
+  toast.show({
+    headline: "Form submitted",
+    color: "success",
+  });
+};
+</script>
+
+<template>
+  <OnyxForm class="form" @submit.prevent="handleSubmit">
+    <OnyxInput label="Favorite band" pattern="/[A-Za-z ]+/" />
+    <OnyxInput label="Favorite password" required type="password" />
+    <OnyxInput label="Number of hairs" :min="0" />
+    <OnyxButton label="Submit" type="submit" />
+  </OnyxForm>
+</template>
+
+<style lang="scss" scoped>
+.form {
+  display: flex;
+  flex-direction: column;
+  max-width: 20rem; // only for this example
+  gap: var(--onyx-grid-gutter);
+}
+</style>

--- a/packages/sit-onyx/src/utils/storybook.ts
+++ b/packages/sit-onyx/src/utils/storybook.ts
@@ -1,6 +1,5 @@
 import type { ArgTypes, Decorator, StoryObj } from "@storybook/vue3-vite";
 import type { DefineComponent } from "vue";
-import OnyxToast from "../components/OnyxToast/OnyxToast.vue";
 
 export type DefineIconSelectArgTypeOptions = {
   /**
@@ -68,7 +67,6 @@ export const textColorDecorator: Decorator = (story) => ({
  * The example must be put inside e.g. "src/components/{componentName}/examples/{exampleName}".
  *
  * Make sure to import all onyx components, types etc. from the index file "../../../" so its replaced correctly in the code snippet.
- * Will also make the OnyxToast available to be used inside the example.
  *
  * **Note** The "Controls" and "Actions" panel/tab will be disabled for this story since they will probably be mostly unusable due to the custom example.
  */
@@ -99,9 +97,9 @@ export function createAdvancedStoryExample(componentName: string, exampleName: s
 
   return {
     render: (args) => ({
-      components: { Component, OnyxToast },
+      components: { Component },
       setup: () => ({ args }),
-      template: `<OnyxToast /> <Component />`,
+      template: `<Component /> `,
     }),
     parameters: {
       docs: {


### PR DESCRIPTION
closes #4884

Prevent OnyxToast example in Storybook from hiding all toasts even if one is hovered (which stops the timer).
The issue was that we have always added the OnyxToast component for all examples although not needed. Since the OnyxToast example also included the OnyxToast component, it existed twice (perfectly positioned above each other). So hovering one toast still caused the second one to still trigger the close event.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
