### PR TITLE
docs(OnyxSearch): add missing CSS class to filter selects

### DIFF
--- a/packages/sit-onyx/src/components/OnyxSearch/examples/FilterBeside.vue
+++ b/packages/sit-onyx/src/components/OnyxSearch/examples/FilterBeside.vue
@@ -33,6 +33,7 @@ const categoryOptions = [
   >
     <OnyxSelect
       v-model="filters.status"
+      class="select"
       hide-label
       label="Status"
       :options="statusOptions"
@@ -41,6 +42,7 @@ const categoryOptions = [
     />
     <OnyxSelect
       v-model="filters.category"
+      class="select"
       hide-label
       label="Category"
       :options="categoryOptions"


### PR DESCRIPTION
Add missing CSS class to selects of the "FilterBeside" example of the OnyxSearch. Without it, the select width grows if a value is selected due to the clear button

## Checklist

- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
