### PR TITLE
perf: skip type generation for Storybook build

### DIFF
--- a/packages/sit-onyx/vite.config.ts
+++ b/packages/sit-onyx/vite.config.ts
@@ -13,20 +13,22 @@ export default defineConfig({
   ...VITE_BASE_CONFIG,
   mode: "development",
   plugins: [
-    dts({
-      tsconfigPath: "./tsconfig.app.json",
-      compilerOptions: { composite: false },
-      beforeWriteFile: (filePath) => {
-        if (filePath.endsWith(".vue.d.ts")) {
-          return { filePath: filePath.replace(".vue.d.ts", ".d.vue.ts") };
-        }
-      },
-      afterDiagnostic: async (diagnostics) => {
-        if (diagnostics.some((d) => d.category === DiagnosticCategory.Error)) {
-          throw new Error("Build aborted due to TypeScript errors in the library!");
-        }
-      },
-    }),
+    process.env.STORYBOOK === "true"
+      ? undefined
+      : dts({
+          tsconfigPath: "./tsconfig.app.json",
+          compilerOptions: { composite: false },
+          beforeWriteFile: (filePath) => {
+            if (filePath.endsWith(".vue.d.ts")) {
+              return { filePath: filePath.replace(".vue.d.ts", ".d.vue.ts") };
+            }
+          },
+          afterDiagnostic: async (diagnostics) => {
+            if (diagnostics.some((d) => d.category === DiagnosticCategory.Error)) {
+              throw new Error("Build aborted due to TypeScript errors in the library!");
+            }
+          },
+        }),
     vue(vuePluginOptions),
   ],
   build: {


### PR DESCRIPTION
Skip generating typescript declarations when building Storybook which is not needed (because its a deployable, not a library). It speeds up the build time for me locally by 5 seconds (33%).

<img width="807" height="75" alt="image" src="https://github.com/user-attachments/assets/2edf5302-313d-4b53-b7f4-9fbe2e01ef21" />