### PR TITLE
docs: implement text editor examples

### DIFF
--- a/.changeset/slick-buttons-stand.md
+++ b/.changeset/slick-buttons-stand.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/tiptap": minor
+---
+
+feat: generate and publish `component-meta.json` file which includes the onyx API as JSON

--- a/apps/showcase/app/components/ComponentMeta.vue
+++ b/apps/showcase/app/components/ComponentMeta.vue
@@ -8,9 +8,13 @@ const props = defineProps<{
    * @example OnyxButton.
    */
   component: string;
+  /**
+   * The npm package name that the component is including in.
+   */
+  package: string;
 }>();
 
-const meta = computed(() => getComponentMeta(props.component));
+const meta = computed(() => getComponentMeta(props.component, props.package));
 
 // build time breaker to guarantee that no non-existing components are used
 // see "prerender" config in nuxt.config.ts

--- a/apps/showcase/app/components/ComponentMeta.vue
+++ b/apps/showcase/app/components/ComponentMeta.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
    */
   component: string;
   /**
-   * The npm package name that the component is including in.
+   * The name of the npm package that the component belongs to.
    */
   package?: string;
 }>();

--- a/apps/showcase/app/components/ComponentMeta.vue
+++ b/apps/showcase/app/components/ComponentMeta.vue
@@ -11,18 +11,24 @@ const props = defineProps<{
   /**
    * The npm package name that the component is including in.
    */
-  package: string;
+  package?: string;
 }>();
 
