### PR TITLE
fix(OnyxGlobalSearch): Fixed issue, where clicking `target="_blank"` link opens new tab twice

### DIFF
--- a/.changeset/clear-planets-smash.md
+++ b/.changeset/clear-planets-smash.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxGlobalSearch): Fixed issue, where clicking `target="_blank"` link opens new tab twice

--- a/.changeset/fresh-sides-enjoy.md
+++ b/.changeset/fresh-sides-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/headless": minor
+---
+
+feat(createListbox, createCombobox): expose triggering event for `onSelect` hook handler

--- a/packages/headless/src/composables/comboBox/createComboBox.ts
+++ b/packages/headless/src/composables/comboBox/createComboBox.ts
@@ -1,4 +1,4 @@
-import { computed, unref, useId, type MaybeRef, type Ref } from "vue";
+import { computed, toValue, unref, useId, type MaybeRef, type Ref } from "vue";
 import { createBuilder } from "../../utils/builder.js";
 import { isPrintableCharacter, wasKeyPressed, type PressedKey } from "../../utils/keyboard.js";
 import type { Nullable } from "../../utils/types.js";
@@ -71,7 +71,7 @@ export type CreateComboboxOptions<
   /**
    * Hook when an option is (un-)selected.
    */
-  onSelect?: (value: TValue) => void;
+  onSelect?: (value: TValue, event?: Event) => void;
   /**
    * Hook when the first option should be activated.
    */
@@ -143,9 +143,9 @@ export const createComboBox = createBuilder(
 
     const typeAhead = useTypeAhead((inputString) => onTypeAhead?.(inputString));
 
-    const handleSelect = (value: TValue) => {
-      onSelect?.(value);
-      if (!unref(multiple)) {
+    const handleSelect = (value: TValue, event?: Event) => {
+      onSelect?.(value, event);
+      if (!toValue(multiple)) {
         onToggle?.();
       }
     };
@@ -220,7 +220,7 @@ export const createComboBox = createBuilder(
 
     const {
       elements: { option, group, listbox },
-      internals: { getOptionId, getOptionValueById },
+      internals: { getOptionId, getOptionValueById, getOption },
     } = createListbox({
       label: listLabel,
       description: listDescription,
@@ -275,7 +275,7 @@ export const createComboBox = createBuilder(
           onClick: () => onToggle?.(),
         })),
       },
-      internals: { getOptionId, getOptionValueById },
+      internals: { getOptionId, getOptionValueById, getOption },
     };
   },
 );

--- a/packages/headless/src/composables/listbox/createListbox.ts
+++ b/packages/headless/src/composables/listbox/createListbox.ts
@@ -34,7 +34,7 @@ export type CreateListboxOptions<TValue extends ListboxValue, TMultiple extends 
   /**
    * Hook when an option is selected.
    */
-  onSelect?: (value: TValue) => void;
+  onSelect?: (value: TValue, event?: Event) => void;
   /**
    * Hook when the first option should be activated.
    */
@@ -104,6 +104,11 @@ export const createListbox = createBuilder(
       return entries.find(([_value, key]) => key === id)?.[0];
     };
 
+    const getOption = (value: TValue) => {
+      const id = getOptionId(value);
+      return document.getElementById(id);
+    };
+
     /**
      * Whether the listbox element is focused.
      */
@@ -118,10 +123,11 @@ export const createListbox = createBuilder(
       ) {
         return;
       }
-
-      const id = getOptionId(options.activeOption.value);
       await nextTick();
-      document.getElementById(id)?.scrollIntoView({ block: "nearest", inline: "nearest" });
+      getOption(options.activeOption.value)?.scrollIntoView({
+        block: "nearest",
+        inline: "nearest",
+      });
     });
 
     const typeAhead = useTypeAhead((inputString) => options.onTypeAhead?.(inputString));
@@ -131,7 +137,7 @@ export const createListbox = createBuilder(
         case " ":
           event.preventDefault();
           if (options.activeOption.value != undefined) {
-            options.onSelect?.(options.activeOption.value);
+            options.onSelect?.(options.activeOption.value, event);
           }
           break;
 
@@ -223,7 +229,7 @@ export const createListbox = createBuilder(
               "aria-disabled": data.disabled,
               "aria-checked": isMultiselect.value ? selected : undefined,
               "aria-selected": !isMultiselect.value ? selected : undefined,
-              onClick: () => !data.disabled && options.onSelect?.(data.value),
+              onClick: (event) => !data.disabled && options.onSelect?.(data.value, event),
             } as const;
           };
         }),
@@ -234,6 +240,7 @@ export const createListbox = createBuilder(
       internals: {
         getOptionId,
         getOptionValueById,
+        getOption,
       },
     };
   },

