### PR TITLE
fix(useClearButton): show clear button if value is 0 or false

### DIFF
--- a/.changeset/slow-showers-act.md
+++ b/.changeset/slow-showers-act.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(useClearButton): show clear button if value is 0 or false

--- a/packages/sit-onyx/src/composables/useClearButton.spec.ts
+++ b/packages/sit-onyx/src/composables/useClearButton.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test, vi } from "vitest";
+import { ref } from "vue";
+import { useClearButton } from "./useClearButton.js";
+
+vi.mock("../components/OnyxForm/OnyxForm.core.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../components/OnyxForm/OnyxForm.core.js")>();
+  return {
+    ...mod,
+    useFormContext: vi.fn().mockReturnValue({ disabled: ref(false) }),
+  };
+});
+
+test.each([
+  // truthy cases
+  { modelValue: "Test", visible: true },
+  { modelValue: " ", visible: true },
+  { modelValue: 0, visible: true },
+  { modelValue: true, visible: true },
+  { modelValue: false, visible: true },
+  { modelValue: [0], visible: true },
+  // falsy cases
+  { modelValue: undefined, visible: false },
+  { modelValue: null, visible: false },
+  { modelValue: "", visible: false },
+  { modelValue: NaN, visible: false },
+  { modelValue: [], visible: false },
+])("should show clear button with value $modelValue: $visible", ({ modelValue, visible }) => {
+  const { showClearButton } = useClearButton({
+    modelValue: ref(modelValue),
+    props: {},
+  });
+
+  expect(showClearButton.value).toBe(visible);
+});

--- a/packages/sit-onyx/src/composables/useClearButton.spec.ts
+++ b/packages/sit-onyx/src/composables/useClearButton.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from "vitest";
 import { ref } from "vue";
