### PR TITLE
fix: http server only accepting the very first connection

### DIFF
--- a/.changeset/tender-pandas-bet.md
+++ b/.changeset/tender-pandas-bet.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/modelcontextprotocol": patch
+---
+
+fix: http transport (server) only accepting the very first connection

--- a/packages/modelcontextprotocol/src/index.ts
+++ b/packages/modelcontextprotocol/src/index.ts
@@ -54,7 +54,8 @@ Usage:
     onyx-mcp [options]
 
 Options:
- -t, --transport <stdio|http> Which kind of MCP server should be started (default: stdio).
+ -t, --transport <stdio|http> Which kind of MCP server should be started (default: stdio). 
+                              The "http" transport considers PORT and HOST environment variables, when starting the server.
  -r, --resourcesAsTools       Some LLM Coding Assistants (e.g. Gemini) are not able to to use MCP resources (yet). 
                               This setting makes resources also available as tools to support these Coding Assistants.
  -h, --help                   Show this help text and quit.
@@ -67,9 +68,8 @@ Options:
     if (!Object.keys(SUPPORTED_TRANSPORTS).includes(transport)) {
       throw new Error(`Unsupported transport: ${transport}`);
     }
-
-    const server = createServer({ resourcesAsTools });
-    await SUPPORTED_TRANSPORTS[transport as SupportedTransport](server);
+    const getServer = () => createServer({ resourcesAsTools });
+    await SUPPORTED_TRANSPORTS[transport as SupportedTransport](getServer);
   }
 }
 

--- a/packages/modelcontextprotocol/src/server/http.ts
+++ b/packages/modelcontextprotocol/src/server/http.ts
@@ -1,21 +1,24 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { log } from "node:console";
-import { randomUUID } from "node:crypto";
 import { createServer } from "node:http";
 
 /**
  * MCP server running as a http server.
  * `HOST` and `PORT` environment variable can be used to change the server settings.
  */
-export const run = async (server: McpServer) => {
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
+export const run = async (getServer: () => McpServer) => {
+  const httpServer = createServer(async (req, res) => {
+    // MCPServer and Transports cannot be reused and need to be created for each connection.
+    const server = getServer();
+    const transport = new StreamableHTTPServerTransport();
+    res.on("close", () => {
+      transport.close();
+      server.close();
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res);
   });
-
-  await server.connect(transport);
-
-  const httpServer = createServer((req, res) => transport.handleRequest(req, res));
 
   const PORT = Number.parseInt(process.env["PORT"] ?? "3000");
   const HOST = process.env["HOST"] ?? "0.0.0.0";

--- a/packages/modelcontextprotocol/src/server/stdio.ts
+++ b/packages/modelcontextprotocol/src/server/stdio.ts
@@ -6,8 +6,8 @@ import { error } from "node:console";
  * MCP server running via stdio.
  * All logging has to use stderr, otherwise the logging to stdio will break the transport.
  */
-export const run = async (server: McpServer) => {
+export const run = async (getServer: () => McpServer) => {
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await getServer().connect(transport);
   error("MCP Server running on stdio.");
 };


### PR DESCRIPTION
*Cause:* `Transports` and `McpServer` can only be used by a single client. When a second client tries to connect, the connection is rejected, because the transport is already in use.

*Fix:* For each new client a new server and transport is created.