### PR TITLE
chore: fix flaky test by using unique links

### DIFF
--- a/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.ct.tsx
@@ -7,7 +7,7 @@ async function checkAccessibility(axeBuilder: AxeBuilder) {
   expect(accessibilityScanResults.violations).toEqual([]);
 }
 
-export const TEST_GLOBAL_SEARCH_UNIQUE_LINK = "https://onyx-global-search.example.com"
+const TEST_GLOBAL_SEARCH_UNIQUE_LINK = "https://onyx-global-search.example.com";
 
 test("should render groups and options", async ({ page, mount, makeAxeBuilder }) => {
   // ARRANGE

--- a/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.ct.tsx
@@ -7,6 +7,8 @@ async function checkAccessibility(axeBuilder: AxeBuilder) {
   expect(accessibilityScanResults.violations).toEqual([]);
 }
 
+export const TEST_GLOBAL_SEARCH_UNIQUE_LINK = "https://onyx-global-search.example.com"
+
 test("should render groups and options", async ({ page, mount, makeAxeBuilder }) => {
   // ARRANGE
   const component = await mount(TestCase);
@@ -79,7 +81,7 @@ test("should support mouse", async ({ page, mount, context }) => {
   const newTab = await newTabPromise;
 
   // ASSERT
-  await expect(newTab).toHaveURL("https://example.com");
+  await expect(newTab).toHaveURL(TEST_GLOBAL_SEARCH_UNIQUE_LINK);
   await newTab.close();
   expect(count, "should only open a single tab").toBe(1);
 });
@@ -149,7 +151,7 @@ test("should support keyboard navigation", async ({ page, mount, context }) => {
 
   // ASSERT
   const newTab = await newTabPromise;
-  await expect(newTab).toHaveURL("https://example.com");
+  await expect(newTab).toHaveURL(TEST_GLOBAL_SEARCH_UNIQUE_LINK);
   await newTab.close();
   expect(count, "should only open a single tab").toBe(1);
 });

--- a/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.ct.tsx
@@ -7,7 +7,11 @@ async function checkAccessibility(axeBuilder: AxeBuilder) {
   expect(accessibilityScanResults.violations).toEqual([]);
 }
 
-const TEST_GLOBAL_SEARCH_UNIQUE_LINK = "https://onyx-global-search.example.com";
+const EXTERNAL_HREF = "https://onyx-global-search.example.com";
+
+test.beforeEach(async ({ context }) => {
+  await context.route(EXTERNAL_HREF, (route) => route.fulfill({ body: "Test page" }));
+});
 
 test("should render groups and options", async ({ page, mount, makeAxeBuilder }) => {
   // ARRANGE
@@ -81,7 +85,7 @@ test("should support mouse", async ({ page, mount, context }) => {
   const newTab = await newTabPromise;
 
   // ASSERT
-  await expect(newTab).toHaveURL(TEST_GLOBAL_SEARCH_UNIQUE_LINK);
+  await expect(newTab).toHaveURL(EXTERNAL_HREF);
   await newTab.close();
   expect(count, "should only open a single tab").toBe(1);
 });
@@ -151,7 +155,7 @@ test("should support keyboard navigation", async ({ page, mount, context }) => {
 
   // ASSERT
   const newTab = await newTabPromise;
-  await expect(newTab).toHaveURL(TEST_GLOBAL_SEARCH_UNIQUE_LINK);
+  await expect(newTab).toHaveURL(EXTERNAL_HREF);
   await newTab.close();
   expect(count, "should only open a single tab").toBe(1);
 });

--- a/packages/sit-onyx/src/components/OnyxGlobalSearch/TestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxGlobalSearch/TestCase.ct.vue
@@ -4,7 +4,6 @@ import OnyxButton from "../OnyxButton/OnyxButton.vue";
 import OnyxGlobalSearchGroup from "../OnyxGlobalSearchGroup/OnyxGlobalSearchGroup.vue";
 import OnyxGlobalSearchOption from "../OnyxGlobalSearchOption/OnyxGlobalSearchOption.vue";
 import OnyxGlobalSearch from "./OnyxGlobalSearch.vue";
-import { TEST_GLOBAL_SEARCH_UNIQUE_LINK } from "./OnyxGlobalSearch.ct.jsx";
 
 const props = withDefaults(
   defineProps<{
@@ -47,7 +46,7 @@ const props = withDefaults(
           :label="`Result ${group}.2 `.repeat(props.longContent ? 8 : 1)"
           :value="`${group}-2`"
           :icon="iconPlaceholder"
-          :link="{ href: TEST_GLOBAL_SEARCH_UNIQUE_LINK, target: '_blank' }"
+          :link="{ href: 'https://onyx-global-search.example.com', target: '_blank' }"
         />
       </OnyxGlobalSearchGroup>
     </template>

--- a/packages/sit-onyx/src/components/OnyxGlobalSearch/TestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxGlobalSearch/TestCase.ct.vue
@@ -4,6 +4,7 @@ import OnyxButton from "../OnyxButton/OnyxButton.vue";
 import OnyxGlobalSearchGroup from "../OnyxGlobalSearchGroup/OnyxGlobalSearchGroup.vue";
 import OnyxGlobalSearchOption from "../OnyxGlobalSearchOption/OnyxGlobalSearchOption.vue";
 import OnyxGlobalSearch from "./OnyxGlobalSearch.vue";
+import { TEST_GLOBAL_SEARCH_UNIQUE_LINK } from "./OnyxGlobalSearch.ct.jsx";
 
 const props = withDefaults(
   defineProps<{
@@ -46,7 +47,7 @@ const props = withDefaults(
           :label="`Result ${group}.2 `.repeat(props.longContent ? 8 : 1)"
           :value="`${group}-2`"
           :icon="iconPlaceholder"
-          :link="{ href: 'https://example.com', target: '_blank' }"
+          :link="{ href: TEST_GLOBAL_SEARCH_UNIQUE_LINK, target: '_blank' }"
         />
       </OnyxGlobalSearchGroup>
     </template>

--- a/packages/sit-onyx/src/components/OnyxLink/OnyxLink.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxLink/OnyxLink.ct.tsx
@@ -3,7 +3,7 @@ import { executeMatrixScreenshotTest } from "../../playwright/screenshots.js";
 import OnyxLink from "./OnyxLink.vue";
 
 // we do not want to actually make requests to live external applications so we mock them here
-const EXTERNAL_HREF = "https://example.com";
+const EXTERNAL_HREF = "https://onyx-link.example.com";
 
 test.beforeEach(async ({ page }) => {
   await page.route(EXTERNAL_HREF, (route) => route.fulfill({ body: "Test page" }));

--- a/packages/sit-onyx/src/components/OnyxLink/OnyxLink.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxLink/OnyxLink.ct.tsx
@@ -5,8 +5,8 @@ import OnyxLink from "./OnyxLink.vue";
 // we do not want to actually make requests to live external applications so we mock them here
 const EXTERNAL_HREF = "https://onyx-link.example.com";
 
-test.beforeEach(async ({ page }) => {
-  await page.route(EXTERNAL_HREF, (route) => route.fulfill({ body: "Test page" }));
+test.beforeEach(async ({ context }) => {
+  await context.route(EXTERNAL_HREF, (route) => route.fulfill({ body: "Test page" }));
 });
 
 test.describe("Screenshot tests", () => {

--- a/packages/sit-onyx/src/components/OnyxRouterLink/OnyxRouterLink.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxRouterLink/OnyxRouterLink.ct.tsx
@@ -2,7 +2,7 @@ import { expect, test } from "../../playwright/a11y.js";
 import TestWrapper from "./TestWrapper.ct.vue";
 
 // we do not want to actually make requests to live external applications so we mock them here
-const EXTERNAL_HREF = "https://example.com";
+const EXTERNAL_HREF = "https://onyx-router-link.example.com";
 
 test.beforeEach(async ({ page }) => {
   await page.route(EXTERNAL_HREF, (route) => route.fulfill({ body: "Test page" }));

--- a/packages/sit-onyx/src/components/OnyxRouterLink/OnyxRouterLink.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxRouterLink/OnyxRouterLink.ct.tsx
@@ -4,8 +4,8 @@ import TestWrapper from "./TestWrapper.ct.vue";
 // we do not want to actually make requests to live external applications so we mock them here
 const EXTERNAL_HREF = "https://onyx-router-link.example.com";
 
-test.beforeEach(async ({ page }) => {
-  await page.route(EXTERNAL_HREF, (route) => route.fulfill({ body: "Test page" }));
+test.beforeEach(async ({ context }) => {
+  await context.route(EXTERNAL_HREF, (route) => route.fulfill({ body: "Test page" }));
 });
 
 test("should open external link without router", async ({ page, mount }) => {


### PR DESCRIPTION
_Cause:_ Component tests in playwright [reuse browser and context](https://playwright.dev/docs/test-components#whats-the-difference-between-playwrighttest-and-playwrightexperimental-ct-reactvue). In the `OnyxGlobalSearch.ct.tsx` test we click a link to check for a regression where a link was opened twice. This sometimes causes the links in `OnyxLink.ct.tsx` to be rendered as visited, depending on the test order and sharding.

_Fix:_ We make sure to use unique links for the relevant tests.