### PR TITLE
fix(docs): determine browserlist support offline

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -37,6 +37,7 @@
     "@sit-onyx/storybook-utils": "workspace:^",
     "@sit-onyx/tiptap": "workspace:^",
     "@sit-onyx/vitepress-theme": "workspace:^",
+    "browserslist": "^4.28.2",
     "chart.js": "catalog:",
     "postcss": "^8.5.15",
     "sass-embedded": "catalog:",

--- a/apps/docs/src/.vitepress/browser-loader.data.mock.ts
+++ b/apps/docs/src/.vitepress/browser-loader.data.mock.ts
@@ -4,22 +4,16 @@ import type { Data } from "./browser-loader.data.js";
 export const data: Data = {
   browsers: [
     {
-      coverage: 96.86,
       id: "chrome",
       name: "Chrome",
-      versions: {
-        "108.0.0": 108,
-        "107.0.0": 107,
-      },
+      version: "107",
+      image: "/images/browsers/chrome.svg",
     },
     {
-      coverage: 91.86,
       id: "firefox",
       name: "Firefox",
-      versions: {
-        "108.0.0": 108,
-        "107.0.0": 107,
-      },
+      version: "42",
+      image: "/images/browsers/firefox.svg",
     },
   ],
 };

--- a/apps/docs/src/.vitepress/browser-loader.data.ts
+++ b/apps/docs/src/.vitepress/browser-loader.data.ts
@@ -1,15 +1,24 @@
-import { readFile } from "fs/promises";
-import { fileURLToPath } from "url";
+import browserslist from "browserslist";
 import { defineLoader } from "vitepress";
