### PR TITLE
docs(showcase): add input and date picker component examples

### DIFF
--- a/.changeset/lazy-impalas-shout.md
+++ b/.changeset/lazy-impalas-shout.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxDatePickerV2): correctly apply `multiView` property when defined as boolean shorthand

--- a/apps/showcase/app/components/ComponentExampleOptions.vue
+++ b/apps/showcase/app/components/ComponentExampleOptions.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { iconSettings } from "@sit-onyx/icons";
 import { DENSITIES, type Density } from "sit-onyx";
 
 export type ComponentExampleOptions = {
@@ -10,13 +11,18 @@ const options = defineModel<ComponentExampleOptions>({ default: () => ({}) });
 </script>
 
 <template>
-  <OnyxFlyoutMenu :label="$t('components.options.change')" drilldown-mode="external">
+  <OnyxFlyoutMenu
+    :label="$t('components.options.change')"
+    drilldown-mode="external"
+    trigger="click"
+  >
     <template #button="{ trigger }">
-      <OnyxButton
+      <OnyxIconButton
         v-bind="trigger"
         :label="$t('components.options.change')"
-        color="neutral"
+        :icon="iconSettings"
         density="compact"
+        color="neutral"
       />
     </template>
 

--- a/apps/showcase/app/components/ComponentExampleOptions.vue
+++ b/apps/showcase/app/components/ComponentExampleOptions.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { iconSettings } from "@sit-onyx/icons";
+import { iconMoreVerticalSmall } from "@sit-onyx/icons";
 import { DENSITIES, type Density } from "sit-onyx";
 
 export type ComponentExampleOptions = {
@@ -20,7 +20,7 @@ const options = defineModel<ComponentExampleOptions>({ default: () => ({}) });
       <OnyxIconButton
         v-bind="trigger"
         :label="$t('components.options.change')"
-        :icon="iconSettings"
+        :icon="iconMoreVerticalSmall"
         density="compact"
         color="neutral"
       />

--- a/apps/showcase/app/components/ComponentStatusTag.vue
+++ b/apps/showcase/app/components/ComponentStatusTag.vue
@@ -16,8 +16,8 @@ const tagProps = computed<Record<typeof props.status, OnyxTagProps>>(() => {
       color: "primary",
       icon: iconNew,
     },
-    beta: {
-      label: t("components.status.beta.label"),
+    experimental: {
+      label: t("components.status.experimental.label"),
       color: "info",
       icon: iconTestTube,
     },

--- a/apps/showcase/app/components/ComponentStatusTag.vue
+++ b/apps/showcase/app/components/ComponentStatusTag.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { ComponentsEnCollectionItem } from "@nuxt/content";
-import { iconNew, iconTestTube } from "@sit-onyx/icons";
+import { iconCircleAttention, iconNew, iconTestTube } from "@sit-onyx/icons";
 import type { OnyxTagProps } from "sit-onyx";
 
 const props = defineProps<{
@@ -20,6 +20,11 @@ const tagProps = computed<Record<typeof props.status, OnyxTagProps>>(() => {
       label: t("components.status.beta.label"),
       color: "info",
       icon: iconTestTube,
+    },
+    deprecated: {
+      label: t("components.status.deprecated.label"),
+      color: "danger",
+      icon: iconCircleAttention,
     },
   };
 });

--- a/apps/showcase/app/components/ComponentStatusTag.vue
+++ b/apps/showcase/app/components/ComponentStatusTag.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { ComponentsEnCollectionItem } from "@nuxt/content";
-import { iconNew } from "@sit-onyx/icons";
+import { iconNew, iconTestTube } from "@sit-onyx/icons";
 import type { OnyxTagProps } from "sit-onyx";
 
 const props = defineProps<{
@@ -15,6 +15,11 @@ const tagProps = computed<Record<typeof props.status, OnyxTagProps>>(() => {
       label: t("components.status.new"),
       color: "primary",
       icon: iconNew,
+    },
+    beta: {
+      label: t("components.status.beta.label"),
+      color: "info",
+      icon: iconTestTube,
     },
   };
 });

--- a/apps/showcase/app/components/content/ComponentExample.vue
+++ b/apps/showcase/app/components/content/ComponentExample.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { iconSync } from "@sit-onyx/icons";
+import { iconUndo } from "@sit-onyx/icons";
 import type { Component } from "vue";
 import type { ComponentExampleOptions } from "../ComponentExampleOptions.vue";
 
@@ -115,7 +115,7 @@ const attrs = useAttrs();
       <template #actions>
         <OnyxIconButton
           v-if="Object.keys(options).length > 0"
-          :icon="iconSync"
+          :icon="iconUndo"
           :label="$t('components.options.reset')"
           color="neutral"
           density="compact"

--- a/apps/showcase/app/components/content/ComponentExample.vue
+++ b/apps/showcase/app/components/content/ComponentExample.vue
@@ -11,13 +11,19 @@ const props = withDefaults(
     name: string;
     /**
      * Component preview layout.
-     * - default: Pre-defined Limited width (if only 1 child exists, fullWidth otherwise)
+     * - default: Pre-defined Limited width
      * - fullWidth: Full width
+     * - grow: Same as "default" but children use "flex-grow" to grow the available width
      */
-    layout?: "default" | "fullWidth";
+    layout?: "default" | "fullWidth" | "grow";
+    /**
+     * The orientation of the example if multiple components are used.
+     */
+    orientation?: "horizontal" | "vertical";
   }>(),
   {
     layout: "default",
+    orientation: "horizontal",
   },
 );
 
@@ -93,6 +99,7 @@ const attrs = useAttrs();
               'example__preview-wrapper',
               { [`onyx-density-${options.density}`]: options.density },
               { [`example__preview-wrapper--${props.layout}`]: props.layout },
+              { [`example__preview-wrapper--${props.orientation}`]: props.orientation },
             ]"
           >
             <ExampleComponent />
