### PR TITLE
chore: more flakiness reductions

### DIFF
--- a/packages/playwright-utils/src/screenshots/index.tsx
+++ b/packages/playwright-utils/src/screenshots/index.tsx
@@ -145,7 +145,7 @@ export const useMatrixScreenshotTest = <TContext extends HookContext = HookConte
 
       const component = await mount(html);
       await Promise.all(waitForLoaded);
-      await expect(component).toHaveScreenshot(`${options.name}.png`, { timeout: 10_000 });
+      await expect(() => expect(component).toHaveScreenshot(`${options.name}.png`)).toPass();
 
       await page.unroute(`${SCREENSHOT_ROUTE}*`);
     });

--- a/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.ct.tsx
+++ b/packages/tiptap/src/components/OnyxTextEditor/OnyxTextEditor.ct.tsx
@@ -811,8 +811,9 @@ test("should include editor in native HTML form validation", async ({ mount }) =
   await expect(async () => {
     // unfortunately flaky, therefore we put it into this `expect.toPass` block
     await editor.clear();
-    await expectEmit(onUpdateModelValue, 2, ["<p></p>"]);
+    await expect(editor).toHaveText("");
   }, "should clear the editor").toPass();
+  await expectEmit(onUpdateModelValue, 2, ["<p></p>"]);
 
   await component.getByRole("button", { name: "Submit" }).click();
 


### PR DESCRIPTION
- Wrapped `toHaveScreenshot` into `toPass` to enable retries for matrix screenshot tests for rare cases in which the images aren't rendered yet
- Moved `expectEmit` out of `toPass` logic, as it uses `toPass` itself. This prevented the outer `toPass` from working, because the timeout was triggered before it retried