-import { cached } from "../cached.js";
-
-const browserslistRcPath = fileURLToPath(new URL("../../../../.browserslistrc", import.meta.url));
+import { capitalize } from "vue";
 
 export type Browser = {
-  coverage: number;
+  /**
+   * Browser ID.
+   */
   id: string;
+  /**
+   * User-friendly browser name.
+   */
   name: string;
-  versions: Record<string, number | undefined>;
+  /**
+   * Minimum supported version.
+   */
+  version: string;
+  /**
+   * Image URL for the browser logo.
+   */
+  image: string;
 };
 
 export interface Data {
@@ -17,38 +26,70 @@ export interface Data {
 }
 
 declare const data: Data;
-
 export { data };
 
 /**
- * Based on our browserslist config we load information about supported browser version and coverage from the
- * official browserlist API. This happens only on build time.
- * More information can be found on https://browsersl.ist
+ * Resolves our browserslist config to the minimum supported browser versions.
  */
 export default defineLoader({
-  async load(): Promise<Data> {
-    let browserRules = "";
+  watch: ["../../../../.browserslistrc"],
+  async load(watchedFiles): Promise<Data> {
+    const queries = browserslist.loadConfig({ path: watchedFiles[0] });
+    if (!queries) throw new Error("could not read .browserslistrc file");
 
-    try {
-      const data = await readFile(browserslistRcPath, "utf8");
-      const lines = data.split("\n").filter((l) => !!l && !l.startsWith("#"));
-      browserRules = lines.join("").trim();
-    } catch {
-      throw new Error("could not read .browserslistrc");
+    /**
+     * Key = browser ID, value: supported versions
+     */
+    const versionsByBrowser = new Map<string, Set<string>>();
+
+    for (const entry of browserslist(queries)) {
+      const [id, version] = entry.split(" ");
+
+      // filter out unwanted browsers
+      if (["and_chr", "ios_saf", "node"].includes(id)) continue;
+
+      const set = versionsByBrowser.get(id) ?? new Set();
+      set.add(version);
+      versionsByBrowser.set(id, set);
     }
 
-    const url = new URL(`https://browsersl.ist/api/browsers?q=${browserRules}`);
-    const fetchBrowserslistData = async () => {
-      const response = await fetch(url);
+    const browsers = Array.from(versionsByBrowser.entries()).reduce((obj, [id, versions]) => {
+      const version = sortVersions(Array.from(versions).sort())[0];
+      obj.push({
+        id,
+        version,
+        name: capitalize(id),
+        image: `/images/browsers/${id}.svg`,
+      });
+      return obj;
+    }, [] as Browser[]);
 
-      if (!response.ok) {
-        throw new Error("failed to fetch browserslist API data");
-      }
-
-      const data = await response.json();
-      return { browserRules, ...data };
-    };
-
-    return cached(url, fetchBrowserslistData);
+    return { browsers };
   },
 });
+
+/**
+ * Sorts the given versions ascending.
+ */
+function sortVersions(versions: string[]) {
+  return versions.toSorted((a, b) => {
+    // split the version strings into arrays of numbers
+    const aParts = a.split(".").map(Number);
+    const bParts = b.split(".").map(Number);
+
+    // find the maximum length to ensure we compare all segments (e.g., 1.0 vs 1.0.1)
+    const maxLength = Math.max(aParts.length, bParts.length);
+
+    for (let i = 0; i < maxLength; i++) {
+      // fallback to 0 if a version string has fewer segments (e.g., treat '1' as '1.0.0')
+      const aVal = aParts[i] ?? 0;
+      const bVal = bParts[i] ?? 0;
+
+      if (aVal !== bVal) {
+        return aVal - bVal; // ascending order (smallest first)
+      }
+    }
+
+    return 0; // versions are identical
+  });
+}

--- a/apps/docs/src/.vitepress/components/BrowsersList.vue
+++ b/apps/docs/src/.vitepress/components/BrowsersList.vue
@@ -1,41 +1,25 @@
 <script lang="ts" setup>
 import { data as browsersData } from "#src/.vitepress/browser-loader.data";
-
-const browsers = browsersData.browsers.filter((b) => b.coverage > 0);
-
-const popularBrowsers = ["chrome", "edge", "firefox", "safari", "samsung", "ios_saf"];
-
-const filteredBrowsers = popularBrowsers
-  .map((b) => {
-    const browser = browsers.find((browser) => browser.id === b);
-    if (!browser) return;
-    return {
-      ...browser,
-      minVersion: Object.keys(browser.versions).sort()[0],
-      image: `/images/browsers/${browser.id}.svg`,
-    };
-  })
-  .filter((b) => !!b);
 </script>
 
 <template>
-  <ul class="browsersList">
-    <li v-for="browser in filteredBrowsers" :key="browser.name" class="browser">
+  <ul class="list">
+    <li v-for="browser in browsersData.browsers" :key="browser.id" class="browser">
       <img
         :src="browser.image"
-        :alt="`${browser.name} image`"
+        :alt="`Logo for ${browser.name} browser`"
         width="40px"
         height="40px"
         class="browser__image"
       />
       <p class="browser__name">{{ browser.name }}</p>
-      <p>Version ≥ {{ browser.minVersion }}</p>
+      <p class="browser__version">Version ≥ {{ browser.version }}</p>
     </li>
   </ul>
 </template>
 
 <style lang="scss" scoped>
-.browsersList {
+.list {
   display: flex;
   flex-wrap: wrap;
   gap: var(--onyx-spacing-xl);
@@ -48,14 +32,18 @@ const filteredBrowsers = popularBrowsers
   list-style: none;
   padding: 0;
   margin: 0;
-  p {
+
+  &__version,
+  &__name {
     margin: 0;
     line-height: 1.3;
   }
+
   &__name {
     padding-top: var(--onyx-spacing-xs);
     font-weight: var(--onyx-font-weight-semibold);
   }
+
   &__image {
     position: relative;
     width: 40px;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@sit-onyx/vitepress-theme':
         specifier: workspace:^
         version: link:../../packages/vitepress-theme
+      browserslist:
+        specifier: ^4.28.2
+        version: 4.28.2
       chart.js:
         specifier: 'catalog:'
         version: 4.5.1


### PR DESCRIPTION
Currently all our CI builds fail because the [browsersl.ist](https://browsersl.ist/) website is down. This PR determines the supported browser versions offline using the browserslist npm package instead of relying on the online API.

<img width="941" height="651" alt="image" src="https://github.com/user-attachments/assets/b8351aa4-8f45-4257-aceb-6e36e92bac7e" />
