### PR TITLE
feat(OnyxSidebar): automatically close temporary mobile sidebar if route changes

### DIFF
--- a/.changeset/yummy-years-agree.md
+++ b/.changeset/yummy-years-agree.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxSidebar): automatically close temporary mobile sidebar if route changes

--- a/packages/sit-onyx/src/components/OnyxSidebar/OnyxSidebar.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxSidebar/OnyxSidebar.ct.tsx
@@ -264,4 +264,28 @@ test.describe("small screen", () => {
     // ASSERT
     await expect(leftSidebar).toBeVisible();
   });
+
+  test("should close after navigation", async ({ mount }) => {
+    // ARRANGE
+    const component = await mount(PlaywrightTest, {
+      props: {
+        sidebarLeft: true,
+      },
+    });
+
+    const fab = component.getByRole("button", { name: "Sidebar Left" });
+    const sidebar = component.getByRole("dialog", { name: "Sidebar Left" });
+
+    // ACT
+    await fab.click();
+
+    // ASSERT
+    await expect(sidebar).toBeVisible();
+
+    // ACT
+    await component.update({ props: { currentRoute: "/changed-route" } });
+
+    // ASSERT
+    await expect(sidebar, "should hide temporary sidebar if route changes").toBeHidden();
+  });
 });

--- a/packages/sit-onyx/src/components/OnyxSidebar/OnyxSidebar.vue
+++ b/packages/sit-onyx/src/components/OnyxSidebar/OnyxSidebar.vue
@@ -7,6 +7,7 @@ import {
 } from "@sit-onyx/icons";
 import { computed, onUnmounted, ref, useId, useTemplateRef, watch } from "vue";
 import { useDensity } from "../../composables/density.js";
+import { useLink } from "../../composables/useLink.js";
 import { useResizeObserver } from "../../composables/useResizeObserver.js";
 import { ONYX_BREAKPOINTS } from "../../utils/breakpoints.js";
 import { useGlobalFAB } from "../OnyxGlobalFAB/useGlobalFAB.js";
@@ -22,8 +23,8 @@ const props = withDefaults(defineProps<OnyxSidebarProps>(), {
 
 const emit = defineEmits<{
   /**
-   * Emitted when the drawer should be closed.
-   * Only available when the `drawer` property is set.
+   * Emitted when the temporary sidebar should be closed.
+   * Only available when the `temporary` property is set.
    */
   close: [];
 }>();
@@ -126,6 +127,10 @@ watch(
 onUnmounted(() => {
   globalFAB.remove(id);
 });
+
+// automatically close mobile sidebar after navigation
+const { currentRoute } = useLink();
+watch(currentRoute, () => (isModalOpen.value = false), { deep: true });
 </script>
 
 <template>

--- a/packages/sit-onyx/src/components/OnyxSidebar/PlaywrightTest.vue
+++ b/packages/sit-onyx/src/components/OnyxSidebar/PlaywrightTest.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
-import { provide } from "vue";
+import { computed, provide } from "vue";
+import { ROUTER_INJECTION_KEY } from "../../composables/useLink.js";
 import OnyxAppLayout from "../OnyxAppLayout/OnyxAppLayout.vue";
+import OnyxButton from "../OnyxButton/OnyxButton.vue";
 import {
   createGlobalFABProvider,
   GLOBAL_FAB_PROVIDER_INJECTION_KEY,
@@ -17,9 +19,18 @@ const props = defineProps<{
    * If the right sidebar should be displayed
    */
   sidebarRight?: boolean;
+  /**
+   * Current route.
+   */
+  currentRoute?: string;
 }>();
 
 provide(GLOBAL_FAB_PROVIDER_INJECTION_KEY, createGlobalFABProvider());
+
+provide(ROUTER_INJECTION_KEY, {
+  currentRoute: computed(() => props.currentRoute ?? "/"),
+  push: () => ({}),
+});
 </script>
 
 <template>


### PR DESCRIPTION
Automatically close the mobile sidebar if route is changed (same behavior as for mobile nav bar). Previously, the sidebar was still open which is bad UX. Example: View this page in mobile mode and use the sidebar to navigate to a different page: https://onyx-showcase-dev.apps.01.cf.eu01.stackit.cloud/introduction/foundation/density

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because 
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
