### PR TITLE
docs(showcase): Add examples for "Buttons" components

### DIFF
--- a/.changeset/tidy-cars-call.md
+++ b/.changeset/tidy-cars-call.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt-docs": minor
+---
+
+feat(useSidebarNavigation): support new `fields` option to include custom fields for the navigation items

--- a/apps/showcase/app/components/ComponentStatusTag.vue
+++ b/apps/showcase/app/components/ComponentStatusTag.vue
@@ -1,0 +1,25 @@
+<script lang="ts" setup>
+import type { ComponentsEnCollectionItem } from "@nuxt/content";
+import { iconNew } from "@sit-onyx/icons";
+import type { OnyxTagProps } from "sit-onyx";
+
+const props = defineProps<{
+  status: NonNullable<ComponentsEnCollectionItem["status"]>;
+}>();
+
+const { t } = useI18n();
+
+const tagProps = computed<Record<typeof props.status, OnyxTagProps>>(() => {
+  return {
+    new: {
+      label: t("components.status.new"),
+      color: "primary",
+      icon: iconNew,
+    },
+  };
+});
+</script>
+
+<template>
+  <OnyxTag v-bind="tagProps[props.status]" />
+</template>

--- a/apps/showcase/app/components/GlobalSearch.vue
+++ b/apps/showcase/app/components/GlobalSearch.vue
@@ -1,10 +1,16 @@
 <script lang="ts" setup>
 import GlobalSearch from "#layers/onyx/app/components/GlobalSearch.vue";
+import type { Collections } from "@nuxt/content";
 
 const { loggedIn } = useUserSession();
+const { locale } = useI18n();
+
+const collections = computed<(keyof Collections)[]>(() => {
+  return [`content_${locale.value}`, `components_${locale.value}`] as const;
+});
 </script>
 
 <template>
   <!-- this file is needed so we can dynamically exclude auth-only content from the search if the user is NOT logged in -->
-  <GlobalSearch :options="loggedIn ? undefined : { ignoredTags: ['auth-only'] }" />
+  <GlobalSearch :options="loggedIn ? undefined : { ignoredTags: ['auth-only'] }" :collections />
 </template>

--- a/apps/showcase/app/components/content/ComponentExample.vue
+++ b/apps/showcase/app/components/content/ComponentExample.vue
@@ -129,7 +129,7 @@ const options = ref<ComponentExampleOptions>({});
       max-width: 24rem;
     }
 
-    > :first-child:only-child {
+    > :where(:first-child:only-child) {
       flex-grow: 1;
     }
   }

--- a/apps/showcase/app/components/content/ComponentExample.vue
+++ b/apps/showcase/app/components/content/ComponentExample.vue
@@ -66,6 +66,9 @@ const { data: exampleCode } = await useAsyncData(
 );
 
 const options = ref<ComponentExampleOptions>({});
+
+defineOptions({ inheritAttrs: false });
+const attrs = useAttrs();
 </script>
 
 <template>
@@ -74,6 +77,7 @@ const options = ref<ComponentExampleOptions>({});
       <OnyxTab :label="$t('components.preview')" value="preview" density="compact">
         <OnyxCard class="example__preview" :style="{ colorScheme: options.colorScheme }">
           <div
+            v-bind="attrs"
             :class="[
               'example__preview-wrapper',
               { [`onyx-density-${options.density}`]: options.density },
@@ -124,6 +128,10 @@ const options = ref<ComponentExampleOptions>({});
     align-items: center;
     justify-content: center;
     width: 100%;
+
+    // this "useless" transform is used to position fixed components (e.g. OnyxFAB) relative to the preview wrapper
+    // instead of relative to the whole screen
+    transform: translate(0, 0);
 
     &:has(> :first-child:only-child) {
       max-width: 24rem;

--- a/apps/showcase/app/components/content/ComponentExample.vue
+++ b/apps/showcase/app/components/content/ComponentExample.vue
@@ -128,10 +128,6 @@ const options = ref<ComponentExampleOptions>({});
     &:has(> :first-child:only-child) {
       max-width: 24rem;
     }
-
-    > :where(:first-child:only-child) {
-      flex-grow: 1;
-    }
   }
 
   :deep(.example__code) {

--- a/apps/showcase/app/layouts/components.vue
+++ b/apps/showcase/app/layouts/components.vue
@@ -10,6 +10,7 @@ const { locale } = useI18n();
 
 const { navigation } = await useSidebarNavigation({
   collection: computed(() => `components_${locale.value}` as const),
+  fields: ["status"],
 });
 </script>
 
@@ -24,8 +25,14 @@ const { navigation } = await useSidebarNavigation({
           }"
         />
 
-        <!-- TODO: add custom content like tags for new, unstable etc. -->
-        <NestableSidebarItem v-for="item in navigation" :key="item.path" :item />
+        <NestableSidebarItem v-for="item in navigation" :key="item.path" :item>
+          <template #trailing="{ item: currentItem }">
+            <ComponentStatusTag
+              v-if="currentItem.fields?.status"
+              :status="currentItem.fields.status"
+            />
+          </template>
+        </NestableSidebarItem>
       </OnyxSidebar>
     </template>
 

--- a/apps/showcase/app/pages/components/[category]/[name].vue
+++ b/apps/showcase/app/pages/components/[category]/[name].vue
@@ -17,7 +17,10 @@ const activeTab = useRouteQuery("tab", "overview");
     :toc="data.body.toc?.links ?? []"
     :hidden="activeTab !== 'overview'"
   >
-    <ProseH1>{{ data.title }}</ProseH1>
+    <div class="headline">
+      <OnyxHeadline is="h1">{{ data.title }}</OnyxHeadline>
+      <ComponentStatusTag v-if="data.status" :status="data.status" />
+    </div>
 
     <OnyxTabs v-model="activeTab" :label="$t('components.details')">
       <OnyxTab :label="$t('components.overview')" value="overview">
@@ -30,3 +33,13 @@ const activeTab = useRouteQuery("tab", "overview");
     </OnyxTabs>
   </TableOfContentsLayout>
 </template>
+
+<style lang="scss" scoped>
+.headline {
+  margin-bottom: var(--onyx-density-lg);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--onyx-density-md);
+}
+</style>

--- a/apps/showcase/content.config.ts
+++ b/apps/showcase/content.config.ts
@@ -26,6 +26,7 @@ export default defineContentConfig({
       source: { include: "en/components/**", exclude: ["**/*.vue"], prefix: "/components" },
       schema: z.object({
         componentName: z.string(),
+        status: z.enum(["new"]).optional(),
       }),
     }),
   },

