### PR TITLE
docs: fix broken showcase content

### DIFF
--- a/apps/showcase/content/en/introduction/02.foundation/01.colors.md
+++ b/apps/showcase/content/en/introduction/02.foundation/01.colors.md
@@ -13,7 +13,7 @@ We include a free and Open Source theme out-of-the-box which supports light and 
 <layout-container>
 
 <div>
-<onyx-headline is="h4" style="margin-bottom: var(--onyx-density-2xs)">Light mode</onyx-headline>
+<prose-h4 style="margin-top: 0;">Light mode</prose-h4>
 
 <color-palette border="neutral" grid style="color-scheme: only light;">
 <color-palette-item css-variable="var(--onyx-color-base-background-tinted)" text-color="neutral">tinted</color-palette-item>
@@ -22,7 +22,7 @@ We include a free and Open Source theme out-of-the-box which supports light and 
 </div>
 
 <div>
-<onyx-headline is="h4" style="margin-bottom: var(--onyx-density-2xs)">Dark mode</onyx-headline>
+<prose-h4 style="margin-top: 0;">Dark mode</prose-h4>
 
 <color-palette border="neutral" grid style="color-scheme: only dark;">
 <color-palette-item css-variable="var(--onyx-color-base-background-tinted)" text-color="neutral">tinted</color-palette-item>

--- a/apps/showcase/content/en/introduction/02.foundation/02.typography.md
+++ b/apps/showcase/content/en/introduction/02.foundation/02.typography.md
@@ -234,7 +234,7 @@ Use our [OnyxLink](https://storybook.onyx.schwarz/?path=/docs/navigation-link--d
       value: internal
   ---
 
-  <onyx-link href="https://storybook.onyx.schwarz/?path=/docs/navigation-link--docs">Hello World</onyx-link>
+  [Hello World](#)
   ::
 
   ::typography-card
@@ -245,7 +245,7 @@ Use our [OnyxLink](https://storybook.onyx.schwarz/?path=/docs/navigation-link--d
       value: external
   ---
 
-  <onyx-link href="https://storybook.onyx.schwarz/?path=/docs/navigation-link--docs" with-external-icon>Hello World</onyx-link>
+  [Hello World](https://storybook.onyx.schwarz/?path=/docs/navigation-link--docs)
   ::
 
 </div>

--- a/apps/showcase/modules/showcase.ts
+++ b/apps/showcase/modules/showcase.ts
@@ -1,0 +1,22 @@
+import { addComponent, defineNuxtModule } from "nuxt/kit";
+
+export default defineNuxtModule({
+  meta: {
+    name: "@sit-onyx/showcase",
+  },
+  defaults: {},
+  setup() {
+    const globalComponents = ["OnyxTag", "OnyxHeadline"];
+
+    // register specific components globally so they can be used in markdown files
+    globalComponents.forEach((component) => {
+      addComponent({
+        filePath: "sit-onyx",
+        name: component,
+        export: component,
+        global: true,
+        priority: 1,
+      });
+    });
+  },
+});


### PR DESCRIPTION
Currently some showcase pages are broken when viewing in production because onyx components are used inside the markdown that are not registered globally: https://onyx-showcase-dev.apps.01.cf.eu01.stackit.cloud/introduction/foundation/colors
<img width="786" height="184" alt="image" src="https://github.com/user-attachments/assets/c4d23aa4-a3bd-4250-b235-8871e33db130" />


## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
