### PR TITLE
fix(tiptap): do not bundle any Tiptap dependencies

### DIFF
--- a/.changeset/orange-files-enter.md
+++ b/.changeset/orange-files-enter.md
@@ -3,3 +3,5 @@
 ---
 
 fix: do not bundle any Tiptap dependencies
+
+Previously some `@tiptap/` dependencies were bundled inline into the `@sit-onyx/tiptap` package which might have caused issues when additional Tiptap dependencies are installed in the project. This fix also reduces the bundles size of `@sit-onyx/tiptap` by ~85%.

--- a/.changeset/orange-files-enter.md
+++ b/.changeset/orange-files-enter.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/tiptap": patch
+---
+
+fix: do not bundle any Tiptap dependencies

--- a/packages/tiptap/vite.config.ts
+++ b/packages/tiptap/vite.config.ts
@@ -42,7 +42,12 @@ export default defineConfig({
     },
     rolldownOptions: {
       // make sure to externalize dependencies that shouldn't be bundled into the library
-      external: Object.keys(packageJson.peerDependencies),
+      external: [
+        // ensure to externalize all tiptap packages and sub-paths of them
+        // see: https://github.com/ueberdosis/tiptap/issues/3869#issuecomment-2167931620
+        /^@tiptap\/.+$/,
+        ...Object.keys(packageJson.peerDependencies),
+      ],
     },
   },
   test: {


### PR DESCRIPTION
Externalize any Tiptap dependencies from `@sit-onyx/tiptap` so they are not inlined into the build output.