### PR TITLE
chore: add missing changeset for Nuxt module

### DIFF
--- a/.changeset/spotty-lemons-wish.md
+++ b/.changeset/spotty-lemons-wish.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt": minor
+---
+
+feat: support more languages

--- a/.changeset/spotty-lemons-wish.md
+++ b/.changeset/spotty-lemons-wish.md
@@ -3,3 +3,7 @@
 ---
 
 feat: support more languages
+
+The following languages are now supported: Bulgarian, Czech, Spanish, French, Croatian, Italian, Korean (updated), Dutch, Polish, Portuguese, Romanian and Slovak
+
+For a full list, please refer to the [i18n documentation](https://onyx.schwarz/development/i18n.html#build-in-languages).


### PR DESCRIPTION
Add missing changeset for new onyx languages added 4 months ago in #4855 but since we forgot to add a changeset for the Nuxt module, the changes were not released.