--- a/apps/showcase/content/en/components/01.buttons/button/examples/Danger.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/button/examples/Danger.example.vue
@@ -1,9 +1,13 @@
 <script lang="ts" setup>
 import { OnyxButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxButton label="Default" color="danger" />
-  <OnyxButton label="Outline" color="danger" mode="outline" />
-  <OnyxButton label="Plain" color="danger" mode="plain" />
+  <OnyxButton label="Default" color="danger" @click="handleClick" />
+  <OnyxButton label="Outline" color="danger" mode="outline" @click="handleClick" />
+  <OnyxButton label="Plain" color="danger" mode="plain" @click="handleClick" />
 </template>

--- a/apps/showcase/content/en/components/01.buttons/button/examples/Disabled.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/button/examples/Disabled.example.vue
@@ -1,0 +1,9 @@
+<script lang="ts" setup>
+import { OnyxButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxButton label="Default" disabled />
+  <OnyxButton label="Neutral" color="neutral" disabled />
+  <OnyxButton label="Danger" color="danger" disabled />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/button/examples/Icons.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/button/examples/Icons.example.vue
@@ -1,9 +1,18 @@
 <script lang="ts" setup>
 import { iconPlaceholder } from "@sit-onyx/icons";
 import { OnyxButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxButton label="Left icon" :icon="iconPlaceholder" />
-  <OnyxButton label="Right icon" :icon="iconPlaceholder" icon-position="right" />
+  <OnyxButton label="Left icon" :icon="iconPlaceholder" @click="handleClick" />
+  <OnyxButton
+    label="Right icon"
+    :icon="iconPlaceholder"
+    icon-position="right"
+    @click="handleClick"
+  />
 </template>

--- a/apps/showcase/content/en/components/01.buttons/button/examples/Neutral.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/button/examples/Neutral.example.vue
@@ -1,9 +1,13 @@
 <script lang="ts" setup>
 import { OnyxButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxButton label="Default" color="neutral" />
-  <OnyxButton label="Outline" color="neutral" mode="outline" />
-  <OnyxButton label="Plain" color="neutral" mode="plain" />
+  <OnyxButton label="Default" color="neutral" @click="handleClick" />
+  <OnyxButton label="Outline" color="neutral" mode="outline" @click="handleClick" />
+  <OnyxButton label="Plain" color="neutral" mode="plain" @click="handleClick" />
 </template>

--- a/apps/showcase/content/en/components/01.buttons/button/examples/Primary.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/button/examples/Primary.example.vue
@@ -1,9 +1,13 @@
 <script lang="ts" setup>
 import { OnyxButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxButton label="Default" />
-  <OnyxButton label="Outline" mode="outline" />
-  <OnyxButton label="Plain" mode="plain" />
+  <OnyxButton label="Default" @click="handleClick" />
+  <OnyxButton label="Outline" mode="outline" @click="handleClick" />
+  <OnyxButton label="Plain" mode="plain" @click="handleClick" />
 </template>

--- a/apps/showcase/content/en/components/01.buttons/button/index.md
+++ b/apps/showcase/content/en/components/01.buttons/button/index.md
@@ -36,3 +36,14 @@ An optional icon can be placed on either the left or the right side of the label
 The loading state is used after a user interaction to indicate that the triggered action is currently loading / in progress. On the other hand, the skeleton should be used on initial page load when the data for the page / button is initially loaded.
 
 :component-example{name="Loading"}
+
+### Disabled
+
+Buttons can be disabled to indicate that their actions is currently not available and the button can not be clicked.
+For an improved user experience, it should be clear to the user _why_ the button is disabled.
+
+::info-card{headline="Submit buttons in forms"}
+Please not that we do **NOT recommend** to disable "Submit" buttons in forms since this breaks our default form validation behavior where validation is automatically triggered for each form element used inside the form and error messages are displayed correspondingly. For further information, please refer to our [form](/components/form-elements/form) component.
+::
+
+:component-example{name="Disabled"}

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/Basic.example.vue
@@ -1,0 +1,8 @@
+<script lang="ts" setup>
+import { iconArrowSmallUp } from "@sit-onyx/icons";
+import { OnyxFAB } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxFAB label="Back to top" :icon="iconArrowSmallUp" />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/Basic.example.vue
@@ -1,8 +1,12 @@
 <script lang="ts" setup>
 import { iconArrowSmallUp } from "@sit-onyx/icons";
 import { OnyxFAB } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxFAB label="Back to top" :icon="iconArrowSmallUp" />
+  <OnyxFAB label="Back to top" :icon="iconArrowSmallUp" @click="handleClick" />
 </template>

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/GlobalFAB.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/GlobalFAB.example.vue
@@ -1,0 +1,26 @@
+<script lang="ts" setup>
+import { iconPlaceholder, iconPlus, iconX } from "@sit-onyx/icons";
+import { OnyxButton, useGlobalFAB } from "sit-onyx";
+
+const globalFAB = useGlobalFAB();
+
+const addFAB = () => {
+  const newId = globalFAB.items.value.length + 1;
+
+  globalFAB.add({
+    id: newId,
+    label: `Option ${newId}`,
+    icon: iconPlaceholder,
+  });
+};
+
+const removeFAB = () => {
+  const lastId = globalFAB.items.value.at(-1)?.value.id;
+  if (lastId !== undefined) globalFAB.remove(lastId);
+};
+</script>
+
+<template>
+  <OnyxButton label="Add FAB" :icon="iconPlus" @click="addFAB" />
+  <OnyxButton label="Remove FAB" :icon="iconX" @click="removeFAB" />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/Icon.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/Icon.example.vue
@@ -1,8 +1,12 @@
 <script lang="ts" setup>
 import { iconPlaceholder } from "@sit-onyx/icons";
 import { OnyxFAB } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxFAB label="Example label" :icon="iconPlaceholder" hide-label />
+  <OnyxFAB label="Example label" :icon="iconPlaceholder" hide-label @click="handleClick" />
 </template>

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/Icon.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/Icon.example.vue
@@ -1,0 +1,8 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxFAB } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxFAB label="Example label" :icon="iconPlaceholder" hide-label />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/Offset.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/Offset.example.vue
@@ -1,10 +1,20 @@
 <script lang="ts" setup>
 import { iconPlaceholder } from "@sit-onyx/icons";
 import { OnyxFAB } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxFAB class="fab" label="Example label" :icon="iconPlaceholder" hide-label />
+  <OnyxFAB
+    class="fab"
+    label="Example label"
+    :icon="iconPlaceholder"
+    hide-label
+    @click="handleClick"
+  />
 </template>
 
 <style lang="scss" scoped>

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/Offset.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/Offset.example.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxFAB } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxFAB class="fab" label="Example label" :icon="iconPlaceholder" hide-label />
+</template>
+
+<style lang="scss" scoped>
+.fab {
+  --onyx-fab-offset-x: 5rem;
+  --onyx-fab-offset-y: 1rem;
+}
+</style>

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/Options.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/Options.example.vue
@@ -1,12 +1,16 @@
 <script lang="ts" setup>
 import { iconPlaceholder } from "@sit-onyx/icons";
 import { OnyxFAB, OnyxFABItem } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
   <OnyxFAB label="Example label" :icon="iconPlaceholder" hide-label>
-    <OnyxFABItem label="Action 3" :icon="iconPlaceholder" />
-    <OnyxFABItem label="Action 2" :icon="iconPlaceholder" />
-    <OnyxFABItem label="Action 1" :icon="iconPlaceholder" />
+    <OnyxFABItem label="Action 3" :icon="iconPlaceholder" @click="handleClick" />
+    <OnyxFABItem label="Action 2" :icon="iconPlaceholder" @click="handleClick" />
+    <OnyxFABItem label="Action 1" :icon="iconPlaceholder" @click="handleClick" />
   </OnyxFAB>
 </template>

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/Options.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/Options.example.vue
@@ -1,0 +1,12 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxFAB, OnyxFABItem } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxFAB label="Example label" :icon="iconPlaceholder" hide-label>
+    <OnyxFABItem label="Action 3" :icon="iconPlaceholder" />
+    <OnyxFABItem label="Action 2" :icon="iconPlaceholder" />
+    <OnyxFABItem label="Action 1" :icon="iconPlaceholder" />
+  </OnyxFAB>
+</template>

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/Right.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/Right.example.vue
@@ -1,8 +1,18 @@
 <script lang="ts" setup>
 import { iconPlaceholder } from "@sit-onyx/icons";
 import { OnyxFAB } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxFAB label="Example label" :icon="iconPlaceholder" alignment="left" hide-label />
+  <OnyxFAB
+    label="Example label"
+    :icon="iconPlaceholder"
+    alignment="left"
+    hide-label
+    @click="handleClick"
+  />
 </template>

--- a/apps/showcase/content/en/components/01.buttons/fab/examples/Right.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/fab/examples/Right.example.vue
@@ -1,0 +1,8 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxFAB } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxFAB label="Example label" :icon="iconPlaceholder" alignment="left" hide-label />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/fab/index.md
+++ b/apps/showcase/content/en/components/01.buttons/fab/index.md
@@ -1,0 +1,68 @@
+---
+title: Floating action button
+componentName: OnyxFAB
+---
+
+A floating action button (FAB) is a fixed/sticky action button that appears at the bottom corner of a screen.
+
+## Examples
+
+### Basic
+
+The FAB supports text and icons.
+
+:component-example{name="Basic" style="height: 5rem"}
+
+### Icon only
+
+While the label is technically required for accessibility reasons, it can visually be hidden to achieve a icon-only FAB.
+
+:component-example{name="Icon" style="height: 5rem"}
+
+### Left aligned
+
+While the FAB is left aligned by default, it can optionally be right aligned.
+
+:component-example{name="Right" style="height: 5rem"}
+
+### Multiple actions
+
+Multiple actions can be added. The main button will then automatically switch to a flyout trigger so clicking it will toggle the actions.
+
+:component-example{name="Options" style="height: 5rem"}
+
+### Custom offset
+
+Depending on the use case, it might be necessary to position the FAB with an horizontal/vertical offset to e.g. align with custom sidebars or components.
+Use the `--onyx-fab-offset-x` and `--onyx-fab-offset-y` CSS variables for this, they will automatically be applied correctly depending on whether the FAB is left or right aligned.
+
+:component-example{name="Offset" style="height: 6rem"}
+
+### Global FAB
+
+In your application, you might need to show multiple FABs from within different pages / components. We support a universal `useGlobalFAB()` composable for this so you can easily add/remove FABs from anywhere in your application and have them displayed automatically.
+
+<prose-details>
+<prose-summary>Show prerequisites / manual setup</prose-summary>
+
+::info-card{headline="App layout"}
+If you are using the [app layout](/components/layouts/app-layout) component you can skip these manual steps since everything will already be set up automatically.
+::
+
+Otherwise, add the `OnyxGlobalFAB` component once to the root of your application. It will take care of displaying the global FABs correctly.
+
+```vue [Register global FAB]
+<script lang="ts" setup>
+import { OnyxGlobalFAB } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxGlobalFAB />
+</template>
+```
+
+</prose-details>
+
+The FABs for this example are shown at the bottom right if your screen.
+
+:component-example{name="GlobalFAB" style="height: 6rem"}

--- a/apps/showcase/content/en/components/01.buttons/icon-button/examples/Colors.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/icon-button/examples/Colors.example.vue
@@ -1,10 +1,14 @@
 <script lang="ts" setup>
 import { iconDisc, iconTrash, iconX } from "@sit-onyx/icons";
 import { OnyxIconButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxIconButton label="Save" :icon="iconDisc" />
-  <OnyxIconButton label="Cancel" :icon="iconX" color="neutral" />
-  <OnyxIconButton label="Delete" :icon="iconTrash" color="danger" />
+  <OnyxIconButton label="Save" :icon="iconDisc" @click="handleClick" />
+  <OnyxIconButton label="Cancel" :icon="iconX" color="neutral" @click="handleClick" />
+  <OnyxIconButton label="Delete" :icon="iconTrash" color="danger" @click="handleClick" />
 </template>

--- a/apps/showcase/content/en/components/01.buttons/icon-button/examples/Colors.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/icon-button/examples/Colors.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { iconDisc, iconTrash, iconX } from "@sit-onyx/icons";
+import { OnyxIconButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxIconButton label="Save" :icon="iconDisc" />
+  <OnyxIconButton label="Cancel" :icon="iconX" color="neutral" />
+  <OnyxIconButton label="Delete" :icon="iconTrash" color="danger" />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/icon-button/examples/Disabled.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/icon-button/examples/Disabled.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { iconDisc, iconTrash, iconX } from "@sit-onyx/icons";
+import { OnyxIconButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxIconButton label="Save" :icon="iconDisc" disabled />
+  <OnyxIconButton label="Cancel" :icon="iconX" color="neutral" disabled />
+  <OnyxIconButton label="Delete" :icon="iconTrash" color="danger" disabled />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/icon-button/examples/Loading.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/icon-button/examples/Loading.example.vue
@@ -1,0 +1,9 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxIconButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxIconButton label="Loading" :icon="iconPlaceholder" loading />
+  <OnyxIconButton label="Skeleton" :icon="iconPlaceholder" skeleton />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/icon-button/index.md
+++ b/apps/showcase/content/en/components/01.buttons/icon-button/index.md
@@ -1,0 +1,20 @@
+---
+title: Icon button
+componentName: OnyxIconButton
+---
+
+An icon button serves as a compact, label-free version of a traditional [button](/components/buttons/button), used to trigger both primary and secondary actions. It’s a key interactive element, letting users engage quickly with content.
+
+## Examples
+
+### Colors
+
+The icon button supports the same colors as the regular button. For further information on when to use which colors, please refer to the [button documentation](/components/buttons/button).
+
+:component-example{name="Colors"}
+
+### Loading & Skeleton
+
+The loading state is used after a user interaction to indicate that the triggered action is currently loading / in progress. On the other hand, the skeleton should be used on initial page load when the data for the page / button is initially loaded.
+
+:component-example{name="Loading"}

--- a/apps/showcase/content/en/components/01.buttons/icon-button/index.md
+++ b/apps/showcase/content/en/components/01.buttons/icon-button/index.md
@@ -18,3 +18,10 @@ The icon button supports the same colors as the regular button. For further info
 The loading state is used after a user interaction to indicate that the triggered action is currently loading / in progress. On the other hand, the skeleton should be used on initial page load when the data for the page / button is initially loaded.
 
 :component-example{name="Loading"}
+
+### Disabled
+
+The icon button can be disabled to indicate that its associated action is currently not available.
+For an improved user experience, it should be clear to the user _why_ the icon button is disabled.
+
+:component-example{name="Disabled"}

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Danger.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Danger.example.vue
@@ -1,30 +1,34 @@
 <script lang="ts" setup>
 import { iconPlaceholder } from "@sit-onyx/icons";
 import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxSplitButton label="Default" color="danger">
+  <OnyxSplitButton label="Default" color="danger" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 
-  <OnyxSplitButton label="Outline" color="danger" mode="outline">
+  <OnyxSplitButton label="Outline" color="danger" mode="outline" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 
-  <OnyxSplitButton label="Danger" color="danger" mode="plain">
+  <OnyxSplitButton label="Danger" color="danger" mode="plain" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 </template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Danger.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Danger.example.vue
@@ -1,0 +1,30 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSplitButton label="Default" color="danger">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+
+  <OnyxSplitButton label="Outline" color="danger" mode="outline">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+
+  <OnyxSplitButton label="Danger" color="danger" mode="plain">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+</template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Hover.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Hover.example.vue
@@ -1,14 +1,18 @@
 <script lang="ts" setup>
 import { iconPlaceholder } from "@sit-onyx/icons";
 import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxSplitButton label="Example button" trigger="hover">
+  <OnyxSplitButton label="Example button" trigger="hover" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 </template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Hover.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Hover.example.vue
@@ -1,0 +1,14 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSplitButton label="Example button" trigger="hover">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+</template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Icons.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Icons.example.vue
@@ -1,22 +1,31 @@
 <script lang="ts" setup>
 import { iconPlaceholder } from "@sit-onyx/icons";
 import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxSplitButton label="Left icon" :icon="iconPlaceholder">
+  <OnyxSplitButton label="Left icon" :icon="iconPlaceholder" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 
-  <OnyxSplitButton label="Right icon" :icon="iconPlaceholder" icon-position="right">
+  <OnyxSplitButton
+    label="Right icon"
+    :icon="iconPlaceholder"
+    icon-position="right"
+    @click="handleClick"
+  >
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 </template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Icons.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Icons.example.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSplitButton label="Left icon" :icon="iconPlaceholder">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+
+  <OnyxSplitButton label="Right icon" :icon="iconPlaceholder" icon-position="right">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+</template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Loading.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Loading.example.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSplitButton label="Example button" loading>
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+
+  <OnyxSplitButton label="Example button" skeleton>
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+</template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Neutral.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Neutral.example.vue
@@ -1,0 +1,30 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSplitButton label="Default" color="neutral">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+
+  <OnyxSplitButton label="Outline" color="neutral" mode="outline">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+
+  <OnyxSplitButton label="Plain" color="neutral" mode="plain">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+</template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Neutral.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Neutral.example.vue
@@ -1,30 +1,34 @@
 <script lang="ts" setup>
 import { iconPlaceholder } from "@sit-onyx/icons";
 import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxSplitButton label="Default" color="neutral">
+  <OnyxSplitButton label="Default" color="neutral" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 
-  <OnyxSplitButton label="Outline" color="neutral" mode="outline">
+  <OnyxSplitButton label="Outline" color="neutral" mode="outline" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 
-  <OnyxSplitButton label="Plain" color="neutral" mode="plain">
+  <OnyxSplitButton label="Plain" color="neutral" mode="plain" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 </template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Primary.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Primary.example.vue
@@ -1,30 +1,34 @@
 <script lang="ts" setup>
 import { iconPlaceholder } from "@sit-onyx/icons";
 import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxSplitButton label="Default">
+  <OnyxSplitButton label="Default" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 
-  <OnyxSplitButton label="Outline" mode="outline">
+  <OnyxSplitButton label="Outline" mode="outline" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 
-  <OnyxSplitButton label="Plain" mode="plain">
+  <OnyxSplitButton label="Plain" mode="plain" @click="handleClick">
     <template #options>
-      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
-      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" @click="handleClick" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" @click="handleClick" />
     </template>
   </OnyxSplitButton>
 </template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/examples/Primary.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/split-button/examples/Primary.example.vue
@@ -1,0 +1,30 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxMenuItem, OnyxSplitButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSplitButton label="Default">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+
+  <OnyxSplitButton label="Outline" mode="outline">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+
+  <OnyxSplitButton label="Plain" mode="plain">
+    <template #options>
+      <OnyxMenuItem label="Option 1" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 2" :icon="iconPlaceholder" />
+      <OnyxMenuItem label="Option 3" :icon="iconPlaceholder" />
+    </template>
+  </OnyxSplitButton>
+</template>

--- a/apps/showcase/content/en/components/01.buttons/split-button/index.md
+++ b/apps/showcase/content/en/components/01.buttons/split-button/index.md
@@ -1,6 +1,7 @@
 ---
 title: Split button
 componentName: OnyxSplitButton
+status: new
 ---
 
 The split button is used to have multiple actions alongside a group of similar actions. The main action will be displayed on the left and will be triggered immediately after clicking. On the right side and behind an arrow icon, there are multiple additional actions which can be individual or can extend the functionality of the main action.

--- a/apps/showcase/content/en/components/01.buttons/split-button/index.md
+++ b/apps/showcase/content/en/components/01.buttons/split-button/index.md
@@ -1,0 +1,48 @@
+---
+title: Split button
+componentName: OnyxSplitButton
+---
+
+The split button is used to have multiple actions alongside a group of similar actions. The main action will be displayed on the left and will be triggered immediately after clicking. On the right side and behind an arrow icon, there are multiple additional actions which can be individual or can extend the functionality of the main action.
+
+The split button supports the same styles as the regular [button](/components/buttons/button) but extends the button with additional actions.
+
+## Examples
+
+### Primary
+
+See the [button](/components/buttons/button#primary) documentation for when to use primary buttons.
+
+:component-example{name="Primary"}
+
+### Neutral
+
+See the [button](/components/buttons/button#neutral) documentation for when to use neutral buttons.
+
+:component-example{name="Neutral"}
+
+### Danger
+
+See the [button](/components/buttons/button#danger) documentation for when to use danger buttons.
+
+:component-example{name="Danger"}
+
+### Icons
+
+An optional icon can be placed on either the left or the right side of the label.
+
+:component-example{name="Icons"}
+
+### Loading & Skeleton
+
+The loading state is used after a user interaction to indicate that the triggered action is currently loading / in progress. While loading, the additional actions are unavailable.
+
+On the other hand, the skeleton should be used on initial page load when the data for the page / button is initially loaded.
+
+:component-example{name="Loading"}
+
+### Hover
+
+By default, the additional actions are opened on click but you can configure them to optionally show of hover instead.
+
+:component-example{name="Hover"}

--- a/apps/showcase/content/en/components/01.buttons/system-button/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/system-button/examples/Basic.example.vue
@@ -1,0 +1,9 @@
+<script lang="ts" setup>
+import { iconMoreVertical } from "@sit-onyx/icons";
+import { OnyxSystemButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSystemButton label="Example label" :icon="iconMoreVertical" />
+  <OnyxSystemButton label="Example label" />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/system-button/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/system-button/examples/Basic.example.vue
@@ -1,9 +1,13 @@
 <script lang="ts" setup>
 import { iconMoreVertical } from "@sit-onyx/icons";
 import { OnyxSystemButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxSystemButton label="Example label" :icon="iconMoreVertical" />
-  <OnyxSystemButton label="Example label" />
+  <OnyxSystemButton label="Example label" :icon="iconMoreVertical" @click="handleClick" />
+  <OnyxSystemButton label="Example label" @click="handleClick" />
 </template>

--- a/apps/showcase/content/en/components/01.buttons/system-button/examples/Colors.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/system-button/examples/Colors.example.vue
@@ -1,0 +1,9 @@
+<script lang="ts" setup>
+import { OnyxSystemButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSystemButton label="Intense" />
+  <OnyxSystemButton label="Medium" color="medium" />
+  <OnyxSystemButton label="Soft" color="soft" />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/system-button/examples/Colors.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/system-button/examples/Colors.example.vue
@@ -1,9 +1,13 @@
 <script lang="ts" setup>
 import { OnyxSystemButton } from "sit-onyx";
+
+const handleClick = () => {
+  // your logic here...
+};
 </script>
 
 <template>
-  <OnyxSystemButton label="Intense" />
-  <OnyxSystemButton label="Medium" color="medium" />
-  <OnyxSystemButton label="Soft" color="soft" />
+  <OnyxSystemButton label="Intense" @click="handleClick" />
+  <OnyxSystemButton label="Medium" color="medium" @click="handleClick" />
+  <OnyxSystemButton label="Soft" color="soft" @click="handleClick" />
 </template>

--- a/apps/showcase/content/en/components/01.buttons/system-button/examples/Context.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/system-button/examples/Context.example.vue
@@ -21,6 +21,5 @@ const clipboard = useClipboard({ source: email });
   display: flex;
   align-items: center;
   gap: var(--onyx-density-xs);
-  flex-grow: 0;
 }
 </style>

--- a/apps/showcase/content/en/components/01.buttons/system-button/examples/Context.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/system-button/examples/Context.example.vue
@@ -1,0 +1,26 @@
+<script lang="ts" setup>
+import { iconCheckSmall, iconFileCopy } from "@sit-onyx/icons";
+import { useClipboard } from "@vueuse/core";
+import { OnyxIcon, OnyxLink, OnyxSystemButton } from "sit-onyx";
+
+const email = "jane.doe@example.com";
+const clipboard = useClipboard({ source: email });
+</script>
+
+<template>
+  <div class="example">
+    <OnyxLink :href="`mailto:${email}`">{{ email }}</OnyxLink>
+
+    <OnyxIcon v-if="clipboard.copied.value" :icon="iconCheckSmall" color="success" />
+    <OnyxSystemButton v-else label="Copy email" :icon="iconFileCopy" @click="clipboard.copy()" />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.example {
+  display: flex;
+  align-items: center;
+  gap: var(--onyx-density-xs);
+  flex-grow: 0;
+}
+</style>

--- a/apps/showcase/content/en/components/01.buttons/system-button/examples/Disabled.example.vue
+++ b/apps/showcase/content/en/components/01.buttons/system-button/examples/Disabled.example.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import { OnyxSystemButton } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSystemButton label="Disabled system button" disabled />
+</template>

--- a/apps/showcase/content/en/components/01.buttons/system-button/index.md
+++ b/apps/showcase/content/en/components/01.buttons/system-button/index.md
@@ -1,0 +1,35 @@
+---
+title: System button
+componentName: OnyxSystemButton
+---
+
+The system button triggers interactions exclusively for a parent container - not for standalone actions / content - and is therefore smaller than regular buttons. For standalone usage, please prefer the regular [button](/components/buttons/button) or [icon button](/components/buttons/icon-button) instead.
+
+It is commonly used for context menus, e.g. in combination with the [flyout menu](/components/basic/flyout-menu).
+
+## Examples
+
+### Basic
+
+The system button is supported in two variants: Text or icon. A combination of both is not supported.
+
+:component-example{name="Basic"}
+
+### Colors
+
+Different colors can be used, depending on the parent background to provide a good color contrast.
+
+:component-example{name="Colors"}
+
+### Disabled
+
+The system button can be disabled to indicate that its associated action is currently not available.
+For an improved user experience, it should be clear to the user _why_ the icon button is disabled.
+
+:component-example{name="Disabled"}
+
+### Context
+
+The system button is intended to always be used as child component related to a parent to provide additional actions like copying a value, opening a link or showing a context menu.
+
+:component-example{name="Context"}

--- a/apps/showcase/i18n/locales/en-US.json
+++ b/apps/showcase/i18n/locales/en-US.json
@@ -39,6 +39,9 @@
         "light": "light",
         "dark": "dark"
       }
+    },
+    "status": {
+      "new": "New"
     }
   },
   "gettingStarted": "Getting Started",

--- a/packages/nuxt-docs/app/components/GlobalSearch.vue
+++ b/packages/nuxt-docs/app/components/GlobalSearch.vue
@@ -21,6 +21,12 @@ const props = defineProps<{
    * @see https://content.nuxt.com/docs/utils/query-collection-search-sections#api
    */
   options?: Parameters<typeof queryCollectionSearchSections>[1];
+  /**
+   * List of collections to include in the search.
+   *
+   * @default "content_{locale}" where `{locale}` is replaced with the current i18n locale.
+   */
+  collections?: (keyof Collections)[];
 }>();
 
 const { t, locale, locales } = useI18n();
@@ -32,11 +38,21 @@ watch(isOpen, (open) => {
   if (!open) searchTerm.value = "";
 });
 
+const collections = computed<(keyof Collections)[]>(() => {
+  if (props.collections) return props.collections;
+  return [`content_${locale.value}` as keyof Collections];
+});
+
 const { data, status } = await useLazyAsyncData(
-  () => `search-sections-${locale.value}-${props.options}`,
-  () => {
-    const collection = `content_${locale.value}` as keyof Collections;
-    return queryCollectionSearchSections(collection, props.options);
+  () => `search-sections-${collections.value.join("-")}-${props.options}`,
+  async () => {
+    const sections = await Promise.all(
+      collections.value.map((collection) => {
+        return queryCollectionSearchSections(collection, props.options);
+      }),
+    );
+
+    return sections.flatMap((section) => section);
   },
 );
 

--- a/packages/nuxt-docs/app/components/NestableSidebarItem.vue
+++ b/packages/nuxt-docs/app/components/NestableSidebarItem.vue
@@ -1,9 +1,16 @@
-<script lang="ts" setup>
+<script lang="ts" setup generic="TItem extends SidebarNavigationItem">
 import type { SidebarNavigationItem } from "../composables/useSidebarNavigation.js";
 import type { SidebarItemProps } from "./SidebarItem.vue";
 
 const props = defineProps<{
-  item: SidebarNavigationItem;
+  item: TItem;
+}>();
+
+const slots = defineSlots<{
+  /**
+   * Additional trailing content to display on the right.
+   */
+  trailing?(props: { item: TItem }): unknown;
 }>();
 
 const route = useRoute();
@@ -54,7 +61,11 @@ const { icon } = useIcon(computed(() => props.item.icon));
     v-if="!props.item.children?.length"
     class="sidebar-item"
     v-bind="getSidebarItemProps(props.item)"
-  />
+  >
+    <template v-if="slots.trailing" #trailing>
+      <slot name="trailing" :item="props.item"></slot>
+    </template>
+  </SidebarItem>
 
   <OnyxAccordion
     v-else
@@ -83,7 +94,11 @@ const { icon } = useIcon(computed(() => props.item.icon));
           :show-arrow="
             getSidebarItemProps(child).showArrow || getSidebarItemProps(props.item).showArrow
           "
-        />
+        >
+          <template v-if="slots.trailing" #trailing>
+            <slot name="trailing" :item="child as TItem"></slot>
+          </template>
+        </SidebarItem>
       </div>
     </OnyxAccordionItem>
   </OnyxAccordion>

--- a/packages/nuxt-docs/app/components/SidebarItem.vue
+++ b/packages/nuxt-docs/app/components/SidebarItem.vue
@@ -15,19 +15,47 @@ export type SidebarItemProps = {
 
 const props = defineProps<SidebarItemProps>();
 
+const slots = defineSlots<{
+  /**
+   * Additional trailing content to display on the right.
+   */
+  trailing?(): unknown;
+}>();
+
 const { icon } = useIcon(computed(() => props.icon));
 </script>
 
 <template>
   <OnyxSidebarItem class="sidebar-item" :link="props.link">
-    <OnyxIcon v-if="icon" :icon />
-    {{ props.label }}
-    <OnyxIcon v-if="props.showArrow" :icon="iconArrowSmallRight" />
+    <div class="sidebar-item__content">
+      <OnyxIcon v-if="icon" :icon />
+      {{ props.label }}
+      <OnyxIcon v-if="props.showArrow" :icon="iconArrowSmallRight" />
+    </div>
+
+    <div v-if="slots.trailing" class="sidebar-item__trailing onyx-density-compact">
+      <slot name="trailing"></slot>
+    </div>
   </OnyxSidebarItem>
 </template>
 
 <style lang="scss" scoped>
 .sidebar-item {
   margin: var(--onyx-density-2xs) var(--onyx-density-xs);
+  flex-wrap: wrap;
+  justify-content: space-between;
+
+  &__content {
+    display: flex;
+    align-items: inherit;
+    gap: inherit;
+  }
+
+  &__trailing {
+    display: flex;
+    align-items: inherit;
+    gap: inherit;
+    flex-wrap: wrap;
+  }
 }
 </style>

--- a/packages/nuxt-docs/app/composables/useSidebarNavigation.ts
+++ b/packages/nuxt-docs/app/composables/useSidebarNavigation.ts
@@ -1,15 +1,19 @@
 import { computed, useAsyncData, useI18n, useLocalePath, useRoute } from "#imports"; // since nuxt 4.3 the auto-imports don't work for this composable anymore; Might be related to https://github.com/nuxt/nuxt/issues/22342
 import type { Collections, ContentNavigationItem } from "@nuxt/content";
 
-export type SidebarNavigationItem = {
+export type SidebarNavigationItem<TCollection extends keyof Collections = keyof Collections> = {
   title: string;
   /**
    * Item path. Already localized for i18n with `useLocalePath`.
    */
   path: string;
   icon?: string;
-  children?: SidebarNavigationItem[];
+  children?: SidebarNavigationItem<TCollection>[];
   sidebar?: SidebarNavigationOptions;
+  /**
+   * Additional fields. Must be defined when calling `useSidebarNavigation()`.
+   */
+  fields?: Partial<Collections[TCollection]>;
 };
 
 /**
@@ -34,24 +38,33 @@ export type SidebarNavigationOptions = {
   collapsed?: boolean;
 };
 
-export type UseSidebarNavigationOptions = {
-  /**
-   * Collection name to use for querying the navigation.
-   */
-  collection: Ref<keyof Collections>;
-};
+export type UseSidebarNavigationOptions<TCollection extends keyof Collections = keyof Collections> =
+  {
+    /**
+     * Collection name to use for querying the navigation.
+     */
+    collection: Ref<TCollection>;
+    /**
+     * Additional fields to include.
+     */
+    fields?: (keyof Collections[TCollection])[];
+  };
 
 /**
  * Composable for querying and mapping the navigation items for a given collection.
  */
-export const useSidebarNavigation = async (options: UseSidebarNavigationOptions) => {
+export const useSidebarNavigation = async <
+  TCollection extends keyof Collections = keyof Collections,
+>(
+  options: UseSidebarNavigationOptions<TCollection>,
+) => {
   const { locale } = useI18n();
   const localePath = useLocalePath();
   const route = useRoute();
 
   const { data } = await useAsyncData(
     () => `navigation-${options.collection.value}-${locale.value}`,
-    () => queryCollectionNavigation(options.collection.value),
+    () => queryCollectionNavigation(options.collection.value, options.fields),
     { default: () => [] },
   );
 
@@ -60,13 +73,23 @@ export const useSidebarNavigation = async (options: UseSidebarNavigationOptions)
    */
   const allItems = computed(() => {
     // map the items from "@nuxt/content" to our custom data scheme for better type support
-    const mapItem = (item: ContentNavigationItem): SidebarNavigationItem => {
+    const mapItem = (item: ContentNavigationItem): SidebarNavigationItem<TCollection> => {
+      const fields = options.fields?.reduce(
+        (obj, field) => {
+          const extraFieldValue = item[field as keyof typeof item];
+          obj[field] = extraFieldValue as Collections[TCollection][typeof field];
+          return obj;
+        },
+        {} as Collections[TCollection],
+      );
+
       return {
         title: item.title,
         path: localePath(item.path),
         children: item.children?.map(mapItem),
         sidebar: item.sidebar && typeof item.sidebar === "object" ? item.sidebar : undefined,
         icon: item.icon && typeof item.icon === "string" ? item.icon : undefined,
+        fields,
       };
     };
 
@@ -91,9 +114,9 @@ export const useSidebarNavigation = async (options: UseSidebarNavigationOptions)
    * that contains the `currentPath` within its subtree.
    */
   function findDeepestRoot(
-    items: SidebarNavigationItem[],
+    items: SidebarNavigationItem<TCollection>[],
     currentPath: string,
-  ): SidebarNavigationItem | undefined {
+  ): SidebarNavigationItem<TCollection> | undefined {
     /** Helper function to check if a path exists anywhere in a node's subtree */
     const containsPath = (node: SidebarNavigationItem, path: string): boolean => {
       if (node.path === path) return true;
@@ -125,10 +148,10 @@ export const useSidebarNavigation = async (options: UseSidebarNavigationOptions)
    * @param rootStack - (Internal) Accumulator for recursion
    */
   function findPreviousRootItem(
-    items: SidebarNavigationItem[],
+    items: SidebarNavigationItem<TCollection>[],
     currentPath: string,
-    rootStack: SidebarNavigationItem[] = [],
-  ): SidebarNavigationItem | undefined {
+    rootStack: SidebarNavigationItem<TCollection>[] = [],
+  ): SidebarNavigationItem<TCollection> | undefined {
     for (const item of items) {
       const isRoot = item.sidebar?.root === true;
 


### PR DESCRIPTION
Relates to #5493

Add showcase examples for button components:
- Button
- Icon button
- System button
- Split button
- Floating action button

Also fix the global search to include components in the search results (previously they were missing).

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
