### PR TITLE
feat(figma-plugin): implement feedback and improvements

### DIFF
--- a/packages/figma-plugin-sync-icons/plugin/index.ts
+++ b/packages/figma-plugin-sync-icons/plugin/index.ts
@@ -99,8 +99,11 @@ async function syncIcons(message: { accessToken: string }) {
   const structure = remotePage.children;
   const remoteFrameNames = structure.map((frame: FrameNode) => frame.name);
 
+  const removedIcons: string[] = [];
+
   for (const child of [...(destinationPage.children as FrameNode[])]) {
     if (!remoteFrameNames.includes(child.name)) {
+      removedIcons.push(...child.children.map((icon) => icon.name));
       child.remove();
       continue;
     }
@@ -109,6 +112,7 @@ async function syncIcons(message: { accessToken: string }) {
 
     for (const icon of [...child.children]) {
       if (!remoteIconNames.includes(icon.name)) {
+        removedIcons.push(icon.name);
         icon.remove();
       }
     }
@@ -229,10 +233,20 @@ async function syncIcons(message: { accessToken: string }) {
     addedIcons.push(...importedInstances.map((instance) => instance.name));
   }
 
+  const messages: string[] = [];
+
   if (addedIcons.length) {
-    showToast(`Added ${addedIcons.length} new icons: ${addedIcons.join(", ")}`);
+    messages.push(`Added ${addedIcons.length} icons: ${addedIcons.join(", ")}`);
+  }
+  if (removedIcons.length) {
+    messages.push(`Removed ${removedIcons.length} icons: ${removedIcons.join(", ")}`);
+  }
+
+  if (messages.length) {
+    // Figma messages do not support newlines so we separate them with a character instead
+    showToast(messages.join(" | "));
   } else {
-    showToast("No icons added, everything is up to date.");
+    showToast("No icons changed, everything is up to date.");
   }
 
   figma.closePlugin();

--- a/packages/figma-plugin-sync-icons/plugin/index.ts
+++ b/packages/figma-plugin-sync-icons/plugin/index.ts
@@ -236,10 +236,10 @@ async function syncIcons(message: { accessToken: string }) {
   const messages: string[] = [];
 
   if (addedIcons.length) {
-    messages.push(`Added ${addedIcons.length} icons: ${addedIcons.join(", ")}`);
+    messages.push(`${addedIcons.length} added icon(s): ${addedIcons.join(", ")}`);
   }
   if (removedIcons.length) {
-    messages.push(`Removed ${removedIcons.length} icons: ${removedIcons.join(", ")}`);
+    messages.push(`${removedIcons.length} removed icon(s): ${removedIcons.join(", ")}`);
   }
 
   if (messages.length) {

--- a/packages/figma-plugin-sync-icons/plugin/index.ts
+++ b/packages/figma-plugin-sync-icons/plugin/index.ts
@@ -45,7 +45,7 @@ const MESSAGE_HANDLERS: Record<string, (data?: any) => Promise<void>> = {
 runPlugin();
 
 async function runPlugin() {
-  figma.showUI(__html__, { width: 720, height: 384 });
+  figma.showUI(__html__, { width: 400, height: 400 });
 
   figma.ui.onmessage = async (msg) => {
     const handler = MESSAGE_HANDLERS[msg.type];
@@ -56,7 +56,7 @@ async function runPlugin() {
     } catch (e) {
       // eslint-disable-next-line no-console -- error should be logged
       console.error(e);
-      figma.notify((e as Error).message);
+      showToast(e as Error);
       figma.closePlugin();
     }
   };
@@ -114,7 +114,7 @@ async function syncIcons(message: { accessToken: string }) {
     }
   }
 
-  let addedIcons = 0;
+  const addedIcons: string[] = [];
 
   for (const frame of structure) {
     const existingFramesMap = new Map(
@@ -217,8 +217,8 @@ async function syncIcons(message: { accessToken: string }) {
 
         return clone;
       } catch (error) {
-        figma.notify(
-          `Error importing component: ${error instanceof Error ? error.message : error}`,
+        showToast(
+          new Error(`Error importing component: ${error instanceof Error ? error.message : error}`),
         );
       }
       return null;
@@ -226,9 +226,26 @@ async function syncIcons(message: { accessToken: string }) {
 
     const importedInstances = (await Promise.all(iconPromises)).filter((instance) => !!instance);
     importedInstances.forEach((instance) => newFrame.appendChild(instance));
-    addedIcons += importedInstances.length;
+    addedIcons.push(...importedInstances.map((instance) => instance.name));
   }
 
-  figma.notify(`Synched ${addedIcons} new icons`);
+  if (addedIcons.length) {
+    showToast(`Added ${addedIcons.length} new icons: ${addedIcons.join(", ")}`);
+  } else {
+    showToast("No icons added, everything is up to date.");
+  }
+
   figma.closePlugin();
+}
+
+/**
+ * Shows a Figma notification / toast.
+ */
+function showToast(message: string | Error) {
+  const msg = typeof message === "string" ? message : message.message;
+
+  figma.notify(msg, {
+    timeout: 6_000,
+    error: message instanceof Error,
+  });
 }


### PR DESCRIPTION
Relates to #5540

Implement PO feedback for the Figma icon sync plugin:
- adjust window size
- show toast with names or added and removed icons
- increase Figma notification time