### PR TITLE
fix(nuxt-docs): prevent 404 when route starts with locale but has no locale prefix

### DIFF
--- a/.changeset/metal-paws-shine.md
+++ b/.changeset/metal-paws-shine.md
@@ -3,3 +3,5 @@
 ---
 
 fix(useCollection): prevent 404 when route starts with locale but has no locale prefix
+
+This fixes cases where e.g. the route is `/design` for locale `de` which was incorrectly detected as locale prefix (`/de/design`) although no prefix is used in this case.

--- a/.changeset/metal-paws-shine.md
+++ b/.changeset/metal-paws-shine.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt-docs": patch
+---
+
+fix(useCollection): prevent 404 when route starts with locale but has no locale prefix

--- a/packages/nuxt-docs/app/composables/useCollection.ts
+++ b/packages/nuxt-docs/app/composables/useCollection.ts
@@ -32,9 +32,9 @@ export const useCollection = async <TCollection extends keyof Collections = keyo
 
     // get base path of current route (remove a potential locale prefix)
     _path = route.path;
-    const localePrefix = `/${locale.value}`;
+    const localePrefix = `/${locale.value}/`;
 
-    if (_path.startsWith(localePrefix)) return _path.slice(localePrefix.length);
+    if (_path.startsWith(localePrefix)) return `/${_path.slice(localePrefix.length)}`;
     return _path;
   });
 

--- a/packages/nuxt-docs/app/composables/useCollection.ts
+++ b/packages/nuxt-docs/app/composables/useCollection.ts
@@ -34,6 +34,7 @@ export const useCollection = async <TCollection extends keyof Collections = keyo
     _path = route.path;
     const localePrefix = `/${locale.value}/`;
 
+    if (_path === `/${locale.value}`) return "/";
     if (_path.startsWith(localePrefix)) return `/${_path.slice(localePrefix.length)}`;
     return _path;
   });


### PR DESCRIPTION
This fixes cases where e.g. the route is `/design` for locale `de` which was incorrectly detected as locale prefix (`/de/design`) although no prefix is used in this case.

## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