@@ -133,7 +140,7 @@ const attrs = useAttrs();
   }
 
   &__preview-wrapper {
-    --preview-max-width: initial;
+    --preview-max-width: 24rem;
     display: flex;
     flex-direction: row;
     gap: var(--onyx-density-md);
@@ -147,14 +154,24 @@ const attrs = useAttrs();
     // instead of relative to the whole screen
     transform: translate(0, 0);
 
-    &--default {
-      &:has(> :first-child:only-child) {
-        --preview-max-width: 24rem;
+    &--fullWidth {
+      --preview-max-width: initial;
+    }
+
+    &--grow {
+      > * {
+        flex: 1;
+      }
+
+      &.example__preview-wrapper--vertical {
+        > * {
+          width: 100%;
+        }
       }
     }
 
-    &--fullWidth {
-      --preview-max-width: initial;
+    &--vertical {
+      flex-direction: column;
     }
   }
 

--- a/apps/showcase/app/pages/components/[category]/[name].vue
+++ b/apps/showcase/app/pages/components/[category]/[name].vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { iconTestTube } from "@sit-onyx/icons";
+
 definePageMeta({ layout: "components" });
 
 const { locale } = useI18n();
@@ -17,29 +19,50 @@ const activeTab = useRouteQuery("tab", "overview");
     :toc="data.body.toc?.links ?? []"
     :hidden="activeTab !== 'overview'"
   >
-    <div class="headline">
-      <OnyxHeadline is="h1">{{ data.title }}</OnyxHeadline>
-      <ComponentStatusTag v-if="data.status" :status="data.status" />
+    <div class="content">
+      <div class="headline">
+        <OnyxHeadline is="h1">{{ data.title }}</OnyxHeadline>
+        <ComponentStatusTag v-if="data.status" :status="data.status" />
+      </div>
+
+      <OnyxInfoCard
+        v-if="data.status === 'beta'"
+        :headline="$t('components.status.beta.label')"
+        :icon="iconTestTube"
+      >
+        <i18n-t keypath="components.status.beta.description">
+          <template #changelog>
+            <OnyxLink href="/introduction/changelog">{{
+              $t("components.status.beta.changelog")
+            }}</OnyxLink>
+          </template>
+        </i18n-t>
+      </OnyxInfoCard>
+
+      <OnyxTabs v-model="activeTab" :label="$t('components.details')">
+        <OnyxTab :label="$t('components.overview')" value="overview">
+          <ContentRenderer :value="data" />
+        </OnyxTab>
+
+        <OnyxTab :label="$t('components.property', 2)" value="properties">
+          <ComponentMeta :component="data.componentName" />
+        </OnyxTab>
+      </OnyxTabs>
     </div>
-
-    <OnyxTabs v-model="activeTab" :label="$t('components.details')">
-      <OnyxTab :label="$t('components.overview')" value="overview">
-        <ContentRenderer :value="data" />
-      </OnyxTab>
-
-      <OnyxTab :label="$t('components.property', 2)" value="properties">
-        <ComponentMeta :component="data.componentName" />
-      </OnyxTab>
-    </OnyxTabs>
   </TableOfContentsLayout>
 </template>
 
 <style lang="scss" scoped>
 .headline {
-  margin-bottom: var(--onyx-density-lg);
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: var(--onyx-density-md);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--onyx-density-lg);
 }
 </style>

--- a/apps/showcase/app/pages/components/[category]/[name].vue
+++ b/apps/showcase/app/pages/components/[category]/[name].vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { iconTestTube } from "@sit-onyx/icons";
+import { iconCircleAttention, iconTestTube } from "@sit-onyx/icons";
 
 definePageMeta({ layout: "components" });
 
@@ -32,11 +32,20 @@ const activeTab = useRouteQuery("tab", "overview");
       >
         <i18n-t keypath="components.status.beta.description">
           <template #changelog>
-            <OnyxLink href="/introduction/changelog">{{
-              $t("components.status.beta.changelog")
-            }}</OnyxLink>
+            <OnyxLink href="/introduction/changelog">
+              {{ $t("components.status.beta.changelog") }}
+            </OnyxLink>
           </template>
         </i18n-t>
+      </OnyxInfoCard>
+
+      <OnyxInfoCard
+        v-else-if="data.status === 'deprecated'"
+        :headline="$t('components.status.deprecated.label')"
+        :icon="iconCircleAttention"
+        color="danger"
+      >
+        {{ $t("components.status.deprecated.description") }}
       </OnyxInfoCard>
 
       <OnyxTabs v-model="activeTab" :label="$t('components.details')">

--- a/apps/showcase/app/pages/components/[category]/[name].vue
+++ b/apps/showcase/app/pages/components/[category]/[name].vue
@@ -30,7 +30,7 @@ const activeTab = useRouteQuery("tab", "overview");
         :headline="$t('components.status.beta.label')"
         :icon="iconTestTube"
       >
-        <i18n-t keypath="components.status.beta.description">
+        <i18n-t keypath="components.status.beta.description" scope="global">
           <template #changelog>
             <OnyxLink href="/introduction/changelog">
               {{ $t("components.status.beta.changelog") }}

--- a/apps/showcase/app/pages/components/[category]/[name].vue
+++ b/apps/showcase/app/pages/components/[category]/[name].vue
@@ -26,14 +26,14 @@ const activeTab = useRouteQuery("tab", "overview");
       </div>
 
       <OnyxInfoCard
-        v-if="data.status === 'beta'"
-        :headline="$t('components.status.beta.label')"
+        v-if="data.status === 'experimental'"
+        :headline="$t('components.status.experimental.label')"
         :icon="iconTestTube"
       >
-        <i18n-t keypath="components.status.beta.description" scope="global">
+        <i18n-t keypath="components.status.experimental.description" scope="global">
           <template #changelog>
             <OnyxLink href="/introduction/changelog">
-              {{ $t("components.status.beta.changelog") }}
+              {{ $t("components.status.experimental.changelog") }}
             </OnyxLink>
           </template>
         </i18n-t>

--- a/apps/showcase/content.config.ts
+++ b/apps/showcase/content.config.ts
@@ -26,7 +26,7 @@ export default defineContentConfig({
       source: { include: "en/components/**", exclude: ["**/*.vue"], prefix: "/components" },
       schema: z.object({
         componentName: z.string(),
-        status: z.enum(["new", "beta"]).optional(),
+        status: z.enum(["new", "beta", "deprecated"]).optional(),
       }),
     }),
   },

--- a/apps/showcase/content.config.ts
+++ b/apps/showcase/content.config.ts
@@ -26,7 +26,7 @@ export default defineContentConfig({
       source: { include: "en/components/**", exclude: ["**/*.vue"], prefix: "/components" },
       schema: z.object({
         componentName: z.string(),
-        status: z.enum(["new"]).optional(),
+        status: z.enum(["new", "beta"]).optional(),
       }),
     }),
   },