-const meta = computed(() => getComponentMeta(props.component, props.package));
+const { data: meta, status } = await useAsyncData(
+  () => `component-meta-${props.package}-${props.component}`,
+  () => getComponentMeta(props.component, props.package),
+);
 
 // build time breaker to guarantee that no non-existing components are used
 // see "prerender" config in nuxt.config.ts
 watchEffect(() => {
+  // ensure "useAsyncData()" call is ready to be accessed
+  if (status.value !== "success") return;
+
   if (!meta.value) {
     throw createError({
       statusCode: 404,
-      statusMessage: `Component meta not found for component "${props.component}".`,
+      statusMessage: `Component meta not found for component "${props.component}" in package "${props.package}".`,
       // throwing a fatal error  will fail during SSR / prerendering
       fatal: true,
     });

--- a/apps/showcase/app/pages/components/[category]/[name].vue
+++ b/apps/showcase/app/pages/components/[category]/[name].vue
@@ -54,7 +54,7 @@ const activeTab = useRouteQuery("tab", "overview");
         </OnyxTab>
 
         <OnyxTab :label="$t('components.property', 2)" value="properties">
-          <ComponentMeta :component="data.componentName" />
+          <ComponentMeta :component="data.componentName" :package="data.package" />
         </OnyxTab>
       </OnyxTabs>
     </div>

--- a/apps/showcase/app/utils/component-meta.ts
+++ b/apps/showcase/app/utils/component-meta.ts
@@ -1,15 +1,24 @@
-import tiptapComponentMeta from "@sit-onyx/tiptap/component-meta.json";
-import componentMeta from "sit-onyx/dist/component-meta.json";
 import type { ComponentMeta } from "vue-component-meta";
+
+type OnyxComponentMeta =
+  | typeof import("sit-onyx/dist/component-meta.json")
+  | typeof import("@sit-onyx/tiptap/component-meta.json");
 
 /**
  * Gets the meta data for a given onyx component.
  */
-export function getComponentMeta(
+export async function getComponentMeta(
   componentName: string,
-  packageName: string,
-): ComponentMeta | undefined {
-  const data = packageName === "@sit-onyx/tiptap" ? tiptapComponentMeta : componentMeta;
-  const meta = data.find((component) => component.displayName === componentName);
+  packageName = "sit-onyx",
+): Promise<ComponentMeta | undefined> {
+  let data: OnyxComponentMeta | undefined;
+
+  if (packageName === "sit-onyx") {
+    data = (await import("sit-onyx/dist/component-meta.json")).default;
+  } else if (packageName === "@sit-onyx/tiptap") {
+    data = (await import("@sit-onyx/tiptap/component-meta.json")).default;
+  }
+
+  const meta = data?.find((component) => component.displayName === componentName);
   return meta as ComponentMeta | undefined;
 }

--- a/apps/showcase/app/utils/component-meta.ts
+++ b/apps/showcase/app/utils/component-meta.ts
@@ -1,10 +1,15 @@
+import tiptapComponentMeta from "@sit-onyx/tiptap/component-meta.json";
 import componentMeta from "sit-onyx/dist/component-meta.json";
 import type { ComponentMeta } from "vue-component-meta";
 
 /**
  * Gets the meta data for a given onyx component.
  */
-export function getComponentMeta(componentName: string): ComponentMeta | undefined {
-  const meta = componentMeta.find((component) => component.displayName === componentName);
+export function getComponentMeta(
+  componentName: string,
+  packageName: string,
+): ComponentMeta | undefined {
+  const data = packageName === "@sit-onyx/tiptap" ? tiptapComponentMeta : componentMeta;
+  const meta = data.find((component) => component.displayName === componentName);
   return meta as ComponentMeta | undefined;
 }

--- a/apps/showcase/content.config.ts
+++ b/apps/showcase/content.config.ts
@@ -26,6 +26,7 @@ export default defineContentConfig({
       source: { include: "en/components/**", exclude: ["**/*.vue"], prefix: "/components" },
       schema: z.object({
         componentName: z.string(),
+        package: z.string().default("sit-onyx"),
         status: z.enum(["new", "experimental", "deprecated"]).optional(),
       }),
     }),

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/examples/Basic.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxTextEditor } from "@sit-onyx/tiptap";
+import { ref } from "vue";
+
+const value = ref<string>();
+</script>
+
+<template>
+  <OnyxTextEditor v-model="value" label="Example label" placeholder="Placeholder..." required />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/examples/BottomToolbar.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/examples/BottomToolbar.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxTextEditor } from "@sit-onyx/tiptap";
+import { ref } from "vue";
+
+const value = ref<string>();
+</script>
+
+<template>
+  <OnyxTextEditor v-model="value" label="Example label" :toolbar="{ position: 'bottom' }" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/examples/CustomActions.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/examples/CustomActions.example.vue
@@ -1,0 +1,54 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import {
+  OnyxEditorToolbarAction,
+  OnyxEditorToolbarFlyout,
+  OnyxEditorToolbarGroup,
+  OnyxTextEditor,
+  type EditorToolbarFlyoutOption,
+} from "@sit-onyx/tiptap";
+import { computed, useTemplateRef } from "vue";
+
+const textEditor = useTemplateRef("editor");
+
+// you can optionally use the "useEditorUtils" to e.g. check if specific extensions are
+// registered for the Tiptap editor to show/hide actions dynamically
+// const { hasExtension } = useEditorUtils(computed(() => textEditor.value?.editor));
+
+const listOptions = computed<EditorToolbarFlyoutOption[]>(() => {
+  return [
+    {
+      label: "Option 1",
+      icon: iconPlaceholder,
+      active: textEditor.value?.editor?.isActive("extensionName"),
+      onClick: () => {
+        // do something
+      },
+    },
+    {
+      label: "Option 2",
+      icon: iconPlaceholder,
+      active: textEditor.value?.editor?.isActive("extensionName"),
+      onClick: () => {
+        // do something
+      },
+    },
+  ];
+});
+</script>
+
+<template>
+  <OnyxTextEditor ref="editor" label="Example label">
+    <template #actions>
+      <!-- use the OnyxEditorToolbarGroup to separate multiple actions with a vertical line -->
+      <OnyxEditorToolbarGroup>
+        <OnyxEditorToolbarAction label="Action 1" :icon="iconPlaceholder" />
+        <OnyxEditorToolbarAction label="Action 2" :icon="iconPlaceholder" />
+      </OnyxEditorToolbarGroup>
+
+      <OnyxEditorToolbarGroup>
+        <OnyxEditorToolbarFlyout label="Action 3" :icon="iconPlaceholder" :options="listOptions" />
+      </OnyxEditorToolbarGroup>
+    </template>
+  </OnyxTextEditor>
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/examples/Disabled.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/examples/Disabled.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxTextEditor } from "@sit-onyx/tiptap";
+import { ref } from "vue";
+
+const value = ref<string>("<p>Example value</p>");
+</script>
+
+<template>
+  <OnyxTextEditor v-model="value" label="Example label" disabled />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/examples/LabelPositions.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/examples/LabelPositions.example.vue
@@ -1,0 +1,13 @@
+<script lang="ts" setup>
+import { OnyxTextEditor } from "@sit-onyx/tiptap";
+import { ref } from "vue";
+
+const value = ref("");
+</script>
+
+<template>
+  <OnyxTextEditor v-model="value" label="Top" />
+  <OnyxTextEditor v-model="value" :label="{ label: 'Left', position: 'left' }" />
+  <OnyxTextEditor v-model="value" :label="{ label: 'Right', position: 'right' }" />
+  <OnyxTextEditor v-model="value" :label="{ label: 'Hidden', hidden: true }" />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/examples/Loading.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/examples/Loading.example.vue
@@ -1,0 +1,8 @@
+<script lang="ts" setup>
+import { OnyxTextEditor } from "@sit-onyx/tiptap";
+</script>
+
+<template>
+  <OnyxTextEditor label="Loading" loading />
+  <OnyxTextEditor label="Skeleton" skeleton />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/examples/Message.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/examples/Message.example.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+import { OnyxTextEditor } from "@sit-onyx/tiptap";
+import { ref } from "vue";
+
+const value = ref<string>();
+</script>
+
+<template>
+  <OnyxTextEditor
+    v-model="value"
+    label="Example label"
+    :message="{ label: 'Message', tooltipText: 'Message tooltip content' }"
+  />
+  <!--
+    "show-error" is only set for this example so the error is displayed immediately.
+    Remove it if not needed so the error is only displayed after user interaction.
+  -->
+  <OnyxTextEditor
+    v-model="value"
+    label="Example label"
+    :error="{ label: 'Custom error', tooltipText: 'Error tooltip content' }"
+    show-error
+  />
+  <OnyxTextEditor
+    v-model="value"
+    label="Example label"
+    :success="{ label: 'Success', tooltipText: 'Success tooltip content' }"
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/examples/MinMaxLength.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/examples/MinMaxLength.example.vue
@@ -1,0 +1,16 @@
+<script lang="ts" setup>
+import { OnyxTextEditor } from "@sit-onyx/tiptap";
+import { ref } from "vue";
+
+const value = ref<string>();
+</script>
+
+<template>
+  <OnyxTextEditor
+    v-model="value"
+    label="Example label"
+    :minlength="8"
+    :maxlength="32"
+    with-counter
+  />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/examples/StarterKit.example.vue
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/examples/StarterKit.example.vue
@@ -1,0 +1,16 @@
+<script lang="ts" setup>
+import { OnyxStarterKit, OnyxTextEditor } from "@sit-onyx/tiptap";
+
+const extensions = [
+  OnyxStarterKit.configure({
+    blockquote: false, // e.g. disable specific extensions
+    heading: {
+      levels: [1, 2], // or customize existing ones
+    },
+  }),
+];
+</script>
+
+<template>
+  <OnyxTextEditor label="Example label" :extensions />
+</template>

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/index.md
@@ -1,0 +1,45 @@
+---
+title: Text editor
+componentName: OnyxTextEditor
+package: @sit-onyx/tiptap
+status: new
+---
+
+The text editor supports entering text with additional formatting such as inserting links, headlines and more and is therefore ideal for comments, descriptions and more. For simple text-only data, please use the [textarea](/components/form-elements/textarea) instead.
+
+## Installation
+
+Our text editor is based on the [Tiptap editor](https://tiptap.dev/docs/editor/getting-started/overview). Follow the steps below to get started:
+
+<steps>
+
+::step
+#headline
+Install dependencies
+
+#default
+Install the npm package into your project:
+
+:npm-install-code-tabs{packages="@sit-onyx/tiptap"}
+::
+
+::step
+#headline
+Import styles
+
+#default
+Next, import the editor styles. We recommend to import them locally in the component where the editor is used for optimized loading performance. Alternatively, you can also import it globally in the root of your application.
+
+```vue [ExampleComponent.vue]
+<script lang="ts" setup>
+import "@sit-onyx/tiptap/style.css";
+import { OnyxTextEditor } from "@sit-onyx/tiptap";
+</script>
+
+<template>
+<OnyxTextEditor label="Example label" />
+</template>
+```
+::
+
+</steps>

--- a/apps/showcase/content/en/components/02.form-elements/text-editor/index.md
+++ b/apps/showcase/content/en/components/02.form-elements/text-editor/index.md
@@ -2,7 +2,7 @@
 title: Text editor
 componentName: OnyxTextEditor
 package: @sit-onyx/tiptap
-status: new
+status: experimental
 ---
 
 The text editor supports entering text with additional formatting such as inserting links, headlines and more and is therefore ideal for comments, descriptions and more. For simple text-only data, please use the [textarea](/components/form-elements/textarea) instead.
@@ -28,18 +28,116 @@ Install the npm package into your project:
 Import styles
 
 #default
-Next, import the editor styles. We recommend to import them locally in the component where the editor is used for optimized loading performance. Alternatively, you can also import it globally in the root of your application.
+Next, import the editor styles. We recommend to import them globally in the root of your application:
 
-```vue [ExampleComponent.vue]
-<script lang="ts" setup>
-import "@sit-onyx/tiptap/style.css";
-import { OnyxTextEditor } from "@sit-onyx/tiptap";
-</script>
+  ::content-tabs
+  #vue
+  Import the styles in your `main.ts` file. Make sure to import them **after** the regular `sit-onyx/style.css` styles and **before** any of your components (usually the `App.vue` file).
 
-<template>
-<OnyxTextEditor label="Example label" />
-</template>
-```
+  ```ts [main.ts]
+  // make sure to import the Tiptap styles AFTER the general "sit-onyx" styles
+  // import "sit-onyx/style.css";
+  import "@sit-onyx/tiptap/style.css";
+  ```
+
+  #nuxt
+  Import the styles in your Nuxt config:
+
+  ```ts [nuxt.config.ts]
+  export default defineNuxtConfig({
+    css: ["@sit-onyx/tiptap/style.css"],
+  });
+  ```
+  ::
+
 ::
 
 </steps>
+
+## Examples
+
+### Basic
+
+The basic text editor includes a pre-defined set of extensions to support common functionalities. See the [extensions](#extensions) section below for customization options. The height of the editor is sized automatically by default which ensures that there is a minimum height which grows as the user types in until the maximum height is reached. You can customize the minimum and maximum number of rows using the `autosize` property or disable the maximum height completely so the textarea grows infinitely.
+
+_Type in multiple rows in the example below to see the autosize in action._
+
+Additionally, the user can resize the editor manually by dragging the bottom right corner vertically. You can disable this feature using the `disableManualResize` property.
+
+:component-example{name="Basic" layout="grow" style="--preview-max-width: 34rem"}
+
+### Toolbar position
+
+The toolbar can optionally be positioned at the bottom.
+
+:component-example{name="BottomToolbar" layout="grow" style="--preview-max-width: 34rem"}
+
+### Extensions
+
+The editor adapts automatically depending on your configuration. E.g. if you disable specific extensions or options (e.g. heading levels), the displayed editor toolbar will adapt accordingly. The editor extensions can be customized in several ways:
+
+<steps>
+
+::step
+#headline
+Configure starter kit
+
+#default
+The editor uses a custom `OnyxStarterKit` by default which is based on the [Tiptap starter kit](https://tiptap.dev/docs/editor/extensions/functionality/starterkit) but includes additional commonly used extensions and options.
+
+To override / customize the extensions used by the editor, use the `extensions` property to pass in custom extensions which will fully replace the default config. You can either re-use and configure the default `OnyxStarterKit` here or use your own starter kits / extensions.
+
+:component-example{name="StarterKit" layout="grow" style="--preview-max-width: 34rem"}
+::
+
+::step
+#headline
+Custom extensions
+
+#default
+Additionally, the editor can be extended with custom extensions and actions which are displayed at the end of the toolbar. Browse the Tiptap extensions overview for a full list iof extensions.
+
+<div class="onyx-grid">
+<link-card class="onyx-grid-span-4" headline="Tiptap extensions overview" link="https://tiptap.dev/docs/editor/extensions/overview" />
+</div>
+
+<br />
+
+:component-example{name="CustomActions" layout="grow" style="--preview-max-width: 42rem"}
+::
+
+</steps>
+
+
+### Disabled
+
+The editor can be disabled to indicate that it is currently not editable.
+
+:component-example{name="Disabled" layout="grow" style="--preview-max-width: 34rem"}
+
+### Min and max length
+
+When a min or maxlength is defined, the user must enter at least `min` and at most `max` characters before the value is valid. Otherwise the editor is invalid and a proper error message is displayed. Optionally, a character counter can be displayed.
+
+Tiptap's [CharacterCount extension](https://tiptap.dev/docs/editor/extensions/functionality/character-count) is used to determine the character count.
+
+:component-example{name="MinMaxLength" layout="grow" style="--preview-max-width: 34rem"}
+
+### Loading & Skeleton
+
+The loading state is used after a user interaction to indicate that the triggered action is currently loading / in progress. On the other hand, the skeleton should be used on initial page load when the data for the page / editor is initially loaded.
+
+:component-example{name="Loading" layout="grow" orientation="vertical" style="--preview-max-width: 34rem"}
+
+### Message
+
+An optional message, error or success message can be displayed. Each message supports showing an info tooltip with further information.
+When multiple message types are defined at once, only the most relevant will be displayed (e.g. error is preferred over the regular message).
+
+:component-example{name="Message" layout="grow" orientation="vertical" style="--preview-max-width: 34rem"}
+
+### Label positions
+
+The editor label can be positioned in several ways to support a wide variety of layouts.
+
+:component-example{name="LabelPositions" layout="grow" orientation="vertical" style="--preview-max-width: 34rem"}

--- a/apps/showcase/nuxt.config.ts
+++ b/apps/showcase/nuxt.config.ts
@@ -7,6 +7,7 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   extends: ["@sit-onyx/nuxt-docs"],
   modules: ["nuxt-studio", "nuxt-auth-utils", "@vueuse/nuxt"],
+  css: ["@sit-onyx/tiptap/style.css"],
   app: {
     head: {
       link: [{ rel: "icon", href: "/onyx-logo.svg" }],

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -25,6 +25,7 @@
     "@sit-onyx/mdc": "workspace:^",
     "@sit-onyx/nuxt": "workspace:^",
     "@sit-onyx/nuxt-docs": "workspace:^",
+    "@sit-onyx/tiptap": "workspace:^",
     "@vueuse/core": "^14.3.0",
     "@vueuse/nuxt": "^14.3.0",
     "@vueuse/router": "^14.3.0",

--- a/packages/sit-onyx/package.json
+++ b/packages/sit-onyx/package.json
@@ -61,6 +61,7 @@
     "@sit-onyx/playwright-utils": "workspace:^",
     "@sit-onyx/shared": "workspace:^",
     "@sit-onyx/storybook-utils": "workspace:^",
+    "@sit-onyx/vite-plugin-component-meta": "workspace:^",
     "@storybook/addon-a11y": "^10.4.0",
     "@vue/compiler-dom": "catalog:",
     "@vue/test-utils": "^2.4.10",
@@ -72,9 +73,7 @@
     "unplugin-dts": "catalog:",
     "vite": "catalog:",
     "vue": "catalog:",
-    "vue-component-meta": "catalog:",
     "vue-component-type-helpers": "^3.3.1",
-    "vue-docgen-api": "^4.79.2",
     "vue-i18n": "^11.4.4",
     "vue-router": "^5.0.7"
   }

--- a/packages/sit-onyx/vite.config.ts
+++ b/packages/sit-onyx/vite.config.ts
@@ -1,12 +1,12 @@
 /// <reference types="vitest/config" />
 import { vuePluginOptions } from "@sit-onyx/shared/playwright.config.base";
 import { VITE_BASE_CONFIG } from "@sit-onyx/shared/vite.config.base";
+import { extractComponentMeta } from "@sit-onyx/vite-plugin-component-meta";
 import vue from "@vitejs/plugin-vue";
 import { fileURLToPath, URL } from "node:url";
 import { DiagnosticCategory } from "typescript";
 import dts from "unplugin-dts/vite";
 import { defineConfig } from "vite";
-import { extractComponentMeta } from "./build/extract-component-meta.js";
 import packageJson from "./package.json" with { type: "json" };
 
 // https://vitejs.dev/config
@@ -31,7 +31,7 @@ export default defineConfig({
     }),
     vue(vuePluginOptions),
     extractComponentMeta({
-      tsconfigPath: "tsconfig.app.json",
+      tsconfigPath: getFilePath("tsconfig.app.json"),
       include: /\.vue$/,
     }),
   ],

--- a/packages/tiptap/package.json
+++ b/packages/tiptap/package.json
@@ -19,7 +19,8 @@
       "node": "./dist/index.js",
       "default": "./dist/index.js"
     },
-    "./style.css": "./dist/style.css"
+    "./style.css": "./dist/style.css",
+    "./component-meta.json": "./dist/component-meta.json"
   },
   "repository": {
     "type": "git",
@@ -55,6 +56,7 @@
     "@sit-onyx/playwright-utils": "workspace:^",
     "@sit-onyx/shared": "workspace:^",
     "@sit-onyx/storybook-utils": "workspace:^",
+    "@sit-onyx/vite-plugin-component-meta": "workspace:^",
     "@tiptap/extension-heading": "^3.23.5",
     "@tiptap/extension-text-align": "^3.23.5",
     "@tiptap/extensions": "^3.23.5",

--- a/packages/tiptap/vite.config.ts
+++ b/packages/tiptap/vite.config.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest/config" />
 import { VITE_BASE_CONFIG } from "@sit-onyx/shared/vite.config.base";
+import { extractComponentMeta } from "@sit-onyx/vite-plugin-component-meta";
 import vue from "@vitejs/plugin-vue";
 import { fileURLToPath, URL } from "node:url";
 import { DiagnosticCategory } from "typescript";
@@ -27,6 +28,10 @@ export default defineConfig({
       },
     }),
     vue(),
+    extractComponentMeta({
+      tsconfigPath: getFilePath("tsconfig.app.json"),
+      include: /\.vue$/,
+    }),
   ],
   build: {
     lib: {

--- a/packages/vite-plugin-component-meta/README.md
+++ b/packages/vite-plugin-component-meta/README.md
@@ -1,0 +1,9 @@
+<div align="center" style="text-align: center">
+<img alt="onyx logo" src="https://raw.githubusercontent.com/SchwarzIT/onyx/main/.github/onyx-logo.svg" height="96px">
+</div>
+
+<br>
+
+# @sit-onyx/vite-plugin-component-meta
+
+A Vite plugin to generate Vue component meta docs created by [Schwarz IT](https://it.schwarz).

--- a/packages/vite-plugin-component-meta/package.json
+++ b/packages/vite-plugin-component-meta/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@sit-onyx/vite-plugin-component-meta",
+  "description": "A Vite plugin to generate Vue component meta docs",
+  "version": "0.0.0",
+  "type": "module",
+  "author": "Schwarz IT KG",
+  "license": "Apache-2.0",
+  "private": true,
+  "files": [
+    "dist"
+  ],
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "homepage": "https://onyx.schwarz",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SchwarzIT/onyx",
+    "directory": "packages/vite-plugin-component-meta"
+  },
+  "bugs": {
+    "url": "https://github.com/SchwarzIT/onyx/issues"
+  },
+  "scripts": {
+    "build": "tsc"
+  },
+  "peerDependencies": {
+    "vite": ">= 8"
+  },
+  "dependencies": {
+    "vue-component-meta": "catalog:",
+    "vue-docgen-api": "^4.79.2"
+  },
+  "devDependencies": {
+    "@sit-onyx/shared": "workspace:^"
+  }
+}

--- a/packages/vite-plugin-component-meta/src/index.ts
+++ b/packages/vite-plugin-component-meta/src/index.ts
@@ -1,8 +1,7 @@
 // Based on https://github.com/storybookjs/storybook/blob/2b4ef8b687463fb3da89e2888620357afa31dadf/code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts
 import { readFile, stat } from "node:fs/promises";
-import { join, parse } from "node:path";
+import { parse } from "node:path";
 import type { Type } from "typescript";
-
 import { createFilter, type Plugin } from "vite";
 import {
   type ComponentMeta,
@@ -11,39 +10,7 @@ import {
   TypeMeta,
 } from "vue-component-meta";
 import { parseMulti } from "vue-docgen-api";
-
-type MetaSource = {
-  exportName: string;
-  displayName: string;
-  sourceFiles: string;
-} & ComponentMeta &
-  Exclude<MetaCheckerOptions["schema"], boolean>;
-
-type ExtractComponentMetaOptions = {
-  /**
-   * Path of the tsconfig file to use for the vue-component-meta checker.
-   * References are not supported.
-   * @default "tsconfig.json"
-   */
-  tsconfigPath?: string;
-  /**
-   * Filename of the output file. Should have the ".json" extension.
-   * @default "component-meta.json"
-   */
-  fileName?: string;
-  /**
-   * Files/Modules that should be considered.
-   */
-  include?: RegExp;
-  /**
-   * Files/Modules that should be excluded.
-   */
-  exclude?: RegExp;
-  /**
-   * Filter function to filter which exports should actually end up in the emitted file.
-   */
-  filterMeta?: (meta: MetaSource) => boolean;
-};
+import type { ExtractComponentMetaOptions, MetaSource } from "./types.js";
 
 export const DEFAULT_INCLUDE = /\.(vue|ts|js|tsx|jsx)$/;
 /**
@@ -197,20 +164,17 @@ async function createVueComponentMetaChecker(tsconfigPath = "tsconfig.json") {
     },
   };
 
-  const projectRoot = join(import.meta.dirname, "..");
-  const projectTsConfigPath = join(projectRoot, tsconfigPath);
-
-  const exists = await fileExists(projectTsConfigPath);
+  const exists = await fileExists(tsconfigPath);
   if (!exists) {
     throw new Error("The required tsconfig file does not exist!");
   }
 
-  const references = await getTsConfigReferences(projectTsConfigPath);
+  const references = await getTsConfigReferences(tsconfigPath);
   if (references.length > 0) {
     throw new Error("vue-component-meta does not resolve tsconfig references!");
   }
 
-  return createChecker(projectTsConfigPath, checkerOptions);
+  return createChecker(tsconfigPath, checkerOptions);
 }
 
 /** Gets the filename without file extension. */

--- a/packages/vite-plugin-component-meta/src/types.ts
+++ b/packages/vite-plugin-component-meta/src/types.ts
@@ -1,0 +1,34 @@
+import type { ComponentMeta, MetaCheckerOptions } from "vue-component-meta";
+
+export type ExtractComponentMetaOptions = {
+  /**
+   * Path of the tsconfig file to use for the vue-component-meta checker.
+   * References are not supported.
+   * @default "tsconfig.json"
+   */
+  tsconfigPath?: string;
+  /**
+   * Filename of the output file. Should have the ".json" extension.
+   * @default "component-meta.json"
+   */
+  fileName?: string;
+  /**
+   * Files/Modules that should be considered.
+   */
+  include?: RegExp;
+  /**
+   * Files/Modules that should be excluded.
+   */
+  exclude?: RegExp;
+  /**
+   * Filter function to filter which exports should actually end up in the emitted file.
+   */
+  filterMeta?: (meta: MetaSource) => boolean;
+};
+
+export type MetaSource = {
+  exportName: string;
+  displayName: string;
+  sourceFiles: string;
+} & ComponentMeta &
+  Exclude<MetaCheckerOptions["schema"], boolean>;

--- a/packages/vite-plugin-component-meta/tsconfig.json
+++ b/packages/vite-plugin-component-meta/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["@tsconfig/node24/tsconfig.json", "@sit-onyx/shared/tsconfig.json"],
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "types": ["node"],
+    "outDir": "./dist",
+    "declaration": true,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ importers:
       '@sit-onyx/nuxt-docs':
         specifier: workspace:^
         version: link:../../packages/nuxt-docs
+      '@sit-onyx/tiptap':
+        specifier: workspace:^
+        version: link:../../packages/tiptap
       '@vueuse/core':
         specifier: ^14.3.0
         version: 14.3.0(vue@3.5.34(typescript@5.9.3))
@@ -771,6 +774,9 @@ importers:
       '@sit-onyx/storybook-utils':
         specifier: workspace:^
         version: link:../storybook-utils
+      '@sit-onyx/vite-plugin-component-meta':
+        specifier: workspace:^
+        version: link:../vite-plugin-component-meta
       '@storybook/addon-a11y':
         specifier: ^10.4.0
         version: 10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
@@ -804,15 +810,9 @@ importers:
       vue:
         specifier: 3.5.34
         version: 3.5.34(typescript@5.9.3)
-      vue-component-meta:
-        specifier: 'catalog:'
-        version: 3.3.1(typescript@5.9.3)
       vue-component-type-helpers:
         specifier: ^3.3.1
         version: 3.3.1
-      vue-docgen-api:
-        specifier: ^4.79.2
-        version: 4.79.2(vue@3.5.34(typescript@5.9.3))
       vue-i18n:
         specifier: ^11.4.4
         version: 11.4.4(vue@3.5.34(typescript@5.9.3))
@@ -881,6 +881,9 @@ importers:
       '@sit-onyx/storybook-utils':
         specifier: workspace:^
         version: link:../storybook-utils
+      '@sit-onyx/vite-plugin-component-meta':
+        specifier: workspace:^
+        version: link:../vite-plugin-component-meta
       '@tiptap/extension-heading':
         specifier: ^3.23.5
         version: 3.23.5(@tiptap/core@3.23.5(@tiptap/pm@3.23.5))
@@ -911,6 +914,22 @@ importers:
       vite:
         specifier: 8.0.14
         version: 8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
+
+  packages/vite-plugin-component-meta:
+    dependencies:
+      vite:
+        specifier: 8.0.13
+        version: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
+      vue-component-meta:
+        specifier: 'catalog:'
+        version: 3.3.1(typescript@5.9.3)
+      vue-docgen-api:
+        specifier: ^4.79.2
+        version: 4.79.2(vue@3.5.34(typescript@5.9.3))
+    devDependencies:
+      '@sit-onyx/shared':
+        specifier: workspace:^
+        version: link:../shared
 
   packages/vite-plugin-svg:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,8 +918,8 @@ importers:
   packages/vite-plugin-component-meta:
     dependencies:
       vite:
-        specifier: 8.0.13
-        version: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
+        specifier: 8.0.14
+        version: 8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       vue-component-meta:
         specifier: 'catalog:'
         version: 3.3.1(typescript@5.9.3)


### PR DESCRIPTION
Relates to #5494

- implement text editor documentation and examples
- move component-meta vite plugin to separate package so we can re-use in the `@sit-onyx/tiptap` package to also generate the component-meta there

## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
