### PR TITLE
chore: add apt cleanup when using fallback mirror

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -60,6 +60,12 @@ jobs:
       - name: 📦 Install Playwright system dependencies using fallback mirror
         if: ${{ steps.first-playwright-install.outcome == 'failure' }}
         run: |
+          # Clean-up in progress installation: https://wiki.debian.org/Teams/Dpkg/FAQ#db-lock
+          sudo killall apt apt-get
+          sudo fuser -vk -KILL /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend
+          sudo dpkg --configure -a
+
+          # Use different mirror
           sudo sed -i 's/mirror.enzu.com/archive.ubuntu.com/g' /etc/apt/apt-mirrors.txt
           sudo cat /etc/apt/apt-mirrors.txt
 


### PR DESCRIPTION
- Fallback mirror didn't work correctly for installing playwright
  - See: https://github.com/SchwarzIT/onyx/actions/runs/24320729443/job/71006622074
- Added clean-up logic for killed `apt` processes