--- a/apps/showcase/content.config.ts
+++ b/apps/showcase/content.config.ts
@@ -26,7 +26,7 @@ export default defineContentConfig({
       source: { include: "en/components/**", exclude: ["**/*.vue"], prefix: "/components" },
       schema: z.object({
         componentName: z.string(),
-        status: z.enum(["new", "beta", "deprecated"]).optional(),
+        status: z.enum(["new", "experimental", "deprecated"]).optional(),
       }),
     }),
   },

--- a/apps/showcase/content/en/components/01.buttons/button/index.md
+++ b/apps/showcase/content/en/components/01.buttons/button/index.md
@@ -42,8 +42,10 @@ The loading state is used after a user interaction to indicate that the triggere
 Buttons can be disabled to indicate that their actions is currently not available and the button can not be clicked.
 For an improved user experience, it should be clear to the user _why_ the button is disabled.
 
-::info-card{headline="Submit buttons in forms"}
+<div class="onyx-text--small" style="color: var(--onyx-color-text-icons-info-intense)">
+
 Please not that we do **NOT recommend** to disable "Submit" buttons in forms since this breaks our default form validation behavior where validation is automatically triggered for each form element used inside the form and error messages are displayed correspondingly. For further information, please refer to our [form](/components/form-elements/form) component.
