### PR TITLE
feat(OnyxTextEditor): support `minlength`, `maxlength` and `withCounter` properties

### DIFF
--- a/.changeset/sharp-tigers-joke.md
+++ b/.changeset/sharp-tigers-joke.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/tiptap": minor
+---
+
+feat(OnyxTextEditor): support `minlength`, `maxlength` and `withCounter` properties

--- a/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.ct.tsx
+++ b/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.ct.tsx
@@ -808,6 +808,52 @@ test("should include editor in native HTML form validation", async ({ mount }) =
   await expect(errorMessage).toContainText("Required");
 });
 
+test("should support min/max length", async ({ mount }) => {
+  // ARRANGE
+  const component = await mount(
+    <TestCase label="Test label" minlength={3} maxlength={6} withCounter />,
+  );
+  const editor = component.getByLabel("Test label");
+  const errorMessage = component.locator(".onyx-form-element-v2__message--danger");
+
+  // ASSERT
+  await expect(errorMessage).toBeHidden();
+
+  // ACT
+  await editor.fill("12");
+  await editor.blur();
+
+  // ASSERT
+  await expect(component).toContainText("2/6");
+  await expect(errorMessage).toBeVisible();
+  await expect(errorMessage).toContainText("Too short, minimum 3 characters required");
+
+  // ACT
+  await editor.fill("123");
+  await editor.blur();
+
+  // ASSERT
+  await expect(component).toContainText("3/6");
+  await expect(errorMessage).toBeHidden();
+
+  // ACT
+  await editor.fill("123456");
+  await editor.blur();
+
+  // ASSERT
+  await expect(component).toContainText("6/6");
+  await expect(errorMessage).toBeHidden();
+
+  // ACT
+  await editor.fill("1234567");
+  await editor.blur();
+
+  // ASSERT
+  await expect(component).toContainText("7/6");
+  await expect(errorMessage).toBeVisible();
+  await expect(errorMessage).toContainText("Too long, maximum 6 characters allowed");
+});
+
 /**
  * Expects that the given editor toolbar flyout option is selected.
  */

--- a/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.stories.ts
+++ b/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.stories.ts
@@ -57,6 +57,14 @@ export const Required = {
   },
 } satisfies Story;
 
