### PR TITLE
fix(demo-app): prevent broken CSS layers on data grid page

### DIFF
--- a/apps/demo-app/app/components/Banner.vue
+++ b/apps/demo-app/app/components/Banner.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { OnyxImage, type OnyxImageProps } from "sit-onyx";
+import type { OnyxImageProps } from "sit-onyx";
 
 const props = defineProps<Pick<OnyxImageProps, "src">>();
 </script>

--- a/apps/demo-app/app/components/EditableDataGrid.vue
+++ b/apps/demo-app/app/components/EditableDataGrid.vue
@@ -2,22 +2,7 @@
 import { iconArrowSmallUpRight, iconFileCircleCheck } from "@sit-onyx/icons";
 import { OnyxTextEditor } from "@sit-onyx/tiptap";
 import "@sit-onyx/tiptap/style.css";
-import type { ColumnConfig } from "sit-onyx";
-import {
-  createFeature,
-  DataGridFeatures,
-  OnyxAccordion,
-  OnyxAccordionItem,
-  OnyxBadge,
-  OnyxDataGrid,
-  OnyxHeadline,
-  OnyxSeparator,
-  OnyxSidebar,
-  OnyxSlider,
-} from "sit-onyx";
-import type { EditState } from "sit-onyx/dist/components/OnyxDataGrid/features/all.js";
-import { computed, ref, watch } from "vue";
-import { useI18n } from "vue-i18n";
+import { createFeature, DataGridFeatures, type ColumnConfig } from "sit-onyx";
 
 type FoodProduct = {
   id: number;
@@ -90,7 +75,7 @@ const columns = computed<ColumnConfig<FoodProduct>[]>(() => [
 ]);
 
 const isEditable = ref(false);
-const editState = ref<EditState<FoodProduct>>({});
+const editState = ref<DataGridFeatures.EditState<FoodProduct>>({});
 const currentCodeTab = ref("tab-1");
 const isSidebarOpen = ref(false);
 const currentProduct = ref<FoodProduct | null>(null);
@@ -238,9 +223,9 @@ const reset = () => {
       </div>
 
       <div class="sidebar-content-inner">
-        <OnyxHeadline is="h3">{{
-          t("dataGrid.editableTable.product.fields.allergens")
-        }}</OnyxHeadline>
+        <OnyxHeadline is="h3">
+          {{ t("dataGrid.editableTable.product.fields.allergens") }}
+        </OnyxHeadline>
         <div class="allergens-wrapper">
           <OnyxBadge v-for="allergen in currentProduct.allergens" :key="allergen">
             {{ allergen }}

--- a/apps/demo-app/app/components/EditableDataGrid.vue
+++ b/apps/demo-app/app/components/EditableDataGrid.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { iconArrowSmallUpRight, iconFileCircleCheck } from "@sit-onyx/icons";
 import { OnyxTextEditor } from "@sit-onyx/tiptap";
-import "@sit-onyx/tiptap/style.css";
 import { createFeature, DataGridFeatures, type ColumnConfig } from "sit-onyx";
 
 type FoodProduct = {

--- a/apps/demo-app/app/components/GlobalSearch.vue
+++ b/apps/demo-app/app/components/GlobalSearch.vue
@@ -1,14 +1,6 @@
 <script lang="ts" setup>
 import { iconFile, iconSearch } from "@sit-onyx/icons";
-import {
-  normalizedIncludes,
-  OnyxGlobalSearch,
-  OnyxGlobalSearchGroup,
-  OnyxGlobalSearchOption,
-  OnyxUnstableNavButton,
-  type OnyxGlobalSearchOptionProps,
-} from "sit-onyx";
-import { computed, ref, watch } from "vue";
+import { normalizedIncludes, type OnyxGlobalSearchOptionProps } from "sit-onyx";
 
 type SearchGroup = {
   label: string;

--- a/apps/demo-app/app/components/KPICard.vue
+++ b/apps/demo-app/app/components/KPICard.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { iconExpandWindow } from "@sit-onyx/icons";
-import { OnyxCard, OnyxIcon, OnyxTag, type OnyxColor } from "sit-onyx";
+import type { OnyxColor } from "sit-onyx";
 
 const props = defineProps<{
   headline: string;

--- a/apps/demo-app/app/components/LinkCard.vue
+++ b/apps/demo-app/app/components/LinkCard.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { iconArrowSmallRight, iconExpandWindow } from "@sit-onyx/icons";
-import { OnyxCard, type OnyxCardProps, OnyxIcon, extractLinkProps, isInternalLink } from "sit-onyx";
+import { type OnyxCardProps, extractLinkProps, isInternalLink } from "sit-onyx";
 
 export type LinkCardProps = Required<Pick<OnyxCardProps, "link">> & {
   /**

--- a/apps/demo-app/app/components/NavBar.vue
+++ b/apps/demo-app/app/components/NavBar.vue
@@ -8,7 +8,7 @@ import {
   iconUserGroup,
   iconUserId,
 } from "@sit-onyx/icons";
-import { type OnyxNavBarSlots } from "sit-onyx";
+import type { OnyxNavBarSlots } from "sit-onyx";
 import logoUrl from "~/assets/images/onyx-logo.svg";
 
 defineSlots<Pick<OnyxNavBarSlots, "contextArea">>();

--- a/apps/demo-app/app/components/NavbarSwitch.vue
+++ b/apps/demo-app/app/components/NavbarSwitch.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import { iconDashboard, iconDraggable, iconDraggableHorizontal } from "@sit-onyx/icons";
-import { type SelectDialogOption } from "sit-onyx";
-import { computed, ref } from "vue";
+import type { SelectDialogOption } from "sit-onyx";
 
 const isVertical = defineModel<boolean>({ default: false });
 

--- a/apps/demo-app/app/components/NotificationAccordionItem.vue
+++ b/apps/demo-app/app/components/NotificationAccordionItem.vue
@@ -1,7 +1,5 @@
 <script lang="ts" setup>
 import { iconInbox } from "@sit-onyx/icons";
-import { OnyxAccordionItem, OnyxEmpty, OnyxIcon, OnyxNotificationCard } from "sit-onyx";
-import { useI18n } from "vue-i18n";
 import type { MyNotification } from "../stores/notification-store.js";
 
 const { t } = useI18n();

--- a/apps/demo-app/app/components/NotificationCenter.vue
+++ b/apps/demo-app/app/components/NotificationCenter.vue
@@ -1,17 +1,7 @@
 <script lang="ts" setup>
 import { iconBell, iconBellRing, iconCheckRead, iconCircleAttention } from "@sit-onyx/icons";
 import { promiseTimeout } from "@vueuse/core";
-import {
-  OnyxAccordion,
-  OnyxBadge,
-  OnyxBottomBar,
-  OnyxHeadline,
-  OnyxNotificationCard,
-  OnyxSidebar,
-  useGlobalFAB,
-  useNotification,
-} from "sit-onyx";
-import { ref } from "vue";
+import { useGlobalFAB, useNotification } from "sit-onyx";
 import type { MyNotification } from "~/stores/notification-store";
 
 const store = useNotificationStore();

--- a/apps/demo-app/app/components/SystemDataGrid.vue
+++ b/apps/demo-app/app/components/SystemDataGrid.vue
@@ -7,7 +7,6 @@ import {
   type ColumnGroupConfig,
   type TypeRenderMap,
 } from "sit-onyx";
-import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
 

--- a/apps/demo-app/app/components/UploadFileCard.vue
+++ b/apps/demo-app/app/components/UploadFileCard.vue
@@ -6,8 +6,7 @@ import {
   iconMediaPlay,
   iconTrash,
 } from "@sit-onyx/icons";
-import { type FileCardStatus, type OnyxFileCardProps } from "sit-onyx";
-import { computed } from "vue";
+import type { FileCardStatus, OnyxFileCardProps } from "sit-onyx";
 
 const props = defineProps<OnyxFileCardProps>();
 

--- a/apps/demo-app/app/components/UserDataGrid.vue
+++ b/apps/demo-app/app/components/UserDataGrid.vue
@@ -4,14 +4,12 @@ import {
   createFeature,
   DataGridFeatures,
   OnyxAvatar,
-  OnyxDataGrid,
   OnyxSystemButton,
   useToast,
   type ColumnConfig,
   type ColumnGroupConfig,
   type TypeRenderMap,
 } from "sit-onyx";
-import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
 

--- a/apps/demo-app/app/components/UserMenu.vue
+++ b/apps/demo-app/app/components/UserMenu.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 import { iconLogout } from "@sit-onyx/icons";
-import { type OnyxUserMenuProps } from "sit-onyx";
+import type { OnyxUserMenuProps } from "sit-onyx";
 import { version } from "sit-onyx/package.json";
+
 const props = defineProps<Pick<OnyxUserMenuProps, "position">>();
 </script>
 

--- a/apps/demo-app/app/components/VotingCard.vue
+++ b/apps/demo-app/app/components/VotingCard.vue
@@ -7,7 +7,6 @@ import {
   iconThumbsUp,
   iconTrash,
 } from "@sit-onyx/icons";
-import { OnyxCard } from "sit-onyx";
 
 const likes = ref(12);
 const dislikes = ref(1);

--- a/apps/demo-app/app/pages/charts.vue
+++ b/apps/demo-app/app/pages/charts.vue
@@ -2,8 +2,6 @@
 import { registerOnyxPlugin } from "@sit-onyx/chartjs-plugin";
 import { iconArrowSmallDown, iconArrowSmallUp } from "@sit-onyx/icons";
 import { Chart, registerables } from "chart.js";
-import { OnyxHeadline } from "sit-onyx";
-import { useI18n } from "vue-i18n";
 
 Chart.register(...registerables);
 registerOnyxPlugin(Chart);

--- a/apps/demo-app/app/pages/data-grid.vue
+++ b/apps/demo-app/app/pages/data-grid.vue
@@ -1,9 +1,4 @@
 <script lang="ts" setup>
-import { useI18n } from "vue-i18n";
-import EditableDataGrid from "../components/EditableDataGrid.vue";
-import SystemDataGrid from "../components/SystemDataGrid.vue";
-import UserDataGrid from "../components/UserDataGrid.vue";
-
 const modelValue = ref("user-tab");
 const { t } = useI18n();
 </script>

--- a/apps/demo-app/app/pages/index.vue
+++ b/apps/demo-app/app/pages/index.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { iconChart, iconTextSelector, iconToolTable } from "@sit-onyx/icons";
-import { useI18n } from "vue-i18n";
 import bannerImg from "~/assets/images/banner.webp";
 import coverImg from "~/assets/images/cover.webp";
 import onyxLogo from "~/assets/images/onyx-logo.svg?raw";

--- a/apps/demo-app/app/stores/notification-store.ts
+++ b/apps/demo-app/app/stores/notification-store.ts
@@ -1,4 +1,3 @@
-import { defineStore } from "pinia";
 import type { OnyxNotificationCardProps } from "sit-onyx";
 
 export type MyNotification = OnyxNotificationCardProps & {

--- a/apps/demo-app/app/stores/settings-store.ts
+++ b/apps/demo-app/app/stores/settings-store.ts
@@ -1,4 +1,3 @@
-import { defineStore } from "pinia";
 import type { Density } from "sit-onyx";
 
 export type UserSettings = {

--- a/apps/demo-app/layers/blueprint/app/components/LocaleSwitch.vue
+++ b/apps/demo-app/layers/blueprint/app/components/LocaleSwitch.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { iconTranslate } from "@sit-onyx/icons";
-import { type SelectDialogOption } from "sit-onyx";
+import type { SelectDialogOption } from "sit-onyx";
 
 const { locale, setLocale, locales } = useI18n();
 const isLanguageDialogOpen = ref(false);

--- a/apps/demo-app/nuxt.config.ts
+++ b/apps/demo-app/nuxt.config.ts
@@ -9,7 +9,7 @@ export default defineNuxtConfig({
     // see: https://nuxt.com/docs/4.x/guide/going-further/layers#named-layer-aliases
     name: "app",
   },
-  css: [resolve("./app/assets/css/index.scss")],
+  css: [resolve("./app/assets/css/index.scss"), "@sit-onyx/tiptap/style.css"],
   app: {
     head: {
       title: "onyx demo",


### PR DESCRIPTION
- fix(demo-app): prevent broken CSS layers on data grid page
- refactor(demo-app): remove unnecessary imports

The CSS layers issue is only visible when building and running in production