### PR TITLE
fix(nuxt): correctly load i18n locales

### DIFF
--- a/.changeset/three-loops-listen.md
+++ b/.changeset/three-loops-listen.md
@@ -3,3 +3,6 @@
 ---
 
 fix(nuxt): correctly load i18n locales
+
+This fixes the following issue / warning:
+WARN Failed to load messages for locale "en" Failed loading locale (en): /@fs/@sit-onyx/nuxt/dist/runtime/locales/en-US.js — You need to define 'export default' that will return the locale messages.

--- a/.changeset/three-loops-listen.md
+++ b/.changeset/three-loops-listen.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt": patch
+---
+
+fix(nuxt): correctly load i18n locales

--- a/packages/nuxt/src/runtime/locales/bg-BG.js
+++ b/packages/nuxt/src/runtime/locales/bg-BG.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import bgBG from "sit-onyx/locales/bg-BG.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: bgBG };
-});
+export default { onyx: bgBG };

--- a/packages/nuxt/src/runtime/locales/cs-CZ.js
+++ b/packages/nuxt/src/runtime/locales/cs-CZ.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import csCZ from "sit-onyx/locales/cs-CZ.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: csCZ };
-});
+export default { onyx: csCZ };

--- a/packages/nuxt/src/runtime/locales/de-DE.js
+++ b/packages/nuxt/src/runtime/locales/de-DE.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import deDE from "sit-onyx/locales/de-DE.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: deDE };
-});
+export default { onyx: deDE };

--- a/packages/nuxt/src/runtime/locales/en-US.js
+++ b/packages/nuxt/src/runtime/locales/en-US.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import enUS from "sit-onyx/locales/en-US.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: enUS };
-});
+export default { onyx: enUS };

--- a/packages/nuxt/src/runtime/locales/es-ES.js
+++ b/packages/nuxt/src/runtime/locales/es-ES.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import esES from "sit-onyx/locales/es-ES.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: esES };
-});
+export default { onyx: esES };

--- a/packages/nuxt/src/runtime/locales/fr-FR.js
+++ b/packages/nuxt/src/runtime/locales/fr-FR.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import frFR from "sit-onyx/locales/fr-FR.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: frFR };
-});
+export default { onyx: frFR };

--- a/packages/nuxt/src/runtime/locales/hr-HR.js
+++ b/packages/nuxt/src/runtime/locales/hr-HR.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import hrHR from "sit-onyx/locales/hr-HR.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: hrHR };
-});
+export default { onyx: hrHR };

--- a/packages/nuxt/src/runtime/locales/it-IT.js
+++ b/packages/nuxt/src/runtime/locales/it-IT.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import itIT from "sit-onyx/locales/it-IT.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: itIT };
-});
+export default { onyx: itIT };

--- a/packages/nuxt/src/runtime/locales/ko-KR.js
+++ b/packages/nuxt/src/runtime/locales/ko-KR.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import koKR from "sit-onyx/locales/ko-KR.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: koKR };
-});
+export default { onyx: koKR };

--- a/packages/nuxt/src/runtime/locales/nl-NL.js
+++ b/packages/nuxt/src/runtime/locales/nl-NL.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import nlNL from "sit-onyx/locales/nl-NL.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: nlNL };
-});
+export default { onyx: nlNL };

--- a/packages/nuxt/src/runtime/locales/pl-PL.js
+++ b/packages/nuxt/src/runtime/locales/pl-PL.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import plPL from "sit-onyx/locales/pl-PL.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: plPL };
-});
+export default { onyx: plPL };

--- a/packages/nuxt/src/runtime/locales/pt-PT.js
+++ b/packages/nuxt/src/runtime/locales/pt-PT.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import ptPT from "sit-onyx/locales/pt-PT.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: ptPT };
-});
+export default { onyx: ptPT };

--- a/packages/nuxt/src/runtime/locales/ro-RO.js
+++ b/packages/nuxt/src/runtime/locales/ro-RO.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import roRO from "sit-onyx/locales/ro-RO.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: roRO };
-});
+export default { onyx: roRO };

--- a/packages/nuxt/src/runtime/locales/sk-SK.js
+++ b/packages/nuxt/src/runtime/locales/sk-SK.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { defineI18nLocale } from "#i18n";
 import skSK from "sit-onyx/locales/sk-SK.json";
 
-export default defineI18nLocale(() => {
-  return { onyx: skSK };
-});
+export default { onyx: skSK };


### PR DESCRIPTION
When using the onyx Nuxt module inside a Nuxt application, we currently have the following issues:
- the terminal shows this warning: "@sit-onyx/showcase:dev: [5:24:09 PM]  WARN  Failed to load messages for locale "en" Failed loading locale (en): /@fs/onyx/packages/nuxt/dist/runtime/locales/en-US.js — You need to define 'export default' that will return the locale messages."
- on initial page load, only the translation keys are displayed for a short time and then the translations are shown. This is annoying an also leads to hydration warnings

The issues are fixed by updating our exported locales inside the Nuxt module to not use the `defineI18nLocale` utility which is also not needed.

## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