--- a/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.ct.tsx
@@ -1,3 +1,4 @@
+import type { AxeBuilder } from "@axe-core/playwright";
 import { expect, test } from "../../playwright/a11y.js";
 import TestCase from "./TestCase.ct.vue";
 
@@ -56,7 +57,34 @@ test("should render groups and options", async ({ page, mount, makeAxeBuilder })
   await expect(page).toHaveScreenshot("responsive.png");
 });
 
-test("should support keyboard navigation", async ({ page, mount }) => {
+test("should support mouse", async ({ page, mount, context }) => {
+  // ARRANGE
+  const component = await mount(TestCase, { props: { groupCount: 2 } });
+  const input = component.getByLabel("Search for content");
+
+  // ASSERT
+  await expect(input, "should autofocus search input").toBeFocused();
+
+  // ACT + ASSERT
+  await component.getByLabel("Result 1.1").click();
+  await expect(page).toHaveURL(/\/#1-1/);
+
+  // ARRANGE
+  let count = 0;
+  context.on("request", () => count++);
+  const newTabPromise = page.waitForEvent("popup");
+
+  // ACT
+  await component.getByLabel("Result 1.2").click();
+  const newTab = await newTabPromise;
+
+  // ASSERT
+  await expect(newTab).toHaveURL("https://example.com");
+  await newTab.close();
+  expect(count, "should only open a single tab").toBe(1);
+});
+
+test("should support keyboard navigation", async ({ page, mount, context }) => {
   // ARRANGE
   const component = await mount(TestCase, { props: { groupCount: 2 } });
   const input = component.getByLabel("Search for content");
@@ -109,4 +137,19 @@ test("should support keyboard navigation", async ({ page, mount }) => {
   // ACT + ASSERT
   await page.keyboard.press("Enter");
   await expect(page).toHaveURL(/\/#1-1/);
+
+  // ARRANGE
+  let count = 0;
+  context.on("request", () => count++);
+  const newTabPromise = page.waitForEvent("popup");
+
+  // ACT
+  await navigate("ArrowDown");
+  await page.keyboard.press("Enter");
+
+  // ASSERT
+  const newTab = await newTabPromise;
+  await expect(newTab).toHaveURL("https://example.com");
+  await newTab.close();
+  expect(count, "should only open a single tab").toBe(1);
 });

--- a/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.vue
+++ b/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.vue
@@ -88,11 +88,13 @@ const activateOption = (type: "first" | "last" | "previous" | "next") => {
 
 const onAutocomplete = (input: string) => (searchTerm.value = input);
 
-const onSelect = (value: string) => {
-  const id = headless.internals.getOptionId(value);
-  const option = dialogElement.value?.querySelector(`#${id}`);
-  if (!option) return;
-  if ("click" in option && typeof option.click === "function") option.click();
+const onSelect = (value: string, event?: Event) => {
+  const option = headless.internals.getOption(value);
+  const alreadyClicked =
+    event && event.type === "click" && option?.contains(event.target as HTMLElement);
+  if (option && !alreadyClicked) {
+    option.click();
+  }
 };
 
 const headless = createComboBox({

--- a/packages/sit-onyx/src/components/OnyxGlobalSearch/TestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxGlobalSearch/TestCase.ct.vue
@@ -35,12 +35,18 @@ const props = withDefaults(
         :label="`Group ${group}`"
       >
         <OnyxGlobalSearchOption
-          v-for="option in 2"
-          :key="`${group}-${option}`"
-          :label="`Result ${group}.${option} `.repeat(props.longContent ? 8 : 1)"
-          :value="`${group}-${option}`"
+          :key="`${group}-1`"
+          :label="`Result ${group}.1 `.repeat(props.longContent ? 8 : 1)"
+          :value="`${group}-1`"
           :icon="iconPlaceholder"
-          :link="`#${group}-${option}`"
+          :link="`#${group}-1`"
+        />
+        <OnyxGlobalSearchOption
+          :key="`${group}-2`"
+          :label="`Result ${group}.2 `.repeat(props.longContent ? 8 : 1)"
+          :value="`${group}-2`"
+          :icon="iconPlaceholder"
+          :link="{ href: 'https://example.com', target: '_blank' }"
         />
       </OnyxGlobalSearchGroup>
     </template>


### PR DESCRIPTION
Closes #5366 

_Cause:_ Clicking a `OnyxGlobalSearchOption` with the mouse, also triggers the `onSelect` handler, which is used by the `OnyxGlobalSearch` to trigger a click programmatically, again. This behavior is implemented this way, so that `onSelect` can also be triggered by keyboard without being focused.

_Fix:_ We provide the triggering event to the `onSelect` handler and check if there was already a click performed, before triggering a click programmatically.
