### PR TITLE
fix(OnyxBasicDialog, OnyxModal): Fix OnyxModal closing on scrollbar click

### DIFF
--- a/.changeset/lucky-roses-exist.md
+++ b/.changeset/lucky-roses-exist.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxBasicDialog, OnyxModal): Fix OnyxModal closing on scrollbar click

--- a/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.ct.tsx
@@ -283,3 +283,29 @@ test("tooltip inside dialog", async ({ mount, makeAxeBuilder, page }) => {
 
   await expect(page).toHaveScreenshot("with-tooltip.png");
 });
+
+test("scrolling must not trigger an outside click", async ({ mount, page }) => {
+  const onUpdateOpen = createEmitSpy();
+  const onScrollEnd = createEmitSpy();
+
+  const component = await mount(
+    <OnyxBasicDialog
+      label="Label"
+      open
+      modal
+      onUpdate:open={onUpdateOpen}
+      onScrollendCapture={onScrollEnd}
+    >
+      <div style={{ background: "red", width: "200vw" }}>content</div>
+    </OnyxBasicDialog>,
+  );
+
+  // Click on the scrollbar
+  const { height, width, x, y } = (await component.boundingBox())!;
+  const clickX = x + width - 4;
+  const clickY = y + height - 4;
+  await page.mouse.click(clickX, clickY);
+
+  await expectEmit(onScrollEnd, 1);
+  await expectEmit(onUpdateOpen, 0);
+});

--- a/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.ct.tsx
@@ -283,29 +283,3 @@ test("tooltip inside dialog", async ({ mount, makeAxeBuilder, page }) => {
 
   await expect(page).toHaveScreenshot("with-tooltip.png");
 });
-
-test("scrolling must not trigger an outside click", async ({ mount, page }) => {
-  const onUpdateOpen = createEmitSpy();
-  const onScrollEnd = createEmitSpy();
-
-  const component = await mount(
-    <OnyxBasicDialog
-      label="Label"
-      open
-      modal
-      onUpdate:open={onUpdateOpen}
-      onScrollendCapture={onScrollEnd}
-    >
-      <div style={{ background: "red", width: "200vw" }}>content</div>
-    </OnyxBasicDialog>,
-  );
-
-  // Click on the scrollbar
-  const { height, width, x, y } = (await component.boundingBox())!;
-  const clickX = x + width - 4;
-  const clickY = y + height - 4;
-  await page.mouse.click(clickX, clickY);
-
-  await expectEmit(onScrollEnd, 1);
-  await expectEmit(onUpdateOpen, 0);
-});

--- a/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
@@ -129,13 +129,12 @@ defineExpose({
     font-family: var(--onyx-font-family-paragraph);
     color: var(--onyx-color-text-icons-neutral-intense);
     background-color: var(--onyx-color-base-background-blank);
-    overflow: auto;
+    overflow: hidden;
     z-index: var(--onyx-z-index-page-overlay);
     padding: 0;
 
-    $max-size: calc(100% - 2 * var(--onyx-basic-dialog-screen-gap));
-    max-width: $max-size;
-    max-height: $max-size;
+    max-width: calc(100vw - 2 * var(--onyx-basic-dialog-screen-gap));
+    max-height: calc(100vh - 2 * var(--onyx-basic-dialog-screen-gap));
 
     position: fixed;
     top: 0;
@@ -178,6 +177,11 @@ defineExpose({
     &__content {
       padding: var(--onyx-basic-dialog-padding);
       width: inherit;
+
+      /** Ensures that potential scrollbars are on the content element and not on the dialog element. Clicking a scrollbar of the dialog element would trigger an outside click. */
+      max-width: inherit;
+      max-height: inherit;
+      overflow: auto;
     }
   }
 }

--- a/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
@@ -129,7 +129,6 @@ defineExpose({
     font-family: var(--onyx-font-family-paragraph);
     color: var(--onyx-color-text-icons-neutral-intense);
     background-color: var(--onyx-color-base-background-blank);
-    overflow: hidden;
     z-index: var(--onyx-z-index-page-overlay);
     padding: 0;
 

--- a/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
@@ -177,6 +177,7 @@ defineExpose({
     &__content {
       padding: var(--onyx-basic-dialog-padding);
       width: inherit;
+      outline: none;
 
       /** Ensures that potential scrollbars are on the content element and not on the dialog element. Clicking a scrollbar of the dialog element would trigger an outside click. */
       max-width: inherit;

--- a/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxBasicDialog/OnyxBasicDialog.vue
@@ -129,6 +129,7 @@ defineExpose({
     font-family: var(--onyx-font-family-paragraph);
     color: var(--onyx-color-text-icons-neutral-intense);
     background-color: var(--onyx-color-base-background-blank);
+    overflow: hidden;
     z-index: var(--onyx-z-index-page-overlay);
     padding: 0;
 

--- a/packages/sit-onyx/src/components/OnyxDialog/OnyxDialog.vue
+++ b/packages/sit-onyx/src/components/OnyxDialog/OnyxDialog.vue
@@ -108,13 +108,9 @@ const isExpanded = useVModel({
     --onyx-dialog-padding-inline: var(--onyx-density-md);
     --onyx-basic-dialog-padding: 0;
     width: fit-content;
+
     .onyx-basic-popover__dialog {
       --onyx-basic-popover-max-width: calc(100% - 2 * (var(--onyx-density-md)));
-    }
-
-    .onyx-basic-dialog__content {
-      display: flex;
-      flex-direction: column;
     }
 
     &__header {

--- a/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.vue
+++ b/packages/sit-onyx/src/components/OnyxGlobalSearch/OnyxGlobalSearch.vue
@@ -283,6 +283,7 @@ provide(GLOBAL_SEARCH_INJECTION_KEY, { headless, activeValue });
       display: flex;
       flex-direction: column;
       max-width: 100%;
+      overflow: visible; // needed to show focus-visible outline on input
     }
 
     &__input {


### PR DESCRIPTION
Closes #5585

*Cause:* The scrollbar belongs to the `dialog` element. For layout reasons only the `.onyx-basic-dialog__content` element is considered inside when determining an outside click. So clicking the scrollbar triggered an outside click.

*Fix:* Move overflow handling and scrollbars to the content element.