### PR TITLE
docs: fix Storybook code snippets

### DIFF
--- a/.changeset/twelve-canyons-sin.md
+++ b/.changeset/twelve-canyons-sin.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/storybook-utils": patch
+---
+
+fix: prevent broken code snippets when replacing onyx icons and flags

--- a/packages/storybook-utils/src/preview.ts
+++ b/packages/storybook-utils/src/preview.ts
@@ -161,6 +161,7 @@ export const sourceCodeTransformer = async (originalSourceCode: string): Promise
 
   packagesToReplace.forEach((_package) => {
     Object.entries(_package.data).forEach(([name, content]) => {
+      if (typeof content !== "string") return;
       const singleQuotedContent = `'${replaceAll(content, '"', "\\'")}'`;
       const escapedContent = `"${replaceAll(content, '"', '\\"')}"`;
 


### PR DESCRIPTION
Currently Storybook does not show any code snippets.
<img width="422" height="127" alt="image" src="https://github.com/user-attachments/assets/2192bbbe-608b-4795-989b-1071851242f3" />