+import { useFormContext } from "../components/OnyxForm/OnyxForm.core.js";
 import { useClearButton } from "./useClearButton.js";
 
 vi.mock("../components/OnyxForm/OnyxForm.core.js", async (importOriginal) => {
@@ -25,10 +26,60 @@ test.each([
   { modelValue: NaN, visible: false },
   { modelValue: [], visible: false },
 ])("should show clear button with value $modelValue: $visible", ({ modelValue, visible }) => {
+  // ARRANGE
   const { showClearButton } = useClearButton({
     modelValue: ref(modelValue),
     props: {},
   });
 
+  // ASSERT
   expect(showClearButton.value).toBe(visible);
+});
+
+test("should hide when readonly", () => {
+  // ARRANGE
+  const { showClearButton } = useClearButton({
+    modelValue: ref("Test"),
+    props: { readonly: true },
+  });
+
+  // ASSERT
+  expect(showClearButton.value).toBe(false);
+});
+
+test("should hide when loading", () => {
+  // ARRANGE
+  const { showClearButton } = useClearButton({
+    modelValue: ref("Test"),
+    props: { loading: true },
+  });
+
+  // ASSERT
+  expect(showClearButton.value).toBe(false);
+});
+
+test("should hide when disabled", () => {
+  // ARRANGE
+  vi.mocked(useFormContext).mockReturnValue({ disabled: ref(true) } as ReturnType<
+    typeof useFormContext
+  >);
+
+  const { showClearButton } = useClearButton({
+    modelValue: ref("Test"),
+    props: {},
+  });
+
+  // ASSERT
+  expect(showClearButton.value).toBe(false);
+});
+
+test("should hide when explicitly hidden", () => {
+  // ARRANGE
+  const { showClearButton } = useClearButton({
+    modelValue: ref("Test"),
+    props: { hideClearIcon: true },
+  });
+
+  // ASSERT
+  expect(showClearButton.value).toBe(false);
 });

--- a/packages/sit-onyx/src/composables/useClearButton.spec.ts
+++ b/packages/sit-onyx/src/composables/useClearButton.spec.ts
@@ -16,6 +16,7 @@ test.each([
   { modelValue: "Test", visible: true },
   { modelValue: " ", visible: true },
   { modelValue: 0, visible: true },
+  { modelValue: NaN, visible: true },
   { modelValue: true, visible: true },
   { modelValue: false, visible: true },
   { modelValue: [0], visible: true },
@@ -23,7 +24,6 @@ test.each([
   { modelValue: undefined, visible: false },
   { modelValue: null, visible: false },
   { modelValue: "", visible: false },
-  { modelValue: NaN, visible: false },
   { modelValue: [], visible: false },
 ])("should show clear button with value $modelValue: $visible", ({ modelValue, visible }) => {
   // ARRANGE

--- a/packages/sit-onyx/src/composables/useClearButton.ts
+++ b/packages/sit-onyx/src/composables/useClearButton.ts
@@ -27,7 +27,7 @@ export const useClearButton = (options: UseClearButtonOptions) => {
 };
 
 /**
- * Checks if the given value is considered defines in order to show the clear button.
+ * Checks if the given value is considered "defined" in order to show the clear button.
  */
 function isValueDefined(value: unknown): boolean {
   // any number expect NaN (including 0 should be considered defined)

--- a/packages/sit-onyx/src/composables/useClearButton.ts
+++ b/packages/sit-onyx/src/composables/useClearButton.ts
@@ -30,7 +30,6 @@ export const useClearButton = (options: UseClearButtonOptions) => {
  * Checks if the given value is considered "defined" in order to show the clear button.
  */
 function isValueDefined(value: unknown): boolean {
-  // any number expect NaN (including 0 should be considered defined)
   if (typeof value === "number" || typeof value === "boolean") return true;
   if (Array.isArray(value)) return value.length > 0;
   return !!value;

--- a/packages/sit-onyx/src/composables/useClearButton.ts
+++ b/packages/sit-onyx/src/composables/useClearButton.ts
@@ -31,7 +31,7 @@ export const useClearButton = (options: UseClearButtonOptions) => {
  */
 function isValueDefined(value: unknown): boolean {
   // any number expect NaN (including 0 should be considered defined)
-  if (typeof value === "number") return !isNaN(value);
+  if (typeof value === "number") return true;
   if (typeof value == "boolean") return true;
   if (Array.isArray(value)) return value.length > 0;
   return !!value;

--- a/packages/sit-onyx/src/composables/useClearButton.ts
+++ b/packages/sit-onyx/src/composables/useClearButton.ts
@@ -31,8 +31,7 @@ export const useClearButton = (options: UseClearButtonOptions) => {
  */
 function isValueDefined(value: unknown): boolean {
   // any number expect NaN (including 0 should be considered defined)
-  if (typeof value === "number") return true;
-  if (typeof value == "boolean") return true;
+  if (typeof value === "number" || typeof value === "boolean") return true;
   if (Array.isArray(value)) return value.length > 0;
   return !!value;
 }

--- a/packages/sit-onyx/src/composables/useClearButton.ts
+++ b/packages/sit-onyx/src/composables/useClearButton.ts
@@ -20,8 +20,19 @@ export const useClearButton = (options: UseClearButtonOptions) => {
     }
 
     const value = toValue(options.modelValue);
-    return Array.isArray(value) ? value.length > 0 : !!value;
+    return isValueDefined(value);
   });
 
   return { showClearButton };
 };
+
+/**
+ * Checks if the given value is considered defines in order to show the clear button.
+ */
+function isValueDefined(value: unknown): boolean {
+  // any number expect NaN (including 0 should be considered defined)
+  if (typeof value === "number") return !isNaN(value);
+  if (typeof value == "boolean") return true;
+  if (Array.isArray(value)) return value.length > 0;
+  return !!value;
+}


### PR DESCRIPTION
Fix the clear button logic to consider the number "0" and "false" as "being defined" to also show a clear button in this case.

## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
