### PR TITLE
docs: add examples for slider, stepper and switch

### DIFF
--- a/.changeset/beige-icons-invite.md
+++ b/.changeset/beige-icons-invite.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxSlider): prevent using `v-bind()` inside styles in favor of inline styles to avoid broken track styles in some scenarios

--- a/apps/showcase/content/en/components/01.buttons/button/index.md
+++ b/apps/showcase/content/en/components/01.buttons/button/index.md
@@ -21,7 +21,7 @@ Neutral buttons are used for secondary actions such as "Cancel" actions.
 
 ### Danger
 
-Use danger buttons for destructive actions such as "Delete".
+Use danger buttons for destructive actions such as "Delete". For an improved user experience, we strongly recommend to show a confirmation before actually deleting any data. You can use our [alert modal](/components/feedback/alert-modal) component for this.
 
 :component-example{name="Danger"}
 

--- a/apps/showcase/content/en/components/02.form-elements/input/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/input/index.md
@@ -3,7 +3,7 @@ title: Input
 componentName: OnyxInput
 ---
 
-Text inputs are essential UI elements where users can enter textual information. These components play a fundamental role in facilitating user interactions and data input within applications and websites.
+Text inputs are essential UI elements where users can enter textual information. These components play a fundamental role in facilitating user interactions and data input within applications and websites. For numeric values, please use the [stepper](/components/form-elements/stepper) instead.
 
 ## Examples
 

--- a/apps/showcase/content/en/components/02.form-elements/slider/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/slider/examples/Basic.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxSlider } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref(50);
+</script>
+
+<template>
+  <OnyxSlider v-model="value" label="Example label" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/slider/examples/Disabled.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/slider/examples/Disabled.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxSlider } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref(50);
+</script>
+
+<template>
+  <OnyxSlider v-model="value" label="Example label" disabled />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/slider/examples/IconControl.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/slider/examples/IconControl.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxSlider } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref(50);
+</script>
+
+<template>
+  <OnyxSlider v-model="value" label="Example label" control="icon" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/slider/examples/InputControl.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/slider/examples/InputControl.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxSlider } from "sit-onyx";
+import { ref } from "vue";
+
+const range = ref<[number, number]>([25, 75]);
+</script>
+
+<template>
+  <OnyxSlider v-model="range" label="Example label" mode="range" control="input" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/slider/examples/Marks.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/slider/examples/Marks.example.vue
@@ -1,0 +1,24 @@
+<script lang="ts" setup>
+import { OnyxSlider, SliderMark } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref(50);
+
+const marks: SliderMark[] = [
+  { label: "0°C", value: 0 },
+  { label: "25°C", value: 25 },
+  { label: "50°C", value: 50 },
+  { label: "75°C", value: 75 },
+  { label: "100°C", value: 100 },
+];
+</script>
+
+<template>
+  <OnyxSlider v-model="value" label="Discrete marks" :step="25" marks />
+  <OnyxSlider
+    v-model="value"
+    label="Labelled marks"
+    :tooltip="{ formatter: (value) => `${value}%` }"
+    :marks
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/slider/examples/Message.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/slider/examples/Message.example.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+import { OnyxSlider } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref(50);
+</script>
+
+<template>
+  <OnyxSlider
+    v-model="value"
+    label="Example label"
+    :message="{ shortMessage: 'Message', longMessage: 'Message tooltip content' }"
+  />
+  <!--
+    "show-error" is only set for this example so the error is displayed immediately.
+    Remove it if not needed so the error is only displayed after user interaction.
+  -->
+  <OnyxSlider
+    v-model="value"
+    label="Example label"
+    :error="{ shortMessage: 'Custom error', longMessage: 'Error tooltip content' }"
+    show-error
+  />
+  <OnyxSlider
+    v-model="value"
+    label="Example label"
+    :success="{ shortMessage: 'Success', longMessage: 'Success tooltip content' }"
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/slider/examples/Range.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/slider/examples/Range.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxSlider } from "sit-onyx";
+import { ref } from "vue";
+
+const range = ref<[number, number]>([25, 75]);
+</script>
+
+<template>
+  <OnyxSlider v-model="range" label="Example label" mode="range" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/slider/examples/Skeleton.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/slider/examples/Skeleton.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxSlider } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref(50);
+</script>
+
+<template>
+  <OnyxSlider v-model="value" label="Example label" skeleton />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/slider/examples/ValueControl.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/slider/examples/ValueControl.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxSlider } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref(50);
+</script>
+
+<template>
+  <OnyxSlider v-model="value" label="Example label" control="value" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/slider/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/slider/index.md
@@ -1,0 +1,87 @@
+---
+title: Slider
+componentName: OnyxSlider
+---
+
+Sliders allow users to select a value (or a range of two values) inside a given min/max range by dragging a thumb along a track.
+
+## Examples
+
+### Basic
+
+The default slider supports selecting a single value within the given min/max range. The step size can be configured if needed but defaults to 1.
+
+:component-example{name="Basic" layout="grow"}
+
+### Range
+
+The range mode can be used so select a range of two values.
+
+:component-example{name="Range" layout="grow"}
+
+### Marks
+
+Marks can be used to show visual "steps" inside the slider track which can optionally show a label below. They can be auto-generated based on the `step` property which is useful for discrete sliders where the user can only selected specific values (e.g. 0, 25, 50, 75 and 100).
+
+The `mark` slot can be used to provide custom content for each mark such as icons.
+
+:component-example{name="Marks" layout="grow" orientation="vertical"}
+
+### Controls
+
+The slider supports multiple control types that allow the user to change the slider value with an additional action.
+
+<steps>
+
+::step
+#headline
+Icon control
+
+#default
+The icon control shows two additional buttons for increasing and decreasing the value. It is only supported for the single mode.
+
+:component-example{name="IconControl" layout="grow"}
+::
+
+::step
+#headline
+Input control
+
+#default
+The input control shows an additional input where the user can type in to change the current value. This control is supported for both the single and the range mode.
+
+:component-example{name="InputControl" layout="grow"}
+::
+
+::step
+#headline
+Value control
+
+#default
+The value control is not interactive and shows the min and max value of the slider.
+
+:component-example{name="ValueControl" layout="grow"}
+::
+
+</steps>
+
+<br />
+
+### Disabled
+
+The disabled is used to indicate that the slider is currently not editable.
+
+:component-example{name="Disabled" layout="grow"}
+
+### Skeleton
+
+The skeleton should be used on initial page load when the data for the page / slider is initially loaded.
+
+:component-example{name="Skeleton" layout="grow"}
+
+### Message
+
+An optional message, error or success message can be displayed. Each message supports showing an info tooltip with further information.
+When multiple message types are defined at once, only the most relevant will be displayed (e.g. error is preferred over the regular message).
+
+:component-example{name="Message" layout="grow" orientation="vertical"}

--- a/apps/showcase/content/en/components/02.form-elements/slider/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/slider/index.md
@@ -1,6 +1,7 @@
 ---
 title: Slider
 componentName: OnyxSlider
+status: new
 ---
 
 Sliders allow users to select a value (or a range of two values) inside a given min/max range by dragging a thumb along a track.

--- a/apps/showcase/content/en/components/02.form-elements/stepper/examples/Alignment.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/examples/Alignment.example.vue
@@ -1,0 +1,24 @@
+<script lang="ts" setup>
+import { OnyxStepper } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref<number>(42);
+</script>
+
+<template>
+  <OnyxStepper v-model="value" label="Centered" />
+  <OnyxStepper v-model="value" class="stepper--left" label="Left aligned" />
+  <OnyxStepper v-model="value" class="stepper--right" label="Right aligned" />
+</template>
+
+<style lang="scss" scoped>
+.stepper {
+  &--left {
+    --onyx-stepper-text-align: left;
+  }
+
+  &--right {
+    --onyx-stepper-text-align: right;
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/02.form-elements/stepper/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/examples/Basic.example.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+import { OnyxStepper } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref<number>();
+</script>
+
+<template>
+  <OnyxStepper v-model="value" label="Default" placeholder="Placeholder..." required />
+  <OnyxStepper
+    v-model="value"
+    label="Without buttons"
+    placeholder="Placeholder..."
+    required
+    hide-buttons
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/stepper/examples/CustomFormatter.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/examples/CustomFormatter.example.vue
@@ -1,0 +1,14 @@
+<script lang="ts" setup>
+import { OnyxStepper } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref<number>(12.34);
+</script>
+
+<template>
+  <OnyxStepper
+    v-model="value"
+    label="Example label"
+    :format-number="(value) => `Value: ${value}%`"
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/stepper/examples/Formatting.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/examples/Formatting.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxStepper } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref<number>(12.34);
+</script>
+
+<template>
+  <OnyxStepper v-model="value" label="Example label" format-number />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/stepper/examples/LabelPositions.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/examples/LabelPositions.example.vue
@@ -1,0 +1,13 @@
+<script lang="ts" setup>
+import { OnyxStepper } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref<number>();
+</script>
+
+<template>
+  <OnyxStepper v-model="value" label="Top" />
+  <OnyxStepper v-model="value" :label="{ label: 'Left', position: 'left' }" />
+  <OnyxStepper v-model="value" :label="{ label: 'Right', position: 'right' }" />
+  <OnyxStepper v-model="value" :label="{ label: 'Hidden', hidden: true }" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/stepper/examples/Loading.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/examples/Loading.example.vue
@@ -1,0 +1,8 @@
+<script lang="ts" setup>
+import { OnyxStepper } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxStepper label="Loading" loading />
+  <OnyxStepper label="Skeleton" skeleton />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/stepper/examples/Message.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/examples/Message.example.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+import { OnyxStepper } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref<number>();
+</script>
+
+<template>
+  <OnyxStepper
+    v-model="value"
+    label="Example label"
+    :message="{ shortMessage: 'Message', longMessage: 'Message tooltip content' }"
+  />
+  <!--
+    "show-error" is only set for this example so the error is displayed immediately.
+    Remove it if not needed so the error is only displayed after user interaction.
+  -->
+  <OnyxStepper
+    v-model="value"
+    label="Example label"
+    :error="{ shortMessage: 'Custom error', longMessage: 'Error tooltip content' }"
+    show-error
+  />
+  <OnyxStepper
+    v-model="value"
+    label="Example label"
+    :success="{ shortMessage: 'Success', longMessage: 'Success tooltip content' }"
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/stepper/examples/Precision.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/examples/Precision.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxStepper } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref<number>(42);
+</script>
+
+<template>
+  <OnyxStepper v-model="value" label="Example label" :precision="2" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/stepper/examples/Readonly.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/examples/Readonly.example.vue
@@ -1,0 +1,11 @@
+<script lang="ts" setup>
+import { OnyxStepper } from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref(42);
+</script>
+
+<template>
+  <OnyxStepper v-model="value" label="Readonly" readonly />
+  <OnyxStepper v-model="value" label="Disabled" disabled />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/stepper/examples/Slots.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/examples/Slots.example.vue
@@ -1,0 +1,57 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import {
+  OnyxIcon,
+  OnyxSelect,
+  OnyxStepper,
+  OnyxUnstableFormElementAction,
+  SelectOption,
+} from "sit-onyx";
+import { ref } from "vue";
+
+const value = ref<number>();
+
+const unitOptions = [
+  { label: "kg", value: "kg" },
+  { label: "g", value: "g" },
+] satisfies SelectOption[];
+
+const unit = ref(unitOptions[0].value);
+
+const handleActionClick = () => {
+  // your logic here
+};
+</script>
+
+<template>
+  <OnyxStepper v-model="value" label="Example label">
+    <template #leading>
+      <OnyxUnstableFormElementAction
+        label="Example action"
+        :icon="iconPlaceholder"
+        size="lg"
+        @click="handleActionClick"
+      />
+    </template>
+
+    <template #leadingIcons>
+      <OnyxIcon :icon="iconPlaceholder" />
+    </template>
+
+    <template #trailingIcons>
+      <OnyxIcon :icon="iconPlaceholder" />
+    </template>
+
+    <template #trailing>
+      <OnyxSelect
+        v-model="unit"
+        label="Unit"
+        list-label="Available units"
+        alignment="right"
+        :options="unitOptions"
+        hide-clear-icon
+        hide-label
+      />
+    </template>
+  </OnyxStepper>
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/stepper/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/stepper/index.md
@@ -1,0 +1,92 @@
+---
+title: Stepper
+componentName: OnyxStepper
+---
+
+The stepper component lets users input numerical values and adjust them incrementally via plus and minus buttons, making it ideal for setting quantities or values in small, controlled steps.
+
+## Examples
+
+### Basic
+
+The stepper includes a increase/decrease button by default that can optionally be hidden. The step size defaults to 1 but can be customized using the `stepSize` property.
+
+:component-example{name="Basic" layout="grow" orientation="vertical"}
+
+### Precision
+
+You can use the `precision` property to restrict how many decimal places are shown. The entered value is rounded if needed. A precision of `2` means that only two decimal places are allowed, e.g. `1.00`. To only allow "full" numbers, set the precision to `0`. A negative value can also be used to specify the places of the integer part so e.g. `precision="-1"` only allows multiples of 10, `precision="-2"` multiples of 100 and so on.
+
+:component-example{name="Precision" layout="grow"}
+
+### Formatting
+
+In addition to specifying a [precision](#precision), custom formatting can be applied to the value to display any text. Since the formatted text might not always be a valid number, it is only displayed when the stepper is **not** focused / actively edited. While editing the value, the default formatting is used.
+
+There are multiple options available:
+
+<steps>
+
+::step
+#headline
+Locale formatting
+
+#default
+When simply enabling the `formatNumber` property, the value will be formatted depending on the current locale / language of the application. This means e.g. a dot is used to separate the integer and fractional part in Englisch while a comma is used in German.
+
+:component-example{name="Formatting" layout="grow"}
+::
+
+::step
+#headline
+Custom formatting
+
+#default
+Alternatively, a full custom formatter can be defined that returns a custom text for the current value.
+
+
+:component-example{name="CustomFormatter" layout="grow"}
+::
+
+::step
+#headline
+Alignment
+
+#default
+The value is centered by default but can optionally be left or right aligned. All alignment options can be used in combination with custom formatting.
+
+:component-example{name="Alignment" layout="grow" orientation="vertical"}
+::
+
+</steps>
+
+<br />
+
+### Readonly & Disabled
+
+Readonly and disabled are used to indicate that the stepper is currently not editable.
+
+:component-example{name="Readonly" layout="grow"}
+
+The loading state is used after a user interaction to indicate that the triggered action is currently loading / in progress. On the other hand, the skeleton should be used on initial page load when the data for the page / stepper is initially loaded.
+
+:component-example{name="Loading" layout="grow"}
+
+### Message
+
+An optional message, error or success message can be displayed. Each message supports showing an info tooltip with further information.
+When multiple message types are defined at once, only the most relevant will be displayed (e.g. error is preferred over the regular message).
+
+:component-example{name="Message" layout="grow" orientation="vertical"}
+
+### Slots
+
+Multiple slots are supported to pass in custom content if needed. Note that the default increment and decrement button will be hidden if a custom leading or trailing slot is passed.
+
+:component-example{name="Slots" layout="grow"}
+
+### Label positions
+
+The stepper label can be positioned in several ways to support a wide variety of layouts.
+
+:component-example{name="LabelPositions" layout="grow" orientation="vertical"}

--- a/apps/showcase/content/en/components/02.form-elements/switch/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/switch/examples/Basic.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxSwitch } from "sit-onyx";
+import { ref } from "vue";
+
+const checked = ref(false);
+</script>
+
+<template>
+  <OnyxSwitch v-model="checked" label="Example label" required />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/switch/examples/Disabled.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/switch/examples/Disabled.example.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import { OnyxSwitch } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSwitch label="Example label" disabled />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/switch/examples/Loading.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/switch/examples/Loading.example.vue
@@ -1,0 +1,8 @@
+<script lang="ts" setup>
+import { OnyxSwitch } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxSwitch label="Example label" loading />
+  <OnyxSwitch label="Example label" skeleton />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/switch/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/switch/index.md
@@ -1,0 +1,27 @@
+---
+title: Switch
+componentName: OnyxSwitch
+---
+
+Switches are a common UI element used to control binary states, such as on/off, enable/disable or active/inactive. They consist of a toggle mechanism that allow users to switch between two distinct states with a simple interaction.
+
+## Examples
+
+### Basic
+
+The switch can be used with or without a visual label.
+
+:component-example{name="Basic"}
+
+### Loading & Skeleton
+
+The loading state is used after a user interaction to indicate that the triggered action is currently loading / in progress. On the other hand, the skeleton should be used on initial page load when the data for the page / switch is initially loaded.
+
+:component-example{name="Loading"}
+
+### Disabled
+
+The switch can be disabled to indicate that its action is currently not available and the switch can not be toggled.
+For an improved user experience, it should be clear to the user _why_ the switch is disabled.
+
+:component-example{name="Disabled"}

