### PR TITLE
fix(OnyxTable, OnyxDataGrid): prevent empty state from causing infinite growth

### DIFF
--- a/.changeset/fluffy-llamas-exist.md
+++ b/.changeset/fluffy-llamas-exist.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxTable, OnyxDataGrid): prevent empty state from causing infinite growth inside `fit-content` parents (e.g. `OnyxModal` without an explicit width)

--- a/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.ct.tsx
@@ -88,8 +88,8 @@ test("should not resize in a loop when empty and used in a modal without explici
   // ACT
   const box1 = (await modal.boundingBox())!;
 
-  // eslint-disable-next-line playwright/no-wait-for-timeout -- relevant for this test
-  await page.waitForTimeout(2_000);
+  const handle = await modal.elementHandle();
+  await handle!.waitForElementState("stable");
 
   const box2 = (await modal.boundingBox())!;
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGrid.ct.tsx
@@ -1,5 +1,7 @@
 import { expect, test } from "../../playwright/a11y.js";
 import { executeMatrixScreenshotTest } from "../../playwright/screenshots.js";
+import OnyxModal from "../OnyxModal/OnyxModal.vue";
+import OnyxDataGrid from "./OnyxDataGrid.vue";
 import TestWrapperCt from "./TestWrapper.ct.vue";
 import TestWrapperColumnTypeOptionsCt from "./TestWrapperColumnTypeOptions.ct.vue";
 import TestWrapperWithColumnTypesCt from "./TestWrapperWithColumnTypes.ct.vue";
@@ -58,4 +60,39 @@ test.describe("Screenshot tests", () => {
       );
     },
   });
+});
+
+test("should not resize in a loop when empty and used in a modal without explicit width", async ({
+  mount,
+  page,
+}) => {
+  // ARRANGE
+  await mount(
+    <OnyxModal label="Example label" open>
+      <OnyxDataGrid data={[]} columns={["A", "B"]}>
+        <template v-slot:head>
+          <tr>
+            <th>Column A</th>
+            <th>Column B</th>
+          </tr>
+        </template>
+      </OnyxDataGrid>
+    </OnyxModal>,
+  );
+
+  const modal = page.getByRole("dialog", { name: "Example label" });
+
+  // ASSERT
+  await expect(modal).toBeVisible();
+
+  // ACT
+  const box1 = (await modal.boundingBox())!;
+
+  // eslint-disable-next-line playwright/no-wait-for-timeout -- relevant for this test
+  await page.waitForTimeout(2_000);
+
+  const box2 = (await modal.boundingBox())!;
+
+  // ASSERT
+  expect(box1.width).toBe(box2.width);
 });

--- a/packages/sit-onyx/src/components/OnyxTable/OnyxTable.vue
+++ b/packages/sit-onyx/src/components/OnyxTable/OnyxTable.vue
@@ -104,10 +104,12 @@ const headlineId = computed(() => (slots.headline ? _headlineId : undefined));
               <!-- We chose 99 as a sufficiently large colspan number, which should always be able to span all columns of the table.
                Additionally the data grid only supports colspan up to 99, see: https://github.com/SchwarzIT/onyx/blob/joca96/fix-3176-empty-data-grid-broken/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGridRenderer/OnyxDataGridRenderer.vue#L118 -->
               <td colspan="99">
-                <div class="onyx-table__empty-content">
-                  <slot name="empty" :default-message="isEmptyMessage">
-                    <OnyxEmpty> {{ isEmptyMessage }} </OnyxEmpty>
-                  </slot>
+                <div class="onyx-table__empty-wrapper">
+                  <div class="onyx-table__empty-content">
+                    <slot name="empty" :default-message="isEmptyMessage">
+                      <OnyxEmpty> {{ isEmptyMessage }} </OnyxEmpty>
+                    </slot>
+                  </div>
                 </div>
               </td>
             </tr>
@@ -389,13 +391,22 @@ const headlineId = computed(() => (slots.headline ? _headlineId : undefined));
   &__empty {
     --onyx-table-padding-block: 0;
     --onyx-table-padding-inline: 0;
+
+    &-wrapper {
+      // width: 0 + overflow: visible keeps this box from contributing to the
+      // table's intrinsic width, which would otherwise create a feedback loop
+      // inside a fit-content parent (e.g. OnyxModal): observed wrapper width
+      // -> empty content width -> table width -> wrapper width grows again.
+      position: sticky;
+      left: 0;
+      width: 0;
+      overflow: visible;
+    }
+
     &-content {
       display: flex;
       justify-content: center;
       align-items: center;
-
-      position: sticky;
-      left: 0;
       // table width - borders
       width: calc(var(--onyx-table-wrapper-observed-width) - 2 * var(--onyx-1px-in-rem));
       box-sizing: border-box;


### PR DESCRIPTION
Relates to #5614

fix(OnyxTable, OnyxDataGrid): prevent empty state from causing infinite growth inside `fit-content` parents (e.g. `OnyxModal` without an explicit width)

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) or functional test is added
- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
