### PR TITLE
docs: implement "Cards" examples

### DIFF
--- a/apps/showcase/content/en/components/04.cards/card/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/04.cards/card/examples/Basic.example.vue
@@ -1,0 +1,16 @@
+<script lang="ts" setup>
+import { OnyxCard } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxCard class="card">
+    Note: The card component is fully flexible. It can be adjusted with every content the project
+    needs.
+  </OnyxCard>
+</template>
+
+<style lang="scss" scoped>
+.card {
+  color: var(--onyx-color-text-icons-info-intense);
+}
+</style>

--- a/apps/showcase/content/en/components/04.cards/card/examples/Clickable.example.vue
+++ b/apps/showcase/content/en/components/04.cards/card/examples/Clickable.example.vue
@@ -1,0 +1,43 @@
+<script lang="ts" setup>
+import { iconTouchPress } from "@sit-onyx/icons";
+import { OnyxCard, OnyxHeadline, OnyxIcon, useToast } from "sit-onyx";
+
+const toast = useToast();
+
+const handleClick = () => {
+  // your logic here...
+  toast.show({
+    headline: "Card clicked",
+    description: "Implement your custom logic here...",
+  });
+};
+</script>
+
+<template>
+  <OnyxCard class="card" clickable @click="handleClick">
+    <OnyxIcon :icon="iconTouchPress" size="48px" />
+
+    <div class="card__content">
+      <OnyxHeadline is="h3">Example headline</OnyxHeadline>
+      This is an example description for a clickable card.
+    </div>
+  </OnyxCard>
+</template>
+
+<style lang="scss" scoped>
+.card {
+  flex-direction: row;
+  gap: var(--onyx-density-md);
+
+  &:hover {
+    background-color: var(--onyx-color-base-neutral-200);
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--onyx-density-2xs);
+    flex-grow: 1;
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/04.cards/card/examples/Details.example.vue
+++ b/apps/showcase/content/en/components/04.cards/card/examples/Details.example.vue
@@ -1,0 +1,127 @@
+<script lang="ts" setup>
+import { iconCheck, iconFileCopy, iconPlaceholder } from "@sit-onyx/icons";
+import {
+  OnyxButton,
+  OnyxCard,
+  OnyxHeadline,
+  OnyxIcon,
+  OnyxSeparator,
+  OnyxSystemButton,
+  OnyxTag,
+} from "sit-onyx";
+</script>
+
+<template>
+  <OnyxCard class="card">
+    <div class="card__header">
+      <div class="card__icon-wrapper">
+        <OnyxIcon class="card__icon" :icon="iconCheck" size="16px" />
+      </div>
+
+      <div>
+        <OnyxHeadline is="h2">Action successful!</OnyxHeadline>
+        <div class="card__description onyx-text--small">
+          Lorem ipsum dolor sit amet consectetur.
+        </div>
+      </div>
+    </div>
+
+    <OnyxSeparator />
+
+    <div class="card__details">
+      <div class="detail">
+        <span class="detail__label">Number</span>
+        <span class="detail__value onyx-text--monospace">
+          48164100740
+          <OnyxSystemButton label="Copy number" :icon="iconFileCopy" />
+        </span>
+      </div>
+
+      <div class="detail">
+        <span class="detail__label">Date</span>
+        <span class="detail__value"> 10/08/25 </span>
+      </div>
+
+      <div class="detail">
+        <span class="detail__label">Time</span>
+        <span class="detail__value"> 10:42 </span>
+      </div>
+
+      <div class="detail">
+        <span class="detail__label">Status</span>
+        <span class="detail__value">
+          <OnyxTag label="waiting" color="warning" />
+        </span>
+      </div>
+    </div>
+
+    <OnyxButton class="card__button" label="Button" mode="outline" :icon="iconPlaceholder" />
+  </OnyxCard>
+</template>
+
+<style lang="scss" scoped>
+.card {
+  --onyx-card-gap: var(--onyx-density-md);
+  text-align: center;
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--onyx-card-gap);
+    align-items: center;
+  }
+
+  &__icon-wrapper {
+    border-radius: var(--onyx-radius-full);
+    background-color: var(--onyx-color-base-success-100);
+    padding: var(--onyx-density-lg);
+    width: max-content;
+  }
+
+  &__icon {
+    color: #fff;
+    background-color: var(--onyx-color-text-icons-success-intense);
+    border-radius: var(--onyx-radius-full);
+    padding: var(--onyx-density-xs);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: content-box;
+  }
+
+  &__description {
+    color: var(--onyx-color-text-icons-neutral-medium);
+    margin-top: var(--onyx-density-3xs);
+  }
+
+  &__details {
+    display: flex;
+    flex-direction: column;
+    gap: var(--onyx-density-xs);
+  }
+
+  &__button {
+    width: 100%;
+  }
+}
+
+.detail {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--onyx-density-xs);
+
+  &__label {
+    color: var(--onyx-color-text-icons-neutral-soft);
+    font-size: var(--onyx-font-size-sm);
+    line-height: var(--onyx-font-line-height-sm);
+  }
+
+  &__value {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--onyx-density-2xs);
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/04.cards/card/examples/Image.example.vue
+++ b/apps/showcase/content/en/components/04.cards/card/examples/Image.example.vue
@@ -15,7 +15,7 @@ import {
     <OnyxImage
       class="card__image"
       alt="Example image"
-      src="https://picsum.photos/320/128"
+      src="https://picsum.photos/id/16/320/128"
       :height="128"
       :width="320"
       shape="rounded"

--- a/apps/showcase/content/en/components/04.cards/card/examples/Image.example.vue
+++ b/apps/showcase/content/en/components/04.cards/card/examples/Image.example.vue
@@ -1,0 +1,87 @@
+<script lang="ts" setup>
+import {
+  OnyxButton,
+  OnyxCard,
+  OnyxFlyoutMenu,
+  OnyxHeadline,
+  OnyxImage,
+  OnyxMenuItem,
+  OnyxTag,
+} from "sit-onyx";
+</script>
+
+<template>
+  <OnyxCard class="card">
+    <OnyxImage
+      class="card__image"
+      alt="Example image"
+      src="https://picsum.photos/320/128"
+      :height="128"
+      :width="320"
+      shape="rounded"
+    />
+
+    <div class="card__header">
+      <div>
+        <div class="card__category onyx-text--small">Category name</div>
+        <OnyxHeadline is="h2">Example headline</OnyxHeadline>
+      </div>
+
+      <OnyxFlyoutMenu label="Actions" trigger="click">
+        <template #options>
+          <OnyxMenuItem>Action 1</OnyxMenuItem>
+          <OnyxMenuItem>Action 2</OnyxMenuItem>
+          <OnyxMenuItem>Action 3</OnyxMenuItem>
+        </template>
+      </OnyxFlyoutMenu>
+    </div>
+
+    <p class="card__description">
+      Lorem ipsum dolor sit amet consectetur. Id neque viverra faucibus ullamcorper dui volutpat.
+      Vel nec aliquet lorem turpis eu dui. At pellentesque senectus sed volutpat vitae nulla. Nisl
+      cursus dignissim sed eget neque tristique interdum pretium elit.
+    </p>
+
+    <div class="card__tags">
+      <OnyxTag v-for="i in 4" :key="i" label="Tag" color="neutral" />
+    </div>
+
+    <OnyxButton class="card__button" label="Button" />
+  </OnyxCard>
+</template>
+
+<style lang="scss" scoped>
+.card {
+  --onyx-card-gap: var(--onyx-density-md);
+
+  &__image {
+    width: 100%;
+  }
+
+  &__category {
+    color: var(--onyx-color-text-icons-neutral-medium);
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--onyx-card-gap);
+  }
+
+  &__description {
+    color: var(--onyx-color-text-icons-neutral-medium);
+  }
+
+  &__tags {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--onyx-density-xs);
+  }
+
+  &__button {
+    width: 100%;
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/04.cards/card/examples/KPI.example.vue
+++ b/apps/showcase/content/en/components/04.cards/card/examples/KPI.example.vue
@@ -1,0 +1,57 @@
+<script lang="ts" setup>
+import { iconArrowSmallUp, iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxCard, OnyxIcon, OnyxTag } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxCard class="card">
+    <div class="card__header">
+      Example KPI name
+
+      <div class="card__icon">
+        <OnyxIcon :icon="iconPlaceholder" size="16px" />
+      </div>
+    </div>
+
+    <div class="card__content">
+      <span class="card__value"> 5.0 </span>
+      <OnyxTag label="4.2 %" :icon="iconArrowSmallUp" density="compact" color="success" />
+    </div>
+  </OnyxCard>
+</template>
+
+<style lang="scss" scoped>
+.card {
+  &__header {
+    color: var(--onyx-color-text-icons-neutral-medium);
+    display: flex;
+    justify-content: space-between;
+    gap: var(--onyx-card-gap);
+    width: 100%;
+  }
+
+  &__icon {
+    color: #fff;
+    background-color: var(--onyx-color-text-icons-primary-intense);
+    border-radius: var(--onyx-radius-full);
+    padding: var(--onyx-density-xs);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: content-box;
+  }
+
+  &__content {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--onyx-density-md);
+  }
+
+  &__value {
+    font-size: 3rem;
+    line-height: 2.75rem;
+    font-weight: var(--onyx-font-weight-semibold);
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/04.cards/card/examples/Link.example.vue
+++ b/apps/showcase/content/en/components/04.cards/card/examples/Link.example.vue
@@ -1,0 +1,49 @@
+<script lang="ts" setup>
+import { iconArrowSmallRight, iconExpandWindow, iconPlaceholder } from "@sit-onyx/icons";
+import { isInternalLink, OnyxCard, OnyxCardProps, OnyxHeadline, OnyxIcon } from "sit-onyx";
+import { computed } from "vue";
+
+const link: OnyxCardProps["link"] = { href: "https://onyx.schwarz", target: "_blank" };
+
+// we want to show a different arrow icon based on whether the link is internal (same application) or external
+const isInternal = computed(() => {
+  if (!link) return;
+  const normalizedLink = typeof link === "string" ? { href: link } : link;
+  return isInternalLink(normalizedLink.href);
+});
+</script>
+
+<template>
+  <OnyxCard class="card" :link>
+    <OnyxIcon :icon="iconPlaceholder" size="48px" />
+
+    <div class="card__content">
+      <OnyxHeadline is="h3">Example headline</OnyxHeadline>
+      This is an example description for a link card.
+    </div>
+
+    <OnyxIcon class="card__arrow" :icon="isInternal ? iconArrowSmallRight : iconExpandWindow" />
+  </OnyxCard>
+</template>
+
+<style lang="scss" scoped>
+.card {
+  flex-direction: row;
+  gap: var(--onyx-density-md);
+
+  &:hover {
+    background-color: var(--onyx-color-base-neutral-200);
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--onyx-density-2xs);
+    flex-grow: 1;
+  }
+
+  &__arrow {
+    align-self: center;
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/04.cards/card/index.md
+++ b/apps/showcase/content/en/components/04.cards/card/index.md
@@ -8,7 +8,7 @@ Cards serve as versatile containers for a few short, related pieces of content. 
 
 ## Examples
 
-Since cards a very flexible and generic components, the content highly depends on the use case and is fully customizable. You can find a few examples below but feel free to create your own cards!
+Since cards a very flexible and generic components, the content highly depends on the use case and is fully customizable. You can find a few examples below to get started, feel free to copy and adjust them if needed or create your own cards from scratch.
 
 ### Basic
 

--- a/apps/showcase/content/en/components/04.cards/card/index.md
+++ b/apps/showcase/content/en/components/04.cards/card/index.md
@@ -1,0 +1,63 @@
+---
+title: Card
+componentName: OnyxCard
+---
+
+Cards serve as versatile containers for a few short, related pieces of content. Their primary purpose is to present information in a visually appealing and organized manner, enhancing user experience and content discoverability.
+
+
+## Examples
+
+Since cards a very flexible and generic components, the content highly depends on the use case and is fully customizable. You can find a few examples below but feel free to create your own cards!
+
+### Basic
+
+:component-example{name="Basic" layout="grow"}
+
+### Clickable
+
+The whole card can be made clickable in two ways: As button or as link.
+
+<steps>
+
+::step
+#headline
+Button
+
+#default
+Set the `clickable` property to use a button card that can be clicked to perform any custom action.
+
+:component-example{name="Clickable" layout="grow"}
+::
+
+::step
+#headline
+Link
+
+#default
+Alternatively, use the `link` property to add a link to another page.
+
+:component-example{name="Link" layout="grow"}
+::
+
+</steps>
+
+Clickable cards must **NOT** contain any interactive elements inside the content since the whole card is already interactive. If you need to add multiple actions, leave the card non-interactive and add the actions e.g. with multiple buttons inside the card.
+
+### Image card
+
+An image-based card to represent information with additional data such as image, category, tags etc.
+
+:component-example{name="Image" layout="grow"}
+
+### Details card
+
+A details card can be used to represent and focus on data-heavy use cases.
+
+:component-example{name="Details" layout="grow"}
+
+### KPI card
+
+KPI cards can be used to prominently display specific import values.
+
+:component-example{name="KPI" layout="grow"}

--- a/apps/showcase/content/en/components/04.cards/file-card/examples/Actions.example.vue
+++ b/apps/showcase/content/en/components/04.cards/file-card/examples/Actions.example.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+import { iconMoreVerticalSmall, iconTrash } from "@sit-onyx/icons";
+import { OnyxFileCard, OnyxFlyoutMenu, OnyxIconButton, OnyxMenuItem } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxFileCard filename="example.pdf" size="42MiB" type="application/pdf">
+    <template #actions>
+      <OnyxFlyoutMenu label="More actions" trigger="click">
+        <template #button="{ trigger }">
+          <OnyxIconButton
+            v-bind="trigger"
+            label="Toggle more actions"
+            color="neutral"
+            :icon="iconMoreVerticalSmall"
+          />
+        </template>
+
+        <template #options>
+          <OnyxMenuItem label="Action 1" />
+          <OnyxMenuItem label="Action 2" />
+          <OnyxMenuItem label="Action 3" />
+        </template>
+      </OnyxFlyoutMenu>
+
+      <OnyxIconButton color="danger" :icon="iconTrash" label="Remove file" />
+    </template>
+  </OnyxFileCard>
+</template>

--- a/apps/showcase/content/en/components/04.cards/file-card/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/04.cards/file-card/examples/Basic.example.vue
@@ -1,0 +1,19 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { MediaType, OnyxFileCard } from "sit-onyx";
+import { onBeforeUnmount } from "vue";
+
+// create an initial dummy file for this example
+const file = new File([iconPlaceholder], "icon-placeholder.svg", { type: "image/svg+xml" });
+const link = URL.createObjectURL(file);
+onBeforeUnmount(() => URL.revokeObjectURL(link));
+</script>
+
+<template>
+  <OnyxFileCard
+    :filename="file.name"
+    :size="file.size"
+    :type="file.type as MediaType"
+    :link="{ href: link, target: '_blank' }"
+  />
+</template>

--- a/apps/showcase/content/en/components/04.cards/file-card/examples/Skeleton.example.vue
+++ b/apps/showcase/content/en/components/04.cards/file-card/examples/Skeleton.example.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import { OnyxFileCard } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxFileCard filename="example.pdf" size="42MiB" type="application/pdf" skeleton />
+</template>

--- a/apps/showcase/content/en/components/04.cards/file-card/examples/Status.example.vue
+++ b/apps/showcase/content/en/components/04.cards/file-card/examples/Status.example.vue
@@ -1,0 +1,42 @@
+<script lang="ts" setup>
+import { OnyxFileCard } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxFileCard
+    filename="example.pdf"
+    size="42MiB"
+    type="application/pdf"
+    :status="{ text: 'Primary', color: 'primary', progress: 50 }"
+  />
+  <OnyxFileCard
+    filename="example.pdf"
+    size="42MiB"
+    type="application/pdf"
+    :status="{ text: 'Neutral', color: 'neutral', progress: 50 }"
+  />
+  <OnyxFileCard
+    filename="example.pdf"
+    size="42MiB"
+    type="application/pdf"
+    :status="{ text: 'Danger', color: 'danger', progress: 50 }"
+  />
+  <OnyxFileCard
+    filename="example.pdf"
+    size="42MiB"
+    type="application/pdf"
+    :status="{ text: 'Warning', color: 'warning', progress: 50 }"
+  />
+  <OnyxFileCard
+    filename="example.pdf"
+    size="42MiB"
+    type="application/pdf"
+    :status="{ text: 'Success', color: 'success', progress: 50 }"
+  />
+  <OnyxFileCard
+    filename="example.pdf"
+    size="42MiB"
+    type="application/pdf"
+    :status="{ text: 'Info', color: 'info', progress: 50 }"
+  />
+</template>

--- a/apps/showcase/content/en/components/04.cards/file-card/examples/Upload.example.vue
+++ b/apps/showcase/content/en/components/04.cards/file-card/examples/Upload.example.vue
@@ -1,0 +1,128 @@
+<script lang="ts" setup>
+import {
+  iconCircleX,
+  iconCloudArrowUp,
+  iconMediaPause,
+  iconMediaPlay,
+  iconTrash,
+} from "@sit-onyx/icons";
+import { OnyxFileCard, OnyxIconButton, type FileCardStatus } from "sit-onyx";
+import { computed, onUnmounted, ref } from "vue";
+
+type UploadStatus = "ready" | "paused" | "canceled" | "processing" | "done";
+
+/**
+ * Re-usable composable for managing the file upload state.
+ * Should be extracted to a different .ts file in a real project.
+ */
+const useFileUpload = () => {
+  const progress = ref(0);
+  const status = ref<UploadStatus>("ready");
+
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+
+  const removeInterval = () => {
+    clearInterval(intervalId);
+    intervalId = undefined;
+  };
+
+  onUnmounted(removeInterval);
+
+  const start = () => {
+    if (intervalId != undefined) return;
+    status.value = "processing";
+
+    // TODO: implement your actual upload here
+    // for this demo purpose, we will just use an interval
+    intervalId = setInterval(() => {
+      progress.value++;
+
+      if (progress.value >= 100) {
+        removeInterval();
+        status.value = "done";
+        progress.value = 0;
+      }
+    }, 50);
+  };
+
+  const pause = () => {
+    removeInterval();
+    status.value = "paused";
+  };
+
+  const cancel = () => {
+    removeInterval();
+    status.value = "canceled";
+    progress.value = 0;
+  };
+
+  return { progress, status, start, pause, cancel };
+};
+
+const { status, progress, start, pause, cancel } = useFileUpload();
+
+const cardStatus = computed<FileCardStatus>(() => {
+  let _status: FileCardStatus;
+
+  switch (status.value) {
+    case "ready":
+      _status = { text: "Ready to upload", color: "neutral" };
+      break;
+    case "paused":
+      _status = { text: "Paused", color: "neutral" };
+      break;
+    case "canceled":
+      _status = { text: "Canceled", color: "danger" };
+      break;
+    case "done":
+      _status = { text: "Uploaded", color: "success" };
+      break;
+    default:
+      _status = { text: `${progress.value}%`, color: "primary" };
+  }
+
+  return { ..._status, progress: progress.value };
+});
+</script>
+
+<template>
+  <OnyxFileCard filename="example.pdf" type="application/pdf" size="42MiB" :status="cardStatus">
+    <template #actions>
+      <OnyxIconButton
+        v-if="status === 'ready' || status === 'canceled'"
+        label="Start upload"
+        :icon="iconCloudArrowUp"
+        color="primary"
+        @click="start()"
+      />
+      <OnyxIconButton
+        v-if="status === 'processing'"
+        label="Pause upload"
+        :icon="iconMediaPause"
+        color="neutral"
+        @click="pause()"
+      />
+      <OnyxIconButton
+        v-if="status === 'paused'"
+        label="Continue upload"
+        :icon="iconMediaPlay"
+        color="neutral"
+        @click="start()"
+      />
+      <OnyxIconButton
+        v-if="status === 'processing' || status === 'paused'"
+        label="Cancel upload"
+        :icon="iconCircleX"
+        color="neutral"
+        @click="cancel()"
+      />
+
+      <OnyxIconButton
+        v-if="status === 'done'"
+        label="Delete file"
+        :icon="iconTrash"
+        color="danger"
+      />
+    </template>
+  </OnyxFileCard>
+</template>

--- a/apps/showcase/content/en/components/04.cards/file-card/index.md
+++ b/apps/showcase/content/en/components/04.cards/file-card/index.md
@@ -1,0 +1,33 @@
+---
+title: File card
+componentName: OnyxFileCard
+---
+
+The file card is used to represent a selected or upload file. It is mainly used by the [file upload](/components/form-elements/file-upload) component but can also be used individually.
+
+## Examples
+
+### Basic
+
+The file card shows file metadata such as the file name and size. If set, the filename is clickable and will open a link to the file.
+
+:component-example{name="Basic" layout="grow"}
+
+### Actions
+
+Custom actions can be provided to support additional functionality like deleting, downloading etc.
+
+:component-example{name="Actions" layout="grow"}
+
+### Status
+
+Multiple status can be used to represent states like uploaded, error, warning etc. A optional progress bar can be shown.
+See our [color documentation](/introduction/foundation/colors#colors) for when to use which color.
+
+:component-example{name="Status" layout="grow" orientation="vertical"}
+
+### Interactive upload
+
+The file card itself only displays the file but has no actual upload logic since this heavily depends on the backend that is uploaded to. This examples shows how a upload process can look like.
+
+:component-example{name="Upload" layout="grow"}

--- a/apps/showcase/content/en/components/04.cards/file-card/index.md
+++ b/apps/showcase/content/en/components/04.cards/file-card/index.md
@@ -31,3 +31,9 @@ See our [color documentation](/introduction/foundation/colors#colors) for when t
 The file card itself only displays the file but has no actual upload logic since this heavily depends on the backend that is uploaded to. This examples shows how a upload process can look like.
 
 :component-example{name="Upload" layout="grow"}
+
+### Skeleton
+
+The skeleton should be used on initial page load when the data for the page / file is initially loaded.
+
+:component-example{name="Skeleton" layout="grow"}

--- a/apps/showcase/content/en/components/04.cards/info-card/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/04.cards/info-card/examples/Basic.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxInfoCard } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxInfoCard headline="Example headline">
+    Lorem ipsum dolor sit amet consectetur. Felis euismod sit amet nulla nulla amet libero sed. Id
+    non adipiscing duis felis volutpat.
+  </OnyxInfoCard>
+</template>

--- a/apps/showcase/content/en/components/04.cards/info-card/examples/Buttons.example.vue
+++ b/apps/showcase/content/en/components/04.cards/info-card/examples/Buttons.example.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import { OnyxButton, OnyxInfoCard } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxInfoCard headline="Example headline">
+    Lorem ipsum dolor sit amet consectetur. Felis euismod sit amet nulla nulla amet libero sed. Id
+    non adipiscing duis felis volutpat.
+
+    <template #buttons>
+      <OnyxButton color="neutral" label="Button" />
+      <OnyxButton color="neutral" label="Button" />
+    </template>
+  </OnyxInfoCard>
+</template>

--- a/apps/showcase/content/en/components/04.cards/info-card/examples/Closable.example.vue
+++ b/apps/showcase/content/en/components/04.cards/info-card/examples/Closable.example.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import { OnyxInfoCard } from "sit-onyx";
+
+const handleClose = () => {
+  // your close logic here, e.g. store a flag in the browsers local storage
+  // so the info card is not visible when re-loading the application
+};
+</script>
+
+<template>
+  <OnyxInfoCard headline="Example headline" closable @close="handleClose">
+    Lorem ipsum dolor sit amet consectetur. Felis euismod sit amet nulla nulla amet libero sed. Id
+    non adipiscing duis felis volutpat.
+  </OnyxInfoCard>
+</template>

--- a/apps/showcase/content/en/components/04.cards/info-card/examples/Colors.example.vue
+++ b/apps/showcase/content/en/components/04.cards/info-card/examples/Colors.example.vue
@@ -1,0 +1,12 @@
+<script lang="ts" setup>
+import { OnyxInfoCard } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxInfoCard headline="Primary" color="primary"> Example description </OnyxInfoCard>
+  <OnyxInfoCard headline="Neutral" color="neutral"> Example description </OnyxInfoCard>
+  <OnyxInfoCard headline="Danger" color="danger"> Example description </OnyxInfoCard>
+  <OnyxInfoCard headline="Warning" color="warning"> Example description </OnyxInfoCard>
+  <OnyxInfoCard headline="Success" color="success"> Example description </OnyxInfoCard>
+  <OnyxInfoCard headline="Info"> Example description </OnyxInfoCard>
+</template>

--- a/apps/showcase/content/en/components/04.cards/info-card/examples/HeaderActions.example.vue
+++ b/apps/showcase/content/en/components/04.cards/info-card/examples/HeaderActions.example.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import { OnyxInfoCard, OnyxMenuItem } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxInfoCard headline="Example headline">
+    Lorem ipsum dolor sit amet consectetur. Felis euismod sit amet nulla nulla amet libero sed. Id
+    non adipiscing duis felis volutpat.
+
+    <template #headerActions>
+      <OnyxMenuItem label="Action 1" />
+      <OnyxMenuItem label="Action 2" />
+    </template>
+  </OnyxInfoCard>
+</template>

--- a/apps/showcase/content/en/components/04.cards/info-card/index.md
+++ b/apps/showcase/content/en/components/04.cards/info-card/index.md
@@ -1,0 +1,38 @@
+---
+title: Info card
+componentName: OnyxInfoCard
+---
+
+Info cards are used to display informational content to the user or implement error handling within components. They can e.g. be used in cases where the user needs to manually review changes or to inform him about a system-related status.
+
+## Examples
+
+### Basic
+
+A basic info card includes a headline and description text but can also only contain one of them. The default icon can be changed using the `icon` property or removed completely by setting the value to `false`.
+
+:component-example{name="Basic" layout="grow"}
+
+### Colors
+
+Different colors are supported depending on the semantical meaning of the information. See our [color documentation](/introduction/foundation/colors#colors) for when to use which color.
+
+:component-example{name="Colors" layout="grow" orientation="vertical"}
+
+### Closable
+
+For temporary or one-time information, the info card can be closable which allows the user to close it.
+
+:component-example{name="Closable" layout="grow"}
+
+### Buttons
+
+Additional buttons are supported to perform custom actions.
+
+:component-example{name="Buttons" layout="grow"}
+
+### Header actions
+
+Custom actions can be displayed inside the header using a [flyout menu](/components/basic/flyout-menu). See the [menu item](/components/basic/menu-item) component for all available options.
+
+:component-example{name="HeaderActions" layout="grow"}

--- a/packages/sit-onyx/src/components/OnyxFileCard/OnyxFileCard.vue
+++ b/packages/sit-onyx/src/components/OnyxFileCard/OnyxFileCard.vue
@@ -31,7 +31,7 @@ const emit = defineEmits<{
 const slots = defineSlots<{
   /**
    * Optional actions to show on the right side of the card.
-   * Recommended to use the OnyxIconButton component here.
+   * Recommended to use the `OnyxIconButton` or `OnyxFlyoutMenu` component here.
    */
   actions?(): unknown;
 }>();


### PR DESCRIPTION
Relates to #5496

Implement new showcase examples and documentation for all card components

## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
