### PR TITLE
fix(DataGridFeatures.useFiltering): Fix focus loss on filter input when used with useStickyColumns

### DIFF
--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/TestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/TestCase.ct.vue
@@ -1,28 +1,34 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { DataGridEntry, OnyxDataGridProps } from "../../../../index.js";
+import type { DataGridEntry, DataGridFeature, OnyxDataGridProps } from "../../../../index.js";
 import { DataGridFeatures, OnyxDataGrid } from "../../../../index.js";
 import type { StickyColumnsOptions } from "./types.js";
 
-const { columns, data, stickyColumnsOptions, withSelection } = defineProps<
+const { columns, data, stickyColumnsOptions, withSelection, withFiltering } = defineProps<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
   Pick<OnyxDataGridProps<any, any, any, any, any, any>, "columns" | "data"> & {
     stickyColumnsOptions?: StickyColumnsOptions<DataGridEntry>;
     withSelection?: boolean;
+    withFiltering?: boolean;
   }
 >();
 
 const stickyColumnsFeature = computed(() =>
   DataGridFeatures.useStickyColumns(stickyColumnsOptions),
 );
-const selectionFeature = computed(() => DataGridFeatures.useSelection());
+const selectionFeature = DataGridFeatures.useSelection();
+const filteringFeature = DataGridFeatures.useFiltering();
 
 const features = computed(() => {
+  const _features: DataGridFeature<DataGridEntry>[] = [stickyColumnsFeature.value];
   if (withSelection) {
-    return [stickyColumnsFeature.value, selectionFeature.value];
+    _features.push(selectionFeature);
+  }
+  if (withFiltering) {
+    _features.push(filteringFeature);
   }
 
-  return [stickyColumnsFeature.value];
+  return _features;
 });
 </script>
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/stickyColumns.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/stickyColumns.ct.tsx
@@ -354,3 +354,36 @@ test("selection column is automatically sticky when both features are active", a
 
   await expect(component).toHaveScreenshot("data-grid-sticky-selection-column.png");
 });
+
+test("scrolling triggered by filtering overflow shouldn't close search box", async ({ mount }) => {
+  const data = getTestData();
+
+  const component = await mount(
+    <TestCase
+      data={data}
+      columns={columns}
+      stickyColumnsOptions={{ columns: ["a"] }}
+      withFiltering={true}
+    />,
+  );
+  const columnheaderB = component.getByRole("columnheader", { name: "b Toggle column actions" });
+  const searchBox = columnheaderB.getByRole("textbox", { name: "Search column b" });
+
+  // ASSERT
+  await expect(searchBox).toBeHidden();
+
+  // ACT
+  await columnheaderB.getByLabel("Toggle column actions").click();
+
+  // ASSERT
+  await expect(searchBox).toBeVisible();
+
+  // ACT
+  await searchBox.fill("longlonglonglonglonglonglonglonglonglonglong text");
+
+  // ASSERT
+  await expect(component).toBeVisible();
+  await expect(
+    component.getByRole("button", { name: "Remove search term for column" }),
+  ).toBeHidden();
+});

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/stickyColumns.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/stickyColumns/stickyColumns.ts
@@ -97,7 +97,11 @@ export const useStickyColumns = <TEntry extends DataGridEntry>(
       { deep: true, immediate: true },
     );
 
-    const handleScroll = (el: Element) => {
+    const handleScroll = () => {
+      if (!containerElement.value) {
+        return;
+      }
+      const el = containerElement.value;
       const width = el.scrollWidth - el.clientWidth;
       const scrollLeft = Math.round(el.scrollLeft);
       isScrolledLeft.value = scrollLeft > 0;
@@ -269,9 +273,9 @@ export const useStickyColumns = <TEntry extends DataGridEntry>(
           if (!el) return;
           containerElement.value = el as HTMLElement;
           await nextTick();
-          handleScroll(el as HTMLElement);
+          handleScroll();
         },
-        onScrollCapturePassive: (e: Event) => handleScroll(e.target as HTMLElement),
+        onScrollPassive: () => handleScroll(),
       }),
     };
   });


### PR DESCRIPTION
Closes #5517 

**Cause:** We used `onScrollCapturePassive`. An event listener which uses the [capture](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#capture) flag will even be triggered when the event target is a child of the listener element. In this case the scroll event of the overflowing input text triggered the event handler and a re-render.

**Fix:** We use the default non-capturing event listener now. And because the scroll event doesn't bubble, it can only be triggered by the scroll-container itself.