### PR TITLE
fix(OnyxTimePicker): narrow type of "update:modelValue" emit depending on given type

### DIFF
--- a/.changeset/young-balloons-shave.md
+++ b/.changeset/young-balloons-shave.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxTimePicker): narrow type of "update:modelValue" emit depending on given type

--- a/packages/sit-onyx/src/components/OnyxTimePicker/OnyxTimePicker.vue
+++ b/packages/sit-onyx/src/components/OnyxTimePicker/OnyxTimePicker.vue
@@ -6,7 +6,7 @@
 export default {};
 </script>
 
-<script lang="ts" setup generic="TType extends TimePickerType">
+<script lang="ts" setup generic="TType extends TimePickerType = 'default'">
 import { computed, useTemplateRef } from "vue";
 import { SKELETON_INJECTED_SYMBOL } from "../../composables/useSkeletonState.js";
 import { useVModel } from "../../composables/useVModel.js";
@@ -16,7 +16,12 @@ import { FORM_INJECTED_SYMBOL } from "../OnyxForm/OnyxForm.core.js";
 import DefaultTimePicker from "./DefaultTimePicker.vue";
 import RangeTimePicker from "./RangeTimePicker.vue";
 import SelectTimePicker from "./SelectTimePicker.vue";
-import type { OnyxTimePickerProps, OnyxTimePickerSlots, TimePickerType } from "./types.js";
+import type {
+  OnyxTimePickerProps,
+  OnyxTimePickerSlots,
+  TimePickerType,
+  TimeRange,
+} from "./types.js";
 
 const props = withDefaults(defineProps<OnyxTimePickerProps<TType>>(), {
   showSeconds: false,
@@ -35,7 +40,7 @@ const emit = defineEmits<{
   /**
    * Emitted when current value changes.
    */
-  "update:modelValue": [value?: string];
+  "update:modelValue": [value?: TType extends "range" ? TimeRange : string];
   /**
    * Emitted when the open state changes.
    */

--- a/packages/sit-onyx/src/components/OnyxTimePicker/RangeTimePicker.vue
+++ b/packages/sit-onyx/src/components/OnyxTimePicker/RangeTimePicker.vue
@@ -15,7 +15,7 @@ import OnyxFormElementV2 from "../OnyxFormElementV2/OnyxFormElementV2.vue";
 import type { FormElementV2PopoverOptions } from "../OnyxFormElementV2/types.js";
 import { customMessageToFormElementV2Message } from "../OnyxFormElementV2/useLegacyFormElementProps.js";
 import TimePickerGroup, { type Segment } from "./TimePickerGroup.vue";
-import type { OnyxTimePickerProps, OnyxTimePickerSlots } from "./types.js";
+import type { OnyxTimePickerProps, OnyxTimePickerSlots, TimeRange } from "./types.js";
 import { createTimeString, parseTimeString } from "./utils.js";
 
 const props = withDefaults(defineProps<OnyxTimePickerProps>(), {
@@ -26,7 +26,7 @@ const emit = defineEmits<{
   /**
    * Emitted when modelValue changes.
    */
-  "update:modelValue": [value?: string];
+  "update:modelValue": [value?: TimeRange];
   /**
    * Emitted when the open state changes.
    */


### PR DESCRIPTION
Closes #5285 

While using the `OnyxTimePicker` I noticed that the type of the value emitted from "update:modelValue" is statically typed as string, even though it may also be of type `TimeRange` in case `type` is set to `range`.
So I updated the types a bit to reflect this and correctly narrow the emitted type depending on the type set for the component.

Default:
<img width="351" height="174" alt="image" src="https://github.com/user-attachments/assets/1829c88a-2a10-48f3-bd51-aa65c4fe9012" />

Type select:
<img width="353" height="192" alt="image" src="https://github.com/user-attachments/assets/764db2bc-f4ef-47a8-808a-d4b5125b9012" />

Type range:
<img width="401" height="194" alt="image" src="https://github.com/user-attachments/assets/af9b6051-9c46-4ac6-8a7b-9cc5cdbbcbe5" />

> Note: There's a small bug in the IDE when trying to use autocomplete for the `type` property. It will only suggest "default" as a value while "select" and "range" are also valid options. This however only affects auto complete and is resolved when TypeScript version 6 or later is used as language server in the IDE.