### PR TITLE
fix(useExpandableRows): ensure empty header when used with other features

### DIFF
--- a/.changeset/dark-donuts-watch.md
+++ b/.changeset/dark-donuts-watch.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(useExpandableRows): ensure empty header when used with other features

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/expandableRows/TestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/expandableRows/TestCase.ct.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { h } from "vue";
+import { computed, h } from "vue";
 import type { OnyxDataGridProps } from "../../../../index.js";
 import { DataGridFeatures, OnyxDataGrid } from "../../../../index.js";
 
-const { columns, data } = defineProps<
+const props = defineProps<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
-  Pick<OnyxDataGridProps<any, any, any, any, any, any>, "columns" | "data">
+  Pick<OnyxDataGridProps<any, any, any, any, any, any>, "columns" | "data"> & {
+    enableSorting?: boolean;
+  }
 >();
 
 const withExpandableRows = DataGridFeatures.useExpandableRows({
@@ -15,7 +17,11 @@ const withExpandableRows = DataGridFeatures.useExpandableRows({
   ],
 });
 
-const features = [withExpandableRows];
+const withSorting = DataGridFeatures.useSorting({
+  enabled: computed(() => props.enableSorting),
+});
+
+const features = [withExpandableRows, withSorting];
 </script>
 
 <template>

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/expandableRows/expandableRows.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/expandableRows/expandableRows.ct.tsx
@@ -55,3 +55,28 @@ test("should expand rows", async ({ mount, makeAxeBuilder }) => {
   // ASSERT
   await expectRowCount(3);
 });
+
+test("should not render header actions from other features", async ({ mount }) => {
+  // ARRANGE
+  const component = await mount(
+    <TestCase
+      columns={[
+        { key: "a", label: "A" },
+        { key: "b", label: "B" },
+      ]}
+      data={[]}
+      enableSorting
+    />,
+  );
+
+  // ASSERT
+  await expect(
+    component.getByRole("columnheader").first().getByRole("button"),
+    "should hide header actions for expandable column",
+  ).toBeHidden();
+
+  await expect(
+    component.getByRole("columnheader").nth(1).getByRole("button"),
+    "should show header actions for regular columns",
+  ).toBeVisible();
+});

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/expandableRows/expandableRows.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/expandableRows/expandableRows.ts
@@ -73,6 +73,10 @@ export const useExpandableRows = <TEntry extends DataGridEntry>(
       },
       typeRenderer: {
         [BUTTON_COLUMN_TYPE]: createTypeRenderer({
+          header: {
+            // ensure no header actions are rendered from other features like sorting, filtering etc.
+            component: () => null,
+          },
           cell: {
             tdAttributes: {
               class: "onyx-data-grid-expand-cell",


### PR DESCRIPTION
Fix the `useExpandableRows` data grid feature to ensure the header for the expand column is always empty. Previously, other feature actions such as sorting or filtering were shown.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
