### PR TITLE
fix(OnyxTextEditor): consider errors in native HTML form validation

### DIFF
--- a/.changeset/petite-planes-sell.md
+++ b/.changeset/petite-planes-sell.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/tiptap": patch
+---
+
+fix(OnyxTextEditor): consider errors in native HTML form validation

--- a/apps/docs/src/index.data.ts
+++ b/apps/docs/src/index.data.ts
@@ -294,6 +294,11 @@ export default defineLoader({
         status: "implemented",
         href: "https://storybook.onyx.schwarz/?path=/docs/documentation-codetabs--docs",
       },
+      {
+        name: "Text editor",
+        status: "implemented",
+        href: "https://storybook.onyx.schwarz/?path=/docs/form-elements-texteditor--docs",
+      },
     ];
 
     return {

--- a/packages/tiptap/src/components/OnyxTextEditor/FormTestCase.ct.vue
+++ b/packages/tiptap/src/components/OnyxTextEditor/FormTestCase.ct.vue
@@ -1,0 +1,20 @@
+<script lang="ts" setup>
+import { FORM_INJECTED_SYMBOL } from "sit-onyx";
+import OnyxTextEditor from "./OnyxTextEditor.vue";
+import type { OnyxTextEditorProps } from "./types.js";
+
+const props = withDefaults(defineProps<OnyxTextEditorProps>(), {
+  showError: FORM_INJECTED_SYMBOL,
+});
+
+const emit = defineEmits<{
+  submit: [];
+}>();
+</script>
+
+<template>
+  <form @submit.prevent="emit('submit')">
+    <OnyxTextEditor v-bind="props" />
+    <button type="submit">Submit</button>
+  </form>
+</template>

--- a/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.ct.tsx
+++ b/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.ct.tsx
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { DENSITIES } from "sit-onyx";
 import { expect, test } from "../../playwright/a11y.js";
 import { executeMatrixScreenshotTest } from "../../playwright/screenshots.js";
+import FormTestCase from "./FormTestCase.ct.vue";
 import OnyxTextEditor from "./OnyxTextEditor.vue";
 import TestCase from "./TestCase.ct.vue";
 
@@ -779,6 +780,32 @@ test("should show error", async ({ mount }) => {
   // ASSERT
   await expect(error, "should show custom error").toBeVisible();
   await expect(error).toContainText("Custom error");
+});
+
+test("should include editor in native HTML form validation", async ({ mount }) => {
+  // ARRANGE
+  let submitEventCount = 0;
+
+  const component = await mount(
+    <FormTestCase label="Test label" required onSubmit={() => submitEventCount++} />,
+  );
+
+  const editor = component.getByLabel("Test label");
+
+  // ACT
+  await editor.fill("Filled value");
+  await editor.clear();
+
+  await component.getByRole("button", { name: "Submit" }).click();
+
+  // ASSERT
+  const isFormValid = await component.evaluate((form: HTMLFormElement) => form.checkValidity());
+  expect(isFormValid).toBe(false);
+  expect(submitEventCount).toBe(0);
+
+  const errorMessage = component.locator(".onyx-form-element-v2__message--danger");
+  await expect(errorMessage).toBeVisible();
+  await expect(errorMessage).toContainText("Required");
 });
 
 /**

--- a/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.vue
+++ b/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.vue
@@ -5,13 +5,14 @@ import {
   FORM_INJECTED_SYMBOL,
   injectI18n,
   OnyxUnstableFormElementV2,
+  OnyxVisuallyHidden,
   SKELETON_INJECTED_SYMBOL,
   useFormContext,
   useForwardProps,
   useVModel,
   type FormElementV2Tooltip,
 } from "sit-onyx";
-import { computed, provide, ref, useTemplateRef, watch, type StyleValue } from "vue";
+import { computed, provide, ref, useTemplateRef, watch, watchEffect, type StyleValue } from "vue";
 import EditorToolbar from "./EditorToolbar.vue";
 import { OnyxStarterKit } from "./extensions/starterKit.js";
 import { TEXT_EDITOR_INJECTION_KEY, type OnyxTextEditorProps } from "./types.js";
@@ -183,6 +184,20 @@ const toolbarTeleportTarget = computed(() => {
   return el?.querySelector(".onyx-form-element-v2__content");
 });
 
+const nativeInput = useTemplateRef("nativeInput");
+watchEffect(() => {
+  if (!error.value) {
+    nativeInput.value?.setCustomValidity("");
+    return;
+  }
+
+  const errorMessage =
+    typeof error.value === "string"
+      ? error.value
+      : `${error.value.label} ${error.value.tooltipText ?? ""}`.trim();
+  nativeInput.value?.setCustomValidity(errorMessage);
+});
+
 defineExpose({
   /**
    * Tiptap editor instance.
@@ -209,6 +224,16 @@ defineExpose({
     </Teleport>
 
     <EditorContent class="onyx-text-editor__wrapper" :data-autosize-value="autosizeValue" :editor />
+
+    <!-- using a native input to include the editor into HTML form validation -->
+    <OnyxVisuallyHidden aria-hidden="true">
+      <input
+        ref="nativeInput"
+        tabindex="-1"
+        @invalid="isTouched = true"
+        @focus="editor?.commands.focus()"
+      />
+    </OnyxVisuallyHidden>
   </OnyxUnstableFormElementV2>
 </template>
 


### PR DESCRIPTION
Relates to #4915

Sine the Tiptap editor uses a contenteditable div internally, the OnyxTextEditor is currently NOT included in native HTML form validation. It just visually shows the error but the form submit was still successful.

This is fixed now by including a native visually hidden `<input />` internally where the error is synched to

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