--- a/packages/sit-onyx/src/components/OnyxSlider/OnyxSlider.vue
+++ b/packages/sit-onyx/src/components/OnyxSlider/OnyxSlider.vue
@@ -204,7 +204,13 @@ const sharedStepperProps = computed(() => {
 
           <!-- main slider -->
           <span class="onyx-slider__root" v-bind="root">
-            <span class="onyx-slider__rail"></span>
+            <span
+              class="onyx-slider__rail"
+              :style="{
+                '--track-start-percentage': `${track.startPercentage}%`,
+                '--track-end-percentage': `${100 - track.endPercentage}%`,
+              }"
+            ></span>
 
             <template v-for="markItem in marks" :key="markItem.value">
               <span
@@ -379,8 +385,8 @@ const sharedStepperProps = computed(() => {
       }
 
       &::after {
-        left: v-bind("`${track.startPercentage}%`");
-        right: v-bind("`${100 - track.endPercentage}%`");
+        left: var(--track-start-percentage);
+        right: var(--track-end-percentage);
         background-color: var(--onyx-slider-track-background);
         z-index: $track-z-index;
       }


### PR DESCRIPTION
Relates to #5494

- implement documentation / examples for OnyxSlider, OnyxStepper and OnyxSwitch component
- update the OnyxSlider to not use `v-bind()` in CSS and use inline styles instead. It had issues when used inside Nuxt / our showcase where the track was not displayed

## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
