### PR TITLE
chore(changeset): use patch releases

### DIFF
--- a/.changeset/eleven-flies-fly.md
+++ b/.changeset/eleven-flies-fly.md
@@ -1,5 +1,5 @@
 ---
-"@sit-onyx/icons": minor
+"@sit-onyx/icons": patch
 ---
 
 feat: update icons

--- a/.changeset/good-lizards-lose.md
+++ b/.changeset/good-lizards-lose.md
@@ -1,5 +1,5 @@
 ---
-"sit-onyx": minor
+"sit-onyx": patch
 ---
 
 feat(theme): added new PreZero theme fonts


### PR DESCRIPTION
To prepare for our patch fix release, I changed the existing changesets to patch so no minor release is published

## Checklist

<!-- If bullet points below do not apply to your changes (e.g. no documentation needed), just remove it. -->

- [ ] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [ ] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) or functional test is added
- [ ] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [ ] I have performed a self review of my code ("Files changed" tab in the pull request)
- [ ] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