+export const Maxlength = {
+  args: {
+    ...Default.args,
+    maxlength: 64,
+    withCounter: true,
+  },
+} satisfies Story;
+
 export const CustomError = {
   args: {
     ...Default.args,

--- a/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.vue
+++ b/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.vue
@@ -99,6 +99,16 @@ watch(
   { immediate: true },
 );
 
+const characterCount = computed(() => editor.value?.storage.characterCount.characters() ?? 0);
+
+const counter = computed(() => {
+  if (!props.withCounter || !props.maxlength) return;
+  const length = characterCount.value;
+  const maxlength = props.maxlength;
+  const violated = length > maxlength;
+  return { length, maxlength, violated };
+});
+
 /**
  * The Tiptap editor uses a contenteditable div so it does not support the native CSS ":invalid" for showing the error.
  * To workaround this, the track if the value has ever been changed and consider this as "touched" / interacted.
@@ -118,6 +128,22 @@ const error = computed<string | FormElementV2Tooltip | undefined>(() => {
     return {
       label: t.value("validations.valueMissing.preview"),
       tooltipText: t.value("validations.valueMissing.fullError"),
+    };
+  }
+
+  if (props.minlength && characterCount.value < props.minlength) {
+    const translationData = { n: characterCount.value, minLength: props.minlength };
+    return {
+      label: t.value("validations.tooShort.preview", translationData),
+      tooltipText: t.value("validations.tooShort.fullError", translationData),
+    };
+  }
+
+  if (props.maxlength && characterCount.value > props.maxlength) {
+    const translationData = { n: characterCount.value, maxLength: props.maxlength };
+    return {
+      label: t.value("validations.tooLong.preview", translationData),
+      tooltipText: t.value("validations.tooLong.fullError", translationData),
     };
   }
 
@@ -234,6 +260,17 @@ defineExpose({
         @focus="editor?.commands.focus()"
       />
     </OnyxVisuallyHidden>
+
+    <template v-if="counter" #bottomRight>
+      <span
+        :class="[
+          'onyx-text-editor__counter',
+          { 'onyx-text-editor__counter--violated': counter.violated },
+        ]"
+      >
+        {{ counter.length }}/{{ counter.maxlength }}
+      </span>
+    </template>
   </OnyxUnstableFormElementV2>
 </template>
 
@@ -267,6 +304,12 @@ defineExpose({
         // workaround for [#1142](https://github.com/SchwarzIT/onyx/issues/1142)
         // `display: none` or changing "content" causes user resizing to be interrupted
         height: 0;
+      }
+    }
+
+    &__counter {
+      &--violated {
+        color: var(--onyx-color-text-icons-danger-intense);
       }
     }
   }

--- a/packages/tiptap/src/components/OnyxTextEditor/TestCase.ct.vue
+++ b/packages/tiptap/src/components/OnyxTextEditor/TestCase.ct.vue
@@ -1,13 +1,19 @@
 <script lang="ts" setup>
+import { FORM_INJECTED_SYMBOL } from "sit-onyx";
 import { type OnyxStarterKitOptions, OnyxStarterKit } from "./extensions/starterKit.js";
 import OnyxTextEditor from "./OnyxTextEditor.vue";
 import type { OnyxTextEditorProps } from "./types.js";
 
-const props = defineProps<
-  OnyxTextEditorProps & {
-    options?: OnyxStarterKitOptions;
-  }
->();
+const props = withDefaults(
+  defineProps<
+    OnyxTextEditorProps & {
+      options?: OnyxStarterKitOptions;
+    }
+  >(),
+  {
+    showError: FORM_INJECTED_SYMBOL,
+  },
+);
 </script>
 
 <template>

--- a/packages/tiptap/src/components/OnyxTextEditor/extensions/starterKit.ts
+++ b/packages/tiptap/src/components/OnyxTextEditor/extensions/starterKit.ts
@@ -1,5 +1,6 @@
 // extensions/OnyxStarterKit.js
 import TextAlign, { type TextAlignOptions } from "@tiptap/extension-text-align";
+import { CharacterCount } from "@tiptap/extensions";
 import StarterKit, { type StarterKitOptions } from "@tiptap/starter-kit";
 import { Extension, type Extensions } from "@tiptap/vue-3";
 import { OnyxHeadingExtension } from "./heading.js";
@@ -41,6 +42,10 @@ export const OnyxStarterKit = Extension.create<OnyxStarterKitOptions>({
         ...this.options,
         heading: false, // false needed here because we add our custom options below
       }),
+      // Needed in order to support the properties: minlength, maxlength and withCounter
+      // Important: do NOT add a limit here because this would block the user typing which is not desired.
+      // Instead, we want to show a custom error to the user
+      CharacterCount,
     ];
 
     if (this.options.heading !== false) {

--- a/packages/tiptap/src/components/OnyxTextEditor/types.ts
+++ b/packages/tiptap/src/components/OnyxTextEditor/types.ts
@@ -7,11 +7,9 @@ import type {
 } from "sit-onyx";
 import type { InjectionKey, Ref } from "vue";
 
-// TODO: consider the following features if possible:
-// min/max length, autocapitalize
 export type OnyxTextEditorProps = Omit<OnyxFormElementV2Props, "open" | "popoverOptions" | "id"> &
   Pick<SharedFormElementProps, "disabled" | "autofocus" | "placeholder"> &
-  Pick<OnyxTextareaProps, "disableManualResize" | "autosize"> & {
+  Pick<OnyxTextareaProps, "disableManualResize" | "autosize" | "withCounter"> & {
     /**
      * Current editor value.
      */
@@ -25,6 +23,16 @@ export type OnyxTextEditorProps = Omit<OnyxFormElementV2Props, "open" | "popover
      * If set, default extensions will be overridden. Use or configure the OnyxStarterKit in this case.
      */
     extensions?: Extensions;
+    /**
+     * Minimum number of characters that have to to be entered.
+     * Character count is determined using Tiptap's [CharacterCount extension](https://tiptap.dev/docs/editor/extensions/functionality/character-count).
+     */
+    minlength?: number;
+    /**
+     * Maximum number of characters that are allowed to be entered.
+     * Character count is determined using Tiptap's [CharacterCount extension](https://tiptap.dev/docs/editor/extensions/functionality/character-count).
+     */
+    maxlength?: number;
   };
 
 export type ToolbarOptions = {


### PR DESCRIPTION
Relates to #4915

Support additional form validation for min/max length for the OnyxTextEditor

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
