### PR TITLE
fix(OnyxCheckbox): use correct border radius for input and outline

### DIFF
--- a/.changeset/lazy-lands-raise.md
+++ b/.changeset/lazy-lands-raise.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxCheckbox): use correct border radius for input and outline

--- a/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.vue
+++ b/packages/sit-onyx/src/components/OnyxCheckbox/OnyxCheckbox.vue
@@ -180,7 +180,7 @@ useAutofocus(input, props);
       display: inline-flex;
       align-items: flex-start;
       padding: var(--onyx-checkbox-input-padding);
-      border-radius: var(--onyx-radius-component-checkbox);
+      border-radius: var(--onyx-radius-full);
     }
 
     &__label {

--- a/packages/sit-onyx/src/styles/mixins/checkbox.scss
+++ b/packages/sit-onyx/src/styles/mixins/checkbox.scss
@@ -23,7 +23,7 @@
   width: var(--onyx-checkbox-input-size);
   appearance: none;
   margin: 0;
-  border-radius: var(--onyx-radius-sm);
+  border-radius: var(--onyx-radius-component-checkbox);
   outline: none;
   cursor: inherit;
   border: var(--onyx-1px-in-rem) solid var(--onyx-color-component-border-neutral);


### PR DESCRIPTION
Relates to #5138 

Fix border radius variables for checkbox so the input uses the themed variable and the outline is always fully rounded. Previously the outline was squared.
<img width="137" height="60" alt="image" src="https://github.com/user-attachments/assets/bf4c5e8e-f6fd-4489-8b54-058f18c45a6b" />


## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