-::
+
+</div>
 
 :component-example{name="Disabled"}

--- a/apps/showcase/content/en/components/01.buttons/fab/index.md
+++ b/apps/showcase/content/en/components/01.buttons/fab/index.md
@@ -9,7 +9,7 @@ A floating action button (FAB) is a fixed/sticky action button that appears at t
 
 ### Basic
 
-The FAB supports text and icons.
+The FAB supports text and icons. It is positioned in the bottom right corner of the screen by default. For demonstration purposes, the examples on this page are displayed in place.
 
 :component-example{name="Basic" style="height: 5rem"}
 
@@ -21,7 +21,7 @@ While the label is technically required for accessibility reasons, it can visual
 
 ### Left aligned
 
-While the FAB is left aligned by default, it can optionally be right aligned.
+While the FAB is right aligned by default, it can optionally be left aligned.
 
 :component-example{name="Right" style="height: 5rem"}
 
@@ -41,6 +41,10 @@ Use the `--onyx-fab-offset-x` and `--onyx-fab-offset-y` CSS variables for this, 
 ### Global FAB
 
 In your application, you might need to show multiple FABs from within different pages / components. We support a universal `useGlobalFAB()` composable for this so you can easily add/remove FABs from anywhere in your application and have them displayed automatically.
+
+The FABs for this example are shown at the bottom right of your screen.
+
+:component-example{name="GlobalFAB" style="height: 6rem"}
 
 <prose-details>
 <prose-summary>Show prerequisites / manual setup</prose-summary>
@@ -62,7 +66,3 @@ import { OnyxGlobalFAB } from "sit-onyx";
 ```
 
 </prose-details>
-
-The FABs for this example are shown at the bottom right if your screen.
-
-:component-example{name="GlobalFAB" style="height: 6rem"}

--- a/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/CalendarWeeks.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/CalendarWeeks.example.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import { DateRange, OnyxUnstableDatePickerV2 } from "sit-onyx";
+import { ref } from "vue";
+
+const range = ref<DateRange>();
+</script>
+
+<template>
+  <OnyxUnstableDatePickerV2
+    v-model="range"
+    label="Date"
+    selection-mode="range"
+    show-calendar-weeks
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/LabelPositions.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/LabelPositions.example.vue
@@ -1,0 +1,13 @@
+<script lang="ts" setup>
+import { OnyxUnstableDatePickerV2 } from "sit-onyx";
+import { ref } from "vue";
+
+const date = ref<Date>();
+</script>
+
+<template>
+  <OnyxUnstableDatePickerV2 v-model="date" label="Top" />
+  <OnyxUnstableDatePickerV2 v-model="date" :label="{ label: 'Left', position: 'left' }" />
+  <OnyxUnstableDatePickerV2 v-model="date" :label="{ label: 'Right', position: 'right' }" />
+  <OnyxUnstableDatePickerV2 v-model="date" :label="{ label: 'Hidden', hidden: true }" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/Loading.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/Loading.example.vue
@@ -1,0 +1,8 @@
+<script lang="ts" setup>
+import { OnyxUnstableDatePickerV2 } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxUnstableDatePickerV2 label="Loading" loading />
+  <OnyxUnstableDatePickerV2 label="Skeleton" skeleton />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/Message.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/Message.example.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+import { OnyxUnstableDatePickerV2 } from "sit-onyx";
+import { ref } from "vue";
+
+const date = ref<Date>();
+</script>
+
+<template>
+  <OnyxUnstableDatePickerV2
+    v-model="date"
+    label="Date"
+    :message="{ label: 'Message', tooltipText: 'Message tooltip content' }"
+  />
+  <!--
+    "show-error" is only set for this example so the error is displayed immediately.
+    Remove it if not needed so the error is only displayed after user interaction.
+  -->
+  <OnyxUnstableDatePickerV2
+    v-model="date"
+    label="Date"
+    :error="{ label: 'Custom error', tooltipText: 'Error tooltip content' }"
+    show-error
+  />
+  <OnyxUnstableDatePickerV2
+    v-model="date"
+    label="Date"
+    :success="{ label: 'Success', tooltipText: 'Success tooltip content' }"
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/MinMax.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/MinMax.example.vue
@@ -1,0 +1,24 @@
+<script lang="ts" setup>
+import { OnyxUnstableDatePickerV2 } from "sit-onyx";
+import { ref } from "vue";
+
+const date = ref<Date>();
+
+// dynamically determine min and max date based on today
+const today = new Date();
+
+const min = new Date(today);
+min.setDate(min.getDate() - 7);
+
+const max = new Date(today);
+max.setDate(max.getDate() + 7);
+
+const disabledDays = (date: Date) => {
+  // disable individual days, e.g. every Wednesday
+  return date.getDay() === 3;
+};
+</script>
+
+<template>
+  <OnyxUnstableDatePickerV2 v-model="date" label="Date" :min :max :disabled-days />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/Readonly.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/Readonly.example.vue
@@ -1,0 +1,11 @@
+<script lang="ts" setup>
+import { OnyxUnstableDatePickerV2 } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref(new Date());
+</script>
+
+<template>
+  <OnyxUnstableDatePickerV2 v-model="value" label="Readonly" readonly />
+  <OnyxUnstableDatePickerV2 v-model="value" label="Disabled" disabled />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/SelectionModes.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/SelectionModes.example.vue
@@ -1,0 +1,20 @@
+<script lang="ts" setup>
+import { DateRange, OnyxUnstableDatePickerV2 } from "sit-onyx";
+import { ref } from "vue";
+
+const date = ref<Date>();
+const dates = ref<Date[]>([]);
+const range = ref<DateRange>();
+</script>
+
+<template>
+  <OnyxUnstableDatePickerV2 v-model="date" label="Single" />
+  <OnyxUnstableDatePickerV2 v-model="dates" label="Multiple" selection-mode="multiple" />
+  <OnyxUnstableDatePickerV2 v-model="range" label="Range" selection-mode="range" />
+  <OnyxUnstableDatePickerV2
+    v-model="range"
+    label="Range with multi view"
+    selection-mode="range"
+    multi-view
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/Slots.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker-v2/examples/Slots.example.vue
@@ -1,0 +1,57 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import {
+  OnyxIcon,
+  OnyxSelect,
+  OnyxUnstableDatePickerV2,
+  OnyxUnstableFormElementAction,
+  SelectOption,
+} from "sit-onyx";
+import { ref } from "vue";
+
+const date = ref<Date>();
+
+const selectOptions = [
+  { label: "Foo", value: "foo" },
+  { label: "Bar", value: "bar" },
+] satisfies SelectOption[];
+
+const unit = ref(selectOptions[0].value);
+
+const handleActionClick = () => {
+  // your logic here
+};
+</script>
+
+<template>
+  <OnyxUnstableDatePickerV2 v-model="date" label="Date">
+    <template #leading>
+      <OnyxUnstableFormElementAction
+        label="Example action"
+        :icon="iconPlaceholder"
+        size="lg"
+        @click="handleActionClick"
+      />
+    </template>
+
+    <template #leadingIcons>
+      <OnyxIcon :icon="iconPlaceholder" />
+    </template>
+
+    <template #trailingIcons>
+      <OnyxIcon :icon="iconPlaceholder" />
+    </template>
+
+    <template #trailing>
+      <OnyxSelect
+        v-model="unit"
+        label="Unit"
+        list-label="Available units"
+        alignment="right"
+        :options="selectOptions"
+        hide-clear-icon
+        hide-label
+      />
+    </template>
+  </OnyxUnstableDatePickerV2>
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/date-picker-v2/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker-v2/index.md
@@ -1,0 +1,63 @@
+---
+title: Date picker (v2)
+componentName: OnyxDatePickerV2
+status: beta
+---
+
+The date picker component can be used to select a date, multiple dates or a range of dates.
+
+<!-- TODO: check why export name from vue-component-meta is not "OnyxUnstableDatePickerV2" -->
+
+## Examples
+
+### Selection modes
+
+The date picker supports different selection modes like single, multi and range select.
+
+:component-example{name="SelectionModes" layout="grow" orientation="vertical"}
+
+### Min, max and disabled dates
+
+To limit which dates the user can select, you can optionally set a min and max date so all dates before `min` and after `max` will be disabled and can not be selected.
+Additionally, you can define custom / specific dates that are disabled, e.g. due to public holidays.
+
+In the example below, only the past and upcoming 7 days are selectable except Wednesdays.
+
+:component-example{name="MinMax" layout="grow"}
+
+### Calendar weeks
+
+Calendar weeks can be displayed inside the calendar. When using the `range` selection mode, the calendar week can be clicked to automatically select the whole week.
+
+:component-example{name="CalendarWeeks" layout="grow"}
+
+### Readonly & Disabled
+
+Readonly and disabled are used to indicate that the date picker is currently not editable.
+
+:component-example{name="Readonly" layout="grow"}
+
+### Loading & Skeleton
+
+The loading state is used after a user interaction to indicate that the triggered action is currently loading / in progress. On the other hand, the skeleton should be used on initial page load when the data for the page is initially loaded.
+
+:component-example{name="Loading" layout="grow"}
+
+### Message
+
+An optional message, error or success message can be displayed. Each message supports showing an info tooltip with further information.
+When multiple message types are defined at once, only the most relevant will be displayed (e.g. error is preferred over the regular message).
+
+:component-example{name="Message" layout="grow" orientation="vertical"}
+
+### Slots
+
+Multiple slots are supported to pass in custom content if needed.
+
+:component-example{name="Slots" layout="grow"}
+
+### Label positions
+
+The label can be positioned in several ways to support a wide variety of layouts.
+
+:component-example{name="LabelPositions" layout="grow" orientation="vertical"}

--- a/apps/showcase/content/en/components/02.form-elements/date-picker-v2/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker-v2/index.md
@@ -1,7 +1,7 @@
 ---
 title: Date picker (v2)
 componentName: OnyxDatePickerV2
-status: beta
+status: experimental
 ---
 
 The date picker component can be used to select a date, multiple dates or a range of dates.

--- a/apps/showcase/content/en/components/02.form-elements/date-picker/examples/Date.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker/examples/Date.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxDatePicker } from "sit-onyx";
+import { ref } from "vue";
+
+const date = ref<string>();
+</script>
+
+<template>
+  <OnyxDatePicker v-model="date" label="Date" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/date-picker/examples/Datetime.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker/examples/Datetime.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxDatePicker } from "sit-onyx";
+import { ref } from "vue";
+
+const datetime = ref<string>();
+</script>
+
+<template>
+  <OnyxDatePicker v-model="datetime" label="Datetime" type="datetime-local" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/date-picker/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker/index.md
@@ -1,0 +1,19 @@
+---
+title: Date picker
+componentName: OnyxDatePicker
+status: deprecated
+---
+
+The date picker component can be used to select a date or date-time.
+
+## Examples
+
+### Date
+
+:component-example{name="Date" layout="grow"}
+
+### Datetime
+
+When selecting date + time, the timezone of the users local device will be used.
+
+:component-example{name="Datetime" layout="grow"}

--- a/apps/showcase/content/en/components/02.form-elements/date-picker/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/date-picker/index.md
@@ -14,6 +14,6 @@ The date picker component can be used to select a date or date-time.
 
 ### Datetime
 
-When selecting date + time, the timezone of the users local device will be used.
+When selecting date and time, the local timezone of the user will be used.
 
 :component-example{name="Datetime" layout="grow"}

--- a/apps/showcase/content/en/components/02.form-elements/input/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/input/examples/Basic.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxInput } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref("");
+</script>
+
+<template>
+  <OnyxInput v-model="value" label="Example label" placeholder="Placeholder..." required />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/input/examples/LabelPositions.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/input/examples/LabelPositions.example.vue
@@ -1,0 +1,13 @@
+<script lang="ts" setup>
+import { OnyxInput } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref("");
+</script>
+
+<template>
+  <OnyxInput v-model="value" label="Top" />
+  <OnyxInput v-model="value" :label="{ label: 'Left', position: 'left' }" />
+  <OnyxInput v-model="value" :label="{ label: 'Right', position: 'right' }" />
+  <OnyxInput v-model="value" :label="{ label: 'Hidden', hidden: true }" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/input/examples/Loading.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/input/examples/Loading.example.vue
@@ -1,0 +1,8 @@
+<script lang="ts" setup>
+import { OnyxInput } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxInput label="Loading" loading />
+  <OnyxInput label="Skeleton" skeleton />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/input/examples/Message.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/input/examples/Message.example.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+import { OnyxInput } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref("");
+</script>
+
+<template>
+  <OnyxInput
+    v-model="value"
+    label="Example label"
+    :message="{ shortMessage: 'Message', longMessage: 'Message tooltip content' }"
+  />
+  <!--
+    "show-error" is only set for this example so the error is displayed immediately.
+    Remove it if not needed so the error is only displayed after user interaction.
+  -->
+  <OnyxInput
+    v-model="value"
+    label="Example label"
+    :error="{ shortMessage: 'Custom error', longMessage: 'Error tooltip content' }"
+    show-error
+  />
+  <OnyxInput
+    v-model="value"
+    label="Example label"
+    :success="{ shortMessage: 'Success', longMessage: 'Success tooltip content' }"
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/input/examples/MinMaxLength.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/input/examples/MinMaxLength.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxInput } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref("");
+</script>
+
+<template>
+  <OnyxInput v-model="value" label="Example label" :minlength="8" :maxlength="32" with-counter />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/input/examples/Password.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/input/examples/Password.example.vue
@@ -1,0 +1,20 @@
+<script lang="ts" setup>
+import { OnyxInput } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref("very-secret-password");
+const showPassword = ref(false);
+</script>
+
+<template>
+  <!--
+    The "v-model:show-password" is optional.
+    If you don't need to manually control the password visibility, you can remove it so its managed internally.
+  -->
+  <OnyxInput
+    v-model="value"
+    v-model:show-password="showPassword"
+    label="Password"
+    type="password"
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/input/examples/Readonly.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/input/examples/Readonly.example.vue
@@ -1,0 +1,11 @@
+<script lang="ts" setup>
+import { OnyxInput } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref("Example value");
+</script>
+
+<template>
+  <OnyxInput v-model="value" label="Readonly" readonly />
+  <OnyxInput v-model="value" label="Disabled" disabled />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/input/examples/Slots.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/input/examples/Slots.example.vue
@@ -1,0 +1,57 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import {
+  OnyxIcon,
+  OnyxInput,
+  OnyxSelect,
+  OnyxUnstableFormElementAction,
+  SelectOption,
+} from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref("");
+
+const unitOptions = [
+  { label: "kg", value: "kg" },
+  { label: "g", value: "g" },
+] satisfies SelectOption[];
+
+const unit = ref(unitOptions[0].value);
+
+const handleActionClick = () => {
+  // your logic here
+};
+</script>
+
+<template>
+  <OnyxInput v-model="value" label="Example label" disable-slot-padding>
+    <template #leading>
+      <OnyxUnstableFormElementAction
+        label="Example action"
+        :icon="iconPlaceholder"
+        size="lg"
+        @click="handleActionClick"
+      />
+    </template>
+
+    <template #leadingIcons>
+      <OnyxIcon :icon="iconPlaceholder" />
+    </template>
+
+    <template #trailingIcons>
+      <OnyxIcon :icon="iconPlaceholder" />
+    </template>
+
+    <template #trailing>
+      <OnyxSelect
+        v-model="unit"
+        label="Unit"
+        list-label="Available units"
+        alignment="right"
+        :options="unitOptions"
+        hide-clear-icon
+        hide-label
+      />
+    </template>
+  </OnyxInput>
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/input/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/input/index.md
@@ -50,6 +50,6 @@ For password inputs, an additional button is displayed that allows the user to r
 
 ### Label positions
 
-THe input label can be positioned in several ways to support a wide variety of layouts.
+The input label can be positioned in several ways to support a wide variety of layouts.
 
 :component-example{name="LabelPositions" layout="grow" orientation="vertical"}

--- a/apps/showcase/content/en/components/02.form-elements/input/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/input/index.md
@@ -1,0 +1,55 @@
+---
+title: Input
+componentName: OnyxInput
+---
+
+Text inputs are essential UI elements where users can enter textual information. These components play a fundamental role in facilitating user interactions and data input within applications and websites.
+
+## Examples
+
+### Basic
+
+:component-example{name="Basic" layout="grow"}
+
+### Readonly & Disabled
+
+Readonly and disabled are used to indicate that the input is currently not editable.
+
+:component-example{name="Readonly" layout="grow"}
+
+### Min and max length
+
+When a min or maxlength is defined, the user must enter at least `min` and at most `max` characters before the input is valid. Otherwise the input is invalid and a proper error message is displayed. Optionally, a character counter can be displayed.
+
+:component-example{name="MinMaxLength" layout="grow"}
+
+### Loading & Skeleton
+
+The loading state is used after a user interaction to indicate that the triggered action is currently loading / in progress. On the other hand, the skeleton should be used on initial page load when the data for the page is initially loaded.
+
+:component-example{name="Loading" layout="grow"}
+
+### Message
+
+An optional message, error or success message can be displayed. Each message supports showing an info tooltip with further information.
+When multiple message types are defined at once, only the most relevant will be displayed (e.g. error is preferred over the regular message).
+
+:component-example{name="Message" layout="grow" orientation="vertical"}
+
+### Slots
+
+Multiple slots are supported to pass in custom content if needed.
+
+:component-example{name="Slots" layout="grow"}
+
+### Password
+
+For password inputs, an additional button is displayed that allows the user to reveal the entered password.
+
+:component-example{name="Password" layout="grow"}
+
+### Label positions
+
+THe input label can be positioned in several ways to support a wide variety of layouts.
+
+:component-example{name="LabelPositions" layout="grow" orientation="vertical"}

--- a/apps/showcase/i18n/locales/en-US.json
+++ b/apps/showcase/i18n/locales/en-US.json
@@ -42,9 +42,9 @@
     },
     "status": {
       "new": "New",
-      "beta": {
-        "label": "Beta",
-        "description": "This component is currently in beta since we have just recently added it to our design system. We allow breaking changes for this component within minor or patch versions (e.g. 1.x.x) so we can integrate community feedback and ensure high quality. Therefore, we strongly recommend to watch our {changelog} when updating and using this component.",
+      "experimental": {
+        "label": "Experimental",
+        "description": "This component is experimental since we have just recently added it to our design system. We allow breaking changes for this component within minor or patch versions (e.g. 1.0.0 => 1.0.1) so we can integrate community feedback and ensure high quality. Therefore, we strongly recommend to watch our {changelog} when updating and using this component.",
         "changelog": "changelog"
       },
       "deprecated": {

--- a/apps/showcase/i18n/locales/en-US.json
+++ b/apps/showcase/i18n/locales/en-US.json
@@ -41,7 +41,12 @@
       }
     },
     "status": {
-      "new": "New"
+      "new": "New",
+      "beta": {
+        "label": "Beta",
+        "description": "This component is currently in beta since we have just recently added it to our design system. We allow breaking changes for this component within minor or patch versions (e.g. 1.x.x) so we can integrate community feedback and ensure high quality. Therefore, we strongly recommend to watch our {changelog} when updating and using this component.",
+        "changelog": "changelog"
+      }
     }
   },
   "gettingStarted": "Getting Started",

--- a/apps/showcase/i18n/locales/en-US.json
+++ b/apps/showcase/i18n/locales/en-US.json
@@ -46,6 +46,10 @@
         "label": "Beta",
         "description": "This component is currently in beta since we have just recently added it to our design system. We allow breaking changes for this component within minor or patch versions (e.g. 1.x.x) so we can integrate community feedback and ensure high quality. Therefore, we strongly recommend to watch our {changelog} when updating and using this component.",
         "changelog": "changelog"
+      },
+      "deprecated": {
+        "label": "Deprecated",
+        "description": "This component is deprecated and should no longer be used. It is currently kept for backwards compatibility but will be removed in the next major version."
       }
     }
   },

--- a/apps/showcase/i18n/locales/en-US.json
+++ b/apps/showcase/i18n/locales/en-US.json
@@ -32,7 +32,7 @@
     "schema": "Type",
     "options": {
       "reset": "Reset styles",
-      "change": "change styles",
+      "change": "Change styles",
       "density": "Density",
       "appearance": "Appearance",
       "appearances": {

--- a/packages/sit-onyx/src/components/OnyxDatePickerV2/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDatePickerV2/types.ts
@@ -13,7 +13,7 @@ export type OnyxDatePickerV2Props<TSelection extends OnyxCalendarSelectionMode =
       /**
        * Whether to show two calendars in range mode.
        */
-      multiView?: TSelection extends "range" ? boolean : never;
+      multiView?: boolean;
       /**
        * Disable specific dates to select individually.
        *

--- a/packages/sit-onyx/src/components/OnyxDatePickerV2/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDatePickerV2/types.ts
@@ -13,7 +13,8 @@ export type OnyxDatePickerV2Props<TSelection extends OnyxCalendarSelectionMode =
       /**
        * Whether to show two calendars in range mode.
        */
-      multiView?: boolean;
+      // "boolean &" is needed to correctly generate the runtime prop value, see: https://github.com/vuejs/core/issues/13787#issuecomment-3209755164
+      multiView?: boolean & (TSelection extends "range" ? boolean : never);
       /**
        * Disable specific dates to select individually.
        *


### PR DESCRIPTION
Relates to #5494

Implement component examples / documentation for our showcase.
Can be reviewed locally on:
- http://localhost:3000/components/form-elements/input
- http://localhost:3000/components/form-elements/date-picker-v2
- http://localhost:3000/components/form-elements/date-picker

Also added two new component status: Beta and deprecated

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
