### PR TITLE
docs: implement "Data grid" examples and documentation

### DIFF
--- a/apps/showcase/app/components/ComponentMetaDataGrid.vue
+++ b/apps/showcase/app/components/ComponentMetaDataGrid.vue
@@ -90,6 +90,7 @@ const columns = computed(() => {
       key: "schema",
       label: t("components.schema"),
       type: "propertyMetaSchema",
+      width: "minmax(4rem, 16rem)",
     });
   }
 

--- a/apps/showcase/app/components/content/VariableArchitecturePreview.vue
+++ b/apps/showcase/app/components/content/VariableArchitecturePreview.vue
@@ -47,7 +47,7 @@ const descriptionId = useId();
           <OnyxIcon :icon="iconNavigationArrow" />
 
           <div class="variable__value">
-            <span>onyx-color-onyx-purple-800</span>
+            <span>onyx-color-system-purple-800</span>
             <div
               class="variable__color"
               :style="{ backgroundColor: 'var(--onyx-color-text-icons-info-intense)' }"
@@ -59,7 +59,7 @@ const descriptionId = useId();
           <OnyxIcon :icon="iconNavigationArrow" />
 
           <div class="variable__value">
-            <span>onyx-color-onyx-purple-500</span>
+            <span>onyx-color-system-purple-500</span>
             <div
               class="variable__color"
               :style="{ backgroundColor: 'var(--onyx-color-text-icons-info-intense)' }"

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/AsyncFiltering.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/AsyncFiltering.example.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { DataGridFeatures, normalizedIncludes, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed, ref, watch } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+};
+
+function getData(): Entry[] {
+  return [
+    { id: 1, name: "Alice" },
+    { id: 2, name: "Charlie" },
+    { id: 3, name: "Bob" },
+    { id: 4, name: "Robin" },
+    { id: 5, name: "John" },
+  ];
+}
+
+const data = ref<Entry[]>(getData());
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [{ key: "name", label: "Name" }];
+});
+
+const filterState = ref<DataGridFeatures.FilterState<Entry>>({});
+
+const withFiltering = DataGridFeatures.useFiltering<Entry>({
+  // options here...
+  filterState,
+});
+
+const features = [withFiltering];
+
+const isLoading = ref(false);
+
+watch(
+  filterState,
+  async () => {
+    // TODO: send a request with the filter state to your backend here to get the new filtered data
+    // for this example, we fake a request here
+    isLoading.value = true;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    data.value = getData().filter((entry) => {
+      const search = filterState.value.name?.trim();
+      if (!search) return true;
+      return normalizedIncludes(entry.name, search);
+    });
+
+    isLoading.value = false;
+  },
+  { deep: true },
+);
+</script>
+
+<template>
+  <OnyxDataGrid
+    :headline="{ text: 'Example headline', rowCount: true }"
+    :columns
+    :data
+    :features
+    :skeleton="isLoading"
+    async
+  />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/AsyncSorting.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/AsyncSorting.example.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { DataGridFeatures, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed, ref, watch } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+};
+
+const data = ref<Entry[]>([
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Charlie" },
+  { id: 3, name: "Bob" },
+  { id: 4, name: "Robin" },
+  { id: 5, name: "John" },
+]);
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [{ key: "name", label: "Name" }];
+});
+
+const sortState = ref<DataGridFeatures.SortState<Entry>>({
+  column: undefined,
+  direction: "none",
+});
+
+const withSorting = DataGridFeatures.useSorting<Entry>({
+  // options here...
+  sortState,
+});
+
+const features = [withSorting];
+
+const isLoading = ref(false);
+
+watch(sortState, async () => {
+  // TODO: send a request with the sort state to your backend here to get the new sorted data
+  // for this example, we fake a request here
+  isLoading.value = true;
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  data.value.sort((a, b) => a.name.localeCompare(b.name));
+  if (sortState.value.direction === "desc") data.value.reverse();
+  isLoading.value = false;
+});
+</script>
+
+<template>
+  <OnyxDataGrid
+    :headline="{ text: 'Example headline', rowCount: true }"
+    :columns
+    :data
+    :features
+    async
+    :skeleton="isLoading"
+  />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/Basic.example.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, name: "Alice", email: "alice@example.com" },
+    { id: 2, name: "Charlie", email: "charlie@example.com" },
+    { id: 3, name: "Bob", email: "bob@example.com" },
+    { id: 4, name: "Robin", email: "robin@example.com" },
+    { id: 5, name: "John", email: "john@example.com" },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "name", label: "Name" },
+    { key: "email", label: "Email" },
+  ];
+});
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnGroups.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnGroups.example.vue
@@ -14,8 +14,6 @@ const data = computed<Entry[]>(() => {
     { id: 1, name: "Alice", age: 30, birthday: new Date("1990-01-01") },
     { id: 2, name: "Charlie", age: 35, birthday: new Date("1998-02-11") },
     { id: 3, name: "Bob", age: 25, birthday: new Date("1995-06-15") },
-    { id: 4, name: "Robin", age: 28, birthday: new Date("2001-02-22") },
-    { id: 5, name: "John", age: 42, birthday: new Date("1997-04-18") },
   ];
 });
 

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnGroups.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnGroups.example.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ColumnGroupConfig, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+  age: number;
+  birthday: Date;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, name: "Alice", age: 30, birthday: new Date("1990-01-01") },
+    { id: 2, name: "Charlie", age: 35, birthday: new Date("1998-02-11") },
+    { id: 3, name: "Bob", age: 25, birthday: new Date("1995-06-15") },
+    { id: 4, name: "Robin", age: 28, birthday: new Date("2001-02-22") },
+    { id: 5, name: "John", age: 42, birthday: new Date("1997-04-18") },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry, typeof columnGroups>[]>(() => {
+  return [
+    { key: "name", label: "Name" },
+    { key: "age", label: "Age", type: "number", columnGroupKey: "group1" },
+    { key: "birthday", label: "Birthday", type: "date", columnGroupKey: "group1" },
+  ];
+});
+
+const columnGroups = {
+  group1: { label: "Group 1" },
+} satisfies ColumnGroupConfig;
+</script>
+
+<template>
+  <OnyxDataGrid
+    :headline="{ text: 'Example headline', rowCount: true }"
+    :columns
+    :data
+    :column-groups
+  />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeBoolean.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeBoolean.example.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { iconEye, iconEyeDisabled } from "@sit-onyx/icons";
+import { OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  active?: boolean;
+  visible?: boolean;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, active: false, visible: false },
+    { id: 2, active: true, visible: true },
+    { id: 3, active: false, visible: false },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "active", label: "Active?", type: "boolean" },
+    {
+      key: "visible",
+      label: "Visible?",
+      type: {
+        name: "boolean",
+        options: {
+          truthy: {
+            icon: iconEye,
+            color: "success",
+          },
+          falsy: {
+            icon: iconEyeDisabled,
+            color: "danger",
+          },
+        },
+      },
+    },
+  ];
+});
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeDate.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeDate.example.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { DateValue, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  date: DateValue;
+  datetime: DateValue;
+  time: DateValue;
+  timestamp: DateValue;
+  custom: DateValue;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    {
+      id: 1,
+      date: new Date(),
+      datetime: new Date(),
+      time: new Date(),
+      timestamp: new Date(),
+      custom: new Date(),
+    },
+    {
+      id: 2,
+      date: new Date(),
+      datetime: new Date(),
+      time: new Date(),
+      timestamp: new Date(),
+      custom: new Date(),
+    },
+    {
+      id: 3,
+      date: new Date(),
+      datetime: new Date(),
+      time: new Date(),
+      timestamp: new Date(),
+      custom: new Date(),
+    },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "date", label: "Date", type: "date" },
+    { key: "datetime", label: "Datetime", type: "datetime-local" },
+    { key: "time", label: "Time", type: "time" },
+    { key: "timestamp", label: "Timestamp", type: "timestamp" },
+    {
+      key: "custom",
+      label: "Custom format",
+      type: {
+        name: "date",
+        options: {
+          format: {
+            dateStyle: "short",
+          },
+        },
+      },
+    },
+  ];
+});
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeFallback.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeFallback.example.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name?: string;
+  email?: string;
+};
+
+const data = computed<Entry[]>(() => {
+  return [{ id: 1 }, { id: 2 }, { id: 3 }];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "name", label: "Name" },
+    {
+      key: "email",
+      label: "Email",
+      type: {
+        name: "string",
+        options: {
+          fallback: "not defined",
+        },
+      },
+    },
+  ];
+});
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeLink.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeLink.example.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { OnyxDataGrid, type ColumnConfig, type EditLinkValue } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  link?: string | EditLinkValue;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, link: "https://example.com" },
+    { id: 2, link: { href: "/components/data/data-grid", label: "Custom label" } },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    {
+      key: "link",
+      label: "Link",
+      type: {
+        name: "link",
+        // optionally add options such as open links in a new tab
+        options: {
+          target: "_blank",
+        },
+      },
+    },
+  ];
+});
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeNumber.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeNumber.example.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  quantity: number;
+  price: number;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, quantity: 42, price: 1.99 },
+    { id: 2, quantity: 512, price: 259.99 },
+    { id: 3, quantity: 1028, price: 6 },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "quantity", label: "Quantity", type: "number" },
+    {
+      key: "price",
+      label: "Price",
+      type: {
+        name: "number",
+        options: {
+          format: {
+            style: "currency",
+            currency: "EUR",
+          },
+        },
+      },
+    },
+  ];
+});
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeSelect.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeSelect.example.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { OnyxDataGrid, SelectOption, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  role: UserRole;
+};
+
+type UserRole = "user" | "editor" | "admin";
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, role: "user" },
+    { id: 2, role: "admin" },
+    { id: 3, role: "editor" },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    {
+      key: "role",
+      label: "User role",
+      type: {
+        name: "select",
+        options: {
+          options: [
+            { label: "User", value: "user" },
+            { label: "Administrator", value: "admin" },
+            { label: "Editor", value: "editor" },
+          ] satisfies SelectOption<UserRole>[],
+        },
+      },
+    },
+  ];
+});
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeString.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnTypeString.example.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, name: "Alice" },
+    { id: 2, name: "Charlie" },
+    { id: 3, name: "Bob" },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [{ key: "name", label: "Name" }];
+});
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnWidth.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ColumnWidth.example.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+  age: number;
+  description: string;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    {
+      id: 1,
+      name: "Alice",
+      age: 30,
+      description: "This is a example description that could be very long",
+    },
+    {
+      id: 2,
+      name: "Charlie",
+      age: 35,
+      description: "This is a example description that could be very long",
+    },
+    {
+      id: 3,
+      name: "Bob",
+      age: 25,
+      description: "This is a example description that could be very long",
+    },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "name", label: "Name" },
+    { key: "description", label: "Description", width: "minmax(10rem, 20rem)" },
+    { key: "age", label: "Age", type: "number", width: "max-content" },
+  ];
+});
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/EditingInline.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/EditingInline.example.vue
@@ -6,6 +6,7 @@ import {
   OnyxDataGrid,
   SelectOption,
   type ColumnConfig,
+  type EditLinkValue,
 } from "sit-onyx";
 import { computed, ref } from "vue";
 
@@ -16,6 +17,7 @@ type Entry = {
   birthday: Date;
   time: string;
   role: UserRole;
+  link: string | EditLinkValue;
   active?: boolean;
 };
 
@@ -30,6 +32,7 @@ const data = ref<Entry[]>([
     time: "10:00",
     active: true,
     role: "user",
+    link: { href: "https://example.com", label: "Link" },
   },
   {
     id: 4,
@@ -39,6 +42,7 @@ const data = ref<Entry[]>([
     time: "12:30",
     active: true,
     role: "editor",
+    link: { href: "https://example.com", label: "Link" },
   },
   {
     id: 5,
@@ -48,6 +52,7 @@ const data = ref<Entry[]>([
     time: "09:00",
     active: false,
     role: "admin",
+    link: { href: "https://example.com", label: "Link" },
   },
 ]);
 
@@ -58,6 +63,7 @@ const columns = computed<ColumnConfig<Entry>[]>(() => {
     { key: "birthday", label: "Birthday", type: "date" },
     { key: "time", label: "Time", type: "time" },
     { key: "active", label: "Active?", type: "boolean" },
+    { key: "link", label: "Link", type: "link" },
     {
       key: "role",
       label: "User role",

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/EditingInline.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/EditingInline.example.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { iconDisc, iconEdit, iconX } from "@sit-onyx/icons";
+import {
+  createFeature,
+  DataGridFeatures,
+  OnyxDataGrid,
+  SelectOption,
+  type ColumnConfig,
+} from "sit-onyx";
+import { computed, ref } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+  age: number;
+  birthday: Date;
+  time: string;
+  role: UserRole;
+  active?: boolean;
+};
+
+type UserRole = "user" | "editor" | "admin";
+
+const data = ref<Entry[]>([
+  {
+    id: 1,
+    name: "Alice",
+    age: 30,
+    birthday: new Date("1990-01-01"),
+    time: "10:00",
+    active: true,
+    role: "user",
+  },
+  {
+    id: 4,
+    name: "Robin",
+    age: 28,
+    birthday: new Date("2001-02-22"),
+    time: "12:30",
+    active: true,
+    role: "editor",
+  },
+  {
+    id: 5,
+    name: "John",
+    age: 42,
+    birthday: new Date("1997-04-18"),
+    time: "09:00",
+    active: false,
+    role: "admin",
+  },
+]);
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "name", label: "Name" },
+    { key: "age", label: "Age", type: "number" },
+    { key: "birthday", label: "Birthday", type: "date" },
+    { key: "time", label: "Time", type: "time" },
+    { key: "active", label: "Active?", type: "boolean" },
+    {
+      key: "role",
+      label: "User role",
+      type: {
+        name: "select",
+        options: {
+          options: [
+            { label: "User", value: "user" },
+            { label: "Administrator", value: "admin" },
+            { label: "Editor", value: "editor" },
+          ] satisfies SelectOption<UserRole>[],
+        },
+      },
+    },
+  ];
+});
+
+const isEditable = ref(false);
+const editState = ref<DataGridFeatures.EditState<Entry>>({});
+
+const withEditing = DataGridFeatures.useEditing<Entry>({
+  // options here...
+  mode: "manual",
+  enabled: isEditable,
+  editState,
+});
+
+// The logic when and how the editing is enabled, saved and cancelled is completely up to the developer.
+// In this example we use a custom feature to add buttons to interact with the feature
+const withEditingActions = createFeature(() => ({
+  name: Symbol("editingActions"),
+  watch: [isEditable],
+  actions: () => {
+    if (isEditable.value) {
+      return [
+        {
+          label: "Cancel",
+          displayAs: "button",
+          color: "neutral",
+          mode: "plain",
+          icon: iconX,
+          onClick: handleCancel,
+        },
+        {
+          label: "Save",
+          displayAs: "button",
+          icon: iconDisc,
+          onClick: handleSave,
+        },
+      ];
+    }
+
+    return [
+      {
+        label: "Edit",
+        displayAs: "button",
+        icon: iconEdit,
+        onClick: () => (isEditable.value = true),
+      },
+    ];
+  },
+}));
+
+const features = [withEditing, withEditingActions];
+
+const handleSave = () => {
+  for (const id in editState.value) {
+    const changes = editState.value[id];
+
+    const index = data.value.findIndex((row) => row.id === Number.parseInt(id));
+    if (index === -1) continue;
+
+    // the edit state only includes actually changed data so we need to make sure keep
+    // all previous data
+    data.value[index] = { ...data.value[index], ...changes };
+  }
+
+  isEditable.value = false;
+};
+
+const handleCancel = () => {
+  editState.value = {};
+  isEditable.value = false;
+};
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data :features />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/ExpandableRows.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/ExpandableRows.example.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { DataGridFeatures, OnyxDataGrid, OnyxInfoCard, type ColumnConfig } from "sit-onyx";
+import { computed, h } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, name: "Alice" },
+    { id: 2, name: "Charlie" },
+    { id: 3, name: "Bob" },
+    { id: 4, name: "Robin" },
+    { id: 5, name: "John" },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [{ key: "name", label: "Name" }];
+});
+
+const withExpandableRows = DataGridFeatures.useExpandableRows<Entry>({
+  component: (row) =>
+    h(
+      // Tip: We recommend creating a single custom Vue component for the content
+      // and simply render it here and pass the required props.
+      OnyxInfoCard,
+      { headline: `Slot content for "${row.name}"` },
+      () => "Place any components here that fit your needs.",
+    ),
+});
+
+const features = [withExpandableRows];
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data :features />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/Filtering.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/Filtering.example.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { DataGridFeatures, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, name: "Alice" },
+    { id: 2, name: "Charlie" },
+    { id: 3, name: "Bob" },
+    { id: 4, name: "Robin" },
+    { id: 5, name: "John" },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [{ key: "name", label: "Name" }];
+});
+
+const withFiltering = DataGridFeatures.useFiltering<Entry>({
+  // options here...
+});
+
+const features = [withFiltering];
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data :features />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/FilteringAsync.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/FilteringAsync.example.vue
@@ -10,8 +10,6 @@ type Entry = {
 function getData(): Entry[] {
   return [
     { id: 1, name: "Alice" },
-    { id: 2, name: "Charlie" },
-    { id: 3, name: "Bob" },
     { id: 4, name: "Robin" },
     { id: 5, name: "John" },
   ];

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/HideColumns.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/HideColumns.example.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { DataGridFeatures, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 type Entry = {
   id: number;
@@ -27,11 +27,16 @@ const columns = computed<ColumnConfig<Entry>[]>(() => {
   ];
 });
 
-const withSorting = DataGridFeatures.useSorting<Entry>({
+const hiddenColumns = ref<DataGridFeatures.HideColumnsState<Entry>>(
+  new Set(["birthday", "active"]),
+);
+
+const withHideColumns = DataGridFeatures.useHideColumns<Entry>({
   // options here...
+  state: hiddenColumns,
 });
 
-const features = [withSorting];
+const features = [withHideColumns];
 </script>
 
 <template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/Pagination.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/Pagination.example.vue
@@ -8,22 +8,24 @@ type Entry = {
 };
 
 const data = computed<Entry[]>(() => {
-  return [
-    { id: 1, name: "Alice" },
-    { id: 4, name: "Robin" },
-    { id: 5, name: "John" },
-  ];
+  // generating some dummy data
+  return Array.from({ length: 128 }, (_, index) => {
+    const id = index + 1;
+    return { id, name: `Name ${id}` };
+  });
 });
 
 const columns = computed<ColumnConfig<Entry>[]>(() => {
   return [{ key: "name", label: "Name" }];
 });
 
-const withFiltering = DataGridFeatures.useFiltering<Entry>({
+const withPagination = DataGridFeatures.usePagination({
   // options here...
+  pageSize: 10,
+  itemsPerPage: [10, 25, 50],
 });
 
-const features = [withFiltering];
+const features = [withPagination];
 </script>
 
 <template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/PaginationAsync.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/PaginationAsync.example.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { DataGridFeatures, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed, ref, watch } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+};
+
+/** Our "dummy" API response for this example */
+type PaginatedEntries = {
+  items: Entry[];
+  total: number;
+};
+
+const data = ref<PaginatedEntries>({ items: [], total: 0 });
+const isLoading = ref(false);
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [{ key: "name", label: "Name" }];
+});
+
+const paginationState = ref<DataGridFeatures.PaginationState>({
+  current: 1,
+  pages: 1,
+  pageSize: 10,
+});
+
+// update the number of pages when the data is loaded from the API
+// so the data grid is aware of them
+watch(
+  () => data.value.total,
+  (newTotal) => {
+    paginationState.value.pages = Math.ceil(newTotal / paginationState.value.pageSize);
+  },
+  { immediate: true },
+);
+
+const withPagination = DataGridFeatures.usePagination({
+  // options here...
+  paginationState,
+  loading: isLoading,
+  disabled: isLoading,
+});
+
+const features = [withPagination];
+
+// fetch new data when the user switches to another page
+watch(
+  () => paginationState.value.current,
+  async () => {
+    // TODO: send a request with the pagination state to your backend here to get the new data
+    // for this example, we fake a request here
+    isLoading.value = true;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    data.value = loadData(paginationState.value);
+    isLoading.value = false;
+  },
+  { immediate: true, deep: true },
+);
+
+function loadData(pagination: DataGridFeatures.PaginationState): PaginatedEntries {
+  const total = 128;
+  const offset = (pagination.current - 1) * pagination.pageSize + 1;
+  const itemCount = Math.min(pagination.pageSize, total - offset);
+
+  // generating some dummy data
+  const items = Array.from({ length: itemCount }, (_, index) => {
+    const id = offset + index;
+    return { id, name: `Name ${id}` } satisfies Entry;
+  });
+
+  return { items, total };
+}
+</script>
+
+<template>
+  <OnyxDataGrid
+    :headline="{ text: 'Example headline', rowCount: data.total }"
+    :columns
+    :data="data.items"
+    :features
+    :skeleton="isLoading"
+    async
+  />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/PaginationButton.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/PaginationButton.example.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { DataGridFeatures, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+};
+
+const data = computed<Entry[]>(() => {
+  // generating some dummy data
+  return Array.from({ length: 128 }, (_, index) => {
+    const id = index + 1;
+    return { id, name: `Name ${id}` };
+  });
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [{ key: "name", label: "Name" }];
+});
+
+const withPagination = DataGridFeatures.usePagination({
+  // options here...
+  type: "button",
+});
+
+const features = [withPagination];
+</script>
+
+<template>
+  <OnyxDataGrid
+    class="data-grid"
+    :headline="{ text: 'Example headline', rowCount: true }"
+    :columns
+    :data
+    :features
+  />
+</template>
+
+<style lang="scss" scoped>
+.data-grid {
+  max-height: 32rem;
+}
+</style>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/PaginationButton.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/PaginationButton.example.vue
@@ -9,7 +9,7 @@ type Entry = {
 
 const data = computed<Entry[]>(() => {
   // generating some dummy data
-  return Array.from({ length: 128 }, (_, index) => {
+  return Array.from({ length: 20 }, (_, index) => {
     const id = index + 1;
     return { id, name: `Name ${id}` };
   });
@@ -22,23 +22,12 @@ const columns = computed<ColumnConfig<Entry>[]>(() => {
 const withPagination = DataGridFeatures.usePagination({
   // options here...
   type: "button",
+  pageSize: 5,
 });
 
 const features = [withPagination];
 </script>
 
 <template>
-  <OnyxDataGrid
-    class="data-grid"
-    :headline="{ text: 'Example headline', rowCount: true }"
-    :columns
-    :data
-    :features
-  />
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data :features />
 </template>
-
-<style lang="scss" scoped>
-.data-grid {
-  max-height: 32rem;
-}
-</style>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/PaginationLazy.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/PaginationLazy.example.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { DataGridFeatures, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+};
+
+const data = computed<Entry[]>(() => {
+  // generating some dummy data
+  return Array.from({ length: 128 }, (_, index) => {
+    const id = index + 1;
+    return { id, name: `Name ${id}` };
+  });
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [{ key: "name", label: "Name" }];
+});
+
+const withPagination = DataGridFeatures.usePagination({
+  // options here...
+  type: "lazy",
+});
+
+const features = [withPagination];
+</script>
+
+<template>
+  <OnyxDataGrid
+    class="data-grid"
+    :headline="{ text: 'Example headline', rowCount: true }"
+    :columns
+    :data
+    :features
+  />
+</template>
+
+<style lang="scss" scoped>
+.data-grid {
+  max-height: 32rem;
+}
+</style>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/Resizing.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/Resizing.example.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { DataGridFeatures, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, name: "Alice", email: "alice@example.com" },
+    { id: 2, name: "Charlie", email: "charlie@example.com" },
+    { id: 3, name: "Bob", email: "bob@example.com" },
+    { id: 4, name: "Robin", email: "robin@example.com" },
+    { id: 5, name: "John", email: "john@example.com" },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "name", label: "Name" },
+    { key: "email", label: "Email" },
+  ];
+});
+
+const withResizing = DataGridFeatures.useResizing<Entry>({
+  // options here..
+});
+
+const features = [withResizing];
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data :features />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/Selection.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/Selection.example.vue
@@ -61,7 +61,7 @@ const contingentRows = computed(() => {
       :features
     />
 
-    <div class="test onyx-text--small">
+    <div class="data onyx-text--small">
       <p>Mode: {{ selectionState.selectMode }}</p>
       <p>Contingent: {{ contingentRows.map((row) => row.name).join(", ") || "-" }}</p>
       <p>=> Selected rows: {{ selectedRows.map((row) => row.name).join(", ") || "-" }}</p>
@@ -70,7 +70,7 @@ const contingentRows = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-.test {
+.data {
   margin-top: var(--onyx-density-sm);
   color: var(--onyx-color-text-icons-neutral-medium);
 }

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/Selection.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/Selection.example.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { DataGridFeatures, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed, ref } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, name: "Alice" },
+    { id: 2, name: "Charlie" },
+    { id: 3, name: "Bob" },
+    { id: 4, name: "Robin" },
+    { id: 5, name: "John" },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [{ key: "name", label: "Name" }];
+});
+
+const selectionState = ref<DataGridFeatures.SelectionState>({
+  selectMode: "include",
+  // optionally add initially checked rows here
+  contingent: new Set([2]),
+});
+
+const withSelection = DataGridFeatures.useSelection<Entry>({
+  selectionState,
+});
+
+const features = [withSelection];
+
+/**
+ * All selected rows, considering the selection mode.
+ */
+const selectedRows = computed(() => {
+  const { selectMode, contingent } = selectionState.value;
+
+  return data.value.filter((row) => {
+    if (selectMode === "exclude") return !contingent.has(row.id);
+    return contingent.has(row.id);
+  });
+});
+
+// TODO: only used for this example, remove in your project
+/** All rows in the selection contingent. */
+const contingentRows = computed(() => {
+  return data.value.filter((row) => selectionState.value.contingent.has(row.id));
+});
+</script>
+
+<template>
+  <div>
+    <OnyxDataGrid
+      :headline="{ text: 'Example headline', rowCount: true }"
+      :columns
+      :data
+      :features
+    />
+
+    <div class="test onyx-text--small">
+      <p>Mode: {{ selectionState.selectMode }}</p>
+      <p>Contingent: {{ contingentRows.map((row) => row.name).join(", ") || "-" }}</p>
+      <p>=> Selected rows: {{ selectedRows.map((row) => row.name).join(", ") || "-" }}</p>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.test {
+  margin-top: var(--onyx-density-sm);
+  color: var(--onyx-color-text-icons-neutral-medium);
+}
+</style>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/Selection.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/Selection.example.vue
@@ -61,7 +61,7 @@ const contingentRows = computed(() => {
       :features
     />
 
-    <div class="data onyx-text--small">
+    <div class="example onyx-text--small">
       <p>Mode: {{ selectionState.selectMode }}</p>
       <p>Contingent: {{ contingentRows.map((row) => row.name).join(", ") || "-" }}</p>
       <p>=> Selected rows: {{ selectedRows.map((row) => row.name).join(", ") || "-" }}</p>
@@ -70,7 +70,7 @@ const contingentRows = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-.data {
+.example {
   margin-top: var(--onyx-density-sm);
   color: var(--onyx-color-text-icons-neutral-medium);
 }

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/Skeleton.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/Skeleton.example.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    // your date here once loaded
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "name", label: "Name" },
+    { key: "email", label: "Email" },
+  ];
+});
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data skeleton />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/Sorting.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/Sorting.example.vue
@@ -13,8 +13,6 @@ type Entry = {
 const data = computed<Entry[]>(() => {
   return [
     { id: 1, name: "Alice", age: 30, birthday: new Date("1990-01-01"), active: true },
-    { id: 2, name: "Charlie", age: 35, birthday: new Date("1998-02-11"), active: false },
-    { id: 3, name: "Bob", age: 25, birthday: new Date("1995-06-15"), active: false },
     { id: 4, name: "Robin", age: 28, birthday: new Date("2001-02-22"), active: true },
     { id: 5, name: "John", age: 42, birthday: new Date("1997-04-18"), active: false },
   ];

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/Sorting.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/Sorting.example.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { DataGridFeatures, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  name: string;
+  age: number;
+  birthday: Date;
+  active?: boolean;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    { id: 1, name: "Alice", age: 30, birthday: new Date("1990-01-01"), active: true },
+    { id: 2, name: "Charlie", age: 35, birthday: new Date("1998-02-11"), active: false },
+    { id: 3, name: "Bob", age: 25, birthday: new Date("1995-06-15"), active: false },
+    { id: 4, name: "Robin", age: 28, birthday: new Date("2001-02-22"), active: true },
+    { id: 5, name: "John", age: 42, birthday: new Date("1997-04-18"), active: false },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "name", label: "Name" },
+    { key: "age", label: "Age" },
+    { key: "birthday", label: "Birthday", type: "date" },
+    { key: "active", label: "Active?", type: "boolean" },
+  ];
+});
+
+const withSorting = DataGridFeatures.useSorting<Entry>({
+  // options here...
+});
+
+const features = [withSorting];
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data :features />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/SortingAsync.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/SortingAsync.example.vue
@@ -9,8 +9,6 @@ type Entry = {
 
 const data = ref<Entry[]>([
   { id: 1, name: "Alice" },
-  { id: 2, name: "Charlie" },
-  { id: 3, name: "Bob" },
   { id: 4, name: "Robin" },
   { id: 5, name: "John" },
 ]);

--- a/apps/showcase/content/en/components/05.data/data-grid/examples/StickyColumns.example.vue
+++ b/apps/showcase/content/en/components/05.data/data-grid/examples/StickyColumns.example.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { DataGridFeatures, OnyxDataGrid, type ColumnConfig } from "sit-onyx";
+import { computed } from "vue";
+
+type Entry = {
+  id: number;
+  column1: string;
+  column2: string;
+};
+
+const data = computed<Entry[]>(() => {
+  return [
+    {
+      id: 1,
+      column1: "Content",
+      column2:
+        "Scroll me to see the sticky columns in action. This is a very large example column.",
+    },
+    {
+      id: 4,
+      column1: "Content",
+      column2:
+        "Scroll me to see the sticky columns in action. This is a very large example column.",
+    },
+    {
+      id: 5,
+      column1: "Content",
+      column2:
+        "Scroll me to see the sticky columns in action. This is a very large example column.",
+    },
+  ];
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "column1", label: "Column 1", width: "max-content" },
+    // for this example, we make the second column very large so the data grid gets scrollable
+    // don't do this in your project
+    { key: "column2", label: "Column 2", width: "64rem" },
+  ];
+});
+
+const withStickyColumns = DataGridFeatures.useStickyColumns<Entry>({
+  columns: ["column1"],
+  position: "left",
+});
+
+const features = [withStickyColumns];
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Example headline', rowCount: true }" :columns :data :features />
+</template>

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -205,6 +205,8 @@ Alternatively, the pagination can be done asynchronously by an external service,
 
 Allows the user to edit the data. Multiple editing modes are supported depending on the requirements. For [built-in column types](#column-types), a corresponding edit component is used automatically.
 
+Some examples below use custom features, see the [custom feature section](#build-a-custom-feature) for further information.
+
 <steps>
 
 ::step
@@ -213,9 +215,6 @@ Manual
 
 #default
 All rows are editable at once and the rows do not switch between display and edit mode automatically. You have full control over how the editing is enabled, saved, cancelled etc. In this example we use custom buttons but you can also use auto-save or custom logic.
-
-See the [custom feature section](#build-a-custom-feature) on how to build a custom feature.
-
 
 :component-example{name="EditingInline" layout="fullWidth"}
 ::

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -7,32 +7,92 @@ A highly customizable and modular table for displaying complex datasets. The dat
 
 ## Data grid vs. table
 
-- recommend data grid for most cases in general
-- table only in rare edge cases where max. flexibility and customization is required or data grid overhead is unwanted
-- if unsure what to use, use the data grid
-- if there is no reasonable concrete requirement for using the table, use the data grid
+We recommend to use the data grid in most cases since it supports advanced built-in features. The [table](/components/data/table) component is a simple styled wrapper for the HTML [\<table\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table) element without additional features. The table can be used in rare edge cases where maximum flexibility and customization is required or where the data grid overhead is unwanted.
+
+If you are unsure which component to use or there is no reasonable explicit requirement for the table, use the data grid.
 
 ## Examples
 
-- Link zu Code unserer features
-- sort features by how often they are used
+### Basic
+
+A very basic data grid contains one or multiple columns and a set of data to display in rows. Each column has a type that defines how the value is displayed. See the [available column types](#column-types) below.
+
+:component-example{name="Basic" layout="fullWidth"}
 
 ### Column types
 
-List native types
+<!-- TODO: update custom feature link -->
+The data grid supports several column data types out-of-the-box that will display the data accordingly and also integrate with e.g. the [sorting](#sorting) or [filtering](#filtering) feature. To implement custom column types, see the [custom feature section](#build-a-custom-feature) below.
 
+<steps>
+
+::step
+#headline
+String / Text <onyx-tag label="Default" />
+
+#default
+Displays the value as text and is the default type for all columns.
+
+:component-example{name="ColumnTypeString" layout="grow"}
+::
+
+::step
+#headline
+Number
+
+#default
+Displays the value as formatter number depending on the current application language. Optionally, a custom format can be defined using [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat).
+
+:component-example{name="ColumnTypeNumber" layout="grow"}
+::
+
+::step
+#headline
+Date & Time
+
+#default
+Multiple column types are supported to display date, datetime, time and timestamp depending on the current application language. Optionally, a custom format can be defined using [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat).
+
+:component-example{name="ColumnTypeDate" layout="fullWidth"}
+::
+
+::step
+#headline
+Select
+
+#default
+<!-- TODO: change link -->
+The select type allows the developer to define a set of available options where the corresponding text is displayed depending on the value. This is particularly useful when the value is technically an enum but a user-friendly translated label should be shown. When used in combination with the [editing](#editing) feature, the user can change the value based on the pre-defined list of options.
+
+:component-example{name="ColumnTypeSelect" layout="grow"}
+::
+
+::step
+#headline
+Fallback text
+
+#default
+For every column, a fallback text is shown when the cell is empty. By default, "-" is used but a custom text can be defined if needed.
+
+:component-example{name="ColumnTypeFallback" layout="grow"}
+::
+
+</steps>
+
+### Skeleton
+
+The skeleton should be used on initial page load when the data for the page / data grid is initially loaded.
+
+:component-example{name="Skeleton" layout="fullWidth"}
+
+### Grouped columns
+
+Column groups can be used to visually group columns that are related.
+
+:component-example{name="ColumnGroups" layout="fullWidth"}
 
 ## Build a custom feature
 
-Step by step guide...
-
--
-
-### Common use cases build by projects
-
-1. Clickable row
-2. Custom column types
-3. Right aligned action column (with support for truncation + flyout menu)
-
-
-## Best Practices
+::info-card{headline="Coming Soon"}
+This part of the documentation will be available soon.
+::

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -91,6 +91,68 @@ Column groups can be used to visually group columns that are related.
 
 :component-example{name="ColumnGroups" layout="fullWidth"}
 
+## Features
+
+Data grid features are re-usable pieces of code that extend the functionality of the data grid using a unified API. We support several advanced features out-of-the-box for common use cases such as sorting, filtering, pagination and more. See the [custom feature](#build-a-custom-feature) section below for how you can build your own feature.
+
+In fact, every internal functionality of the data grid such as the different [column types](#column-types) is build using a feature.
+
+### Sorting
+
+Allows the user to sort the rows by a specific column. The developer can optionally define an initial sorting, customize the sorting logic and disabled/enabled sorting for specific columns. For [built-in column types](#column-types), the sorting logic is correctly defined by default. For custom types, make sure to define a custom sorting function if alphabetical sorting is not sufficient.
+
+<steps>
+
+::step
+#headline
+Internal
+
+#default
+The data is sorted internally by default considering all available data.
+
+:component-example{name="Sorting" layout="fullWidth"}
+::
+
+::step
+#headline
+Async
+
+#default
+Alternatively, the sorting can be done asynchronously by an external service, e.g. by a backend or API so the data grid does not sort the data itself. Important: Set the `async` property on the data grid to disable the internal data transformations.
+
+:component-example{name="AsyncSorting" layout="fullWidth"}
+::
+
+</steps>
+
+### Filtering / Search
+
+Allows the user to filter / search a column. The developer can optionally customize the filter logic and disabled/enabled filtering for specific columns.
+
+<steps>
+
+::step
+#headline
+Internal
+
+#default
+The data is filtered internally by default considering all available data.
+
+:component-example{name="Filtering" layout="fullWidth"}
+::
+
+::step
+#headline
+Async
+
+#default
+Alternatively, the filtering can be done asynchronously by an external service, e.g. by a backend or API so the data grid does not filter the data itself. Important: Set the `async` property on the data grid to disable the internal data transformations.
+
+:component-example{name="AsyncFiltering" layout="fullWidth"}
+::
+
+</steps>
+
 ## Build a custom feature
 
 ::info-card{headline="Coming Soon"}

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -120,7 +120,7 @@ Async
 #default
 Alternatively, the sorting can be done asynchronously by an external service, e.g. by a backend or API so the data grid does not sort the data itself. Important: Set the `async` property on the data grid to disable the internal data transformations.
 
-:component-example{name="AsyncSorting" layout="fullWidth"}
+:component-example{name="SortingAsync" layout="fullWidth"}
 ::
 
 </steps>
@@ -148,7 +148,55 @@ Async
 #default
 Alternatively, the filtering can be done asynchronously by an external service, e.g. by a backend or API so the data grid does not filter the data itself. Important: Set the `async` property on the data grid to disable the internal data transformations.
 
-:component-example{name="AsyncFiltering" layout="fullWidth"}
+:component-example{name="FilteringAsync" layout="fullWidth"}
+::
+
+</steps>
+
+### Pagination
+
+Use pagination to handle data grids where a lot of data is available which would be too much to show it all at once to optimize performance. Different pagination modes are supported as described below. Each pagination mode also supports a select where the user can select how many items per page should be displayed.
+
+<steps>
+
+::step
+#headline
+Select <onyx-tag label="Default" />
+
+#default
+The select type uses our [pagination](/components/data/pagination) component to show a page select on the bottom right.
+
+:component-example{name="Pagination" layout="fullWidth"}
+::
+
+::step
+#headline
+Lazy loading
+
+#default
+With lazy loading, more data is automatically displayed when the user scrolls to the end of the data grid. You **must** set a maximum height when using lazy loading.
+
+:component-example{name="PaginationLazy" layout="fullWidth"}
+::
+
+::step
+#headline
+Button loading
+
+#default
+Button loading is similar to lazy loading but requires the user to manually click a load more button to load the next page of data. We strongly recommended to set a maximum height since the data grid can get very long when loading many pages.
+
+:component-example{name="PaginationButton" layout="fullWidth"}
+::
+
+::step
+#headline
+Async
+
+#default
+Alternatively, the pagination can be done asynchronously by an external service, e.g. by a backend or API. This is especially useful for performance optimization when not all available data should be loaded at once. Async pagination is compatible with all modes mentioned above. Important: Set the `async` property on the data grid to disable the internal data transformations.
+
+:component-example{name="PaginationAsync" layout="fullWidth"}
 ::
 
 </steps>

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -17,7 +17,7 @@ If you are unsure which component to use or there is no reasonable explicit requ
 
 A very basic data grid contains one or multiple columns and a set of data to display in rows. Each column has a type that defines how the value is displayed. See the [available column types](#column-types) below.
 
-:component-example{name="Basic" layout="fullWidth"}
+:component-example{name="Basic" layout="grow"}
 
 ### Column types
 
@@ -83,13 +83,13 @@ For every column, a fallback text is shown when the cell is empty. By default, "
 
 The skeleton should be used on initial page load when the data for the page / data grid is initially loaded.
 
-:component-example{name="Skeleton" layout="fullWidth"}
+:component-example{name="Skeleton" layout="grow"}
 
 ### Grouped columns
 
 Column groups can be used to visually group columns that are related.
 
-:component-example{name="ColumnGroups" layout="fullWidth"}
+:component-example{name="ColumnGroups" layout="grow"}
 
 ## Features
 
@@ -120,7 +120,7 @@ Async
 #default
 Alternatively, the sorting can be done asynchronously by an external service, e.g. by a backend or API so the data grid does not sort the data itself. Important: Set the `async` property on the data grid to disable the internal data transformations.
 
-:component-example{name="SortingAsync" layout="fullWidth"}
+:component-example{name="SortingAsync" layout="grow"}
 ::
 
 </steps>
@@ -138,7 +138,7 @@ Internal
 #default
 The data is filtered internally by default considering all available data.
 
-:component-example{name="Filtering" layout="fullWidth"}
+:component-example{name="Filtering" layout="grow"}
 ::
 
 ::step
@@ -148,7 +148,7 @@ Async
 #default
 Alternatively, the filtering can be done asynchronously by an external service, e.g. by a backend or API so the data grid does not filter the data itself. Important: Set the `async` property on the data grid to disable the internal data transformations.
 
-:component-example{name="FilteringAsync" layout="fullWidth"}
+:component-example{name="FilteringAsync" layout="grow"}
 ::
 
 </steps>
@@ -166,7 +166,7 @@ Select <onyx-tag label="Default" />
 #default
 The select type uses our [pagination](/components/data/pagination) component to show a page select on the bottom right.
 
-:component-example{name="Pagination" layout="fullWidth"}
+:component-example{name="Pagination" layout="grow"}
 ::
 
 ::step
@@ -176,7 +176,7 @@ Lazy loading
 #default
 With lazy loading, more data is automatically displayed when the user scrolls to the end of the data grid. You **must** set a maximum height when using lazy loading.
 
-:component-example{name="PaginationLazy" layout="fullWidth"}
+:component-example{name="PaginationLazy" layout="grow"}
 ::
 
 ::step
@@ -186,7 +186,7 @@ Button loading
 #default
 Button loading is similar to lazy loading but requires the user to manually click a load more button to load the next page of data.
 
-:component-example{name="PaginationButton" layout="fullWidth"}
+:component-example{name="PaginationButton" layout="grow"}
 ::
 
 ::step
@@ -196,7 +196,7 @@ Async
 #default
 Alternatively, the pagination can be done asynchronously by an external service, e.g. by a backend or API. This is especially useful for performance optimization when not all available data should be loaded at once. Async pagination is compatible with all modes mentioned above. Important: Set the `async` property on the data grid to disable the internal data transformations.
 
-:component-example{name="PaginationAsync" layout="fullWidth"}
+:component-example{name="PaginationAsync" layout="grow"}
 ::
 
 </steps>

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -89,6 +89,12 @@ For every column, a fallback text is shown when the cell is empty. By default, "
 
 </steps>
 
+### Column width
+
+All columns are equally sized by default. The width of every column can be adjusted if needed using any valid value accepted by [grid-template-columns](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/grid-template-columns). So the column can e.g. have a fixed width using a static value like `100px` or `2rem`, a flexible value like `1fr` or `max-content` or a minimum and maximum width using use the [minmax](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/minmax) function.
+
+:component-example{name="ColumnWidth" layout="fullWidth"}
+
 ### Skeleton
 
 The skeleton should be used on initial page load when the data for the page / data grid is initially loaded.

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -69,6 +69,16 @@ The select type allows the developer to define a set of available options where 
 
 ::step
 #headline
+Link
+
+#default
+Allows to display links to other pages or applications. Optionally support to define a custom display label.
+
+:component-example{name="ColumnTypeLink" layout="grow"}
+::
+
+::step
+#headline
 Fallback text
 
 #default

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -91,7 +91,7 @@ For every column, a fallback text is shown when the cell is empty. By default, "
 
 ### Column width
 
-All columns are equally sized by default. The width of every column can be adjusted if needed using any valid value accepted by [grid-template-columns](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/grid-template-columns). So the column can e.g. have a fixed width using a static value like `100px` or `2rem`, a flexible value like `1fr` or `max-content` or a minimum and maximum width using use the [minmax](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/minmax) function.
+All columns are equally sized by default. The width of every column can be adjusted if needed using any valid value accepted by [grid-template-columns](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/grid-template-columns). So the column can e.g. have a fixed width using a static value like `4rem`, a flexible value like `1fr` or `max-content` or a minimum and maximum width using use the [minmax](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/minmax) function.
 
 :component-example{name="ColumnWidth" layout="fullWidth"}
 

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -201,6 +201,27 @@ Alternatively, the pagination can be done asynchronously by an external service,
 
 </steps>
 
+### Editing
+
+Allows the user to edit the data. Multiple editing modes are supported depending on the requirements. For [built-in column types](#column-types), a corresponding edit component is used automatically.
+
+<steps>
+
+::step
+#headline
+Manual
+
+#default
+All rows are editable at once and the rows do not switch between display and edit mode automatically. You have full control over how the editing is enabled, saved, cancelled etc. In this example we use custom buttons but you can also use auto-save or custom logic.
+
+See the [custom feature section](#build-a-custom-feature) on how to build a custom feature.
+
+
+:component-example{name="EditingInline" layout="fullWidth"}
+::
+
+</steps>
+
 ### Sticky columns
 
 One or multiple columns can be made sticky on the left or right side of the data grid. We strongly recommend to use sticky columns sparely since they can block the whole data grid on smaller devices.
@@ -232,7 +253,7 @@ Exclude mode
 #default
 When checking the "Select all" checkbox in the column header, the data grid automatically switches to the "exclude" mode. It assumes the user wants to select _every single row_ in the entire dataset (even the ones on other pages). Everything **except** the rows the user manually unchecks is selected. The "contingent" becomes the "blacklist" of unchecked rows.
 
- **Important Note for Developers**: The data grid only stores the rows that the user unchecked. You need to write custom logic to calculate the final list of selected rows based on your project's specific requirements.
+**Important Note for Developers**: The data grid only stores the rows that the user unchecked. You need to write custom logic to calculate the final list of selected rows based on your project's specific requirements.
 ::
 
 </steps>

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -184,7 +184,7 @@ With lazy loading, more data is automatically displayed when the user scrolls to
 Button loading
 
 #default
-Button loading is similar to lazy loading but requires the user to manually click a load more button to load the next page of data. We strongly recommended to set a maximum height since the data grid can get very long when loading many pages.
+Button loading is similar to lazy loading but requires the user to manually click a load more button to load the next page of data.
 
 :component-example{name="PaginationButton" layout="fullWidth"}
 ::

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -241,6 +241,26 @@ When checking the "Select all" checkbox in the column header, the data grid auto
 
 The checkboxes can optionally be only shown on hover.
 
+### Resizing
+
+Allows the user to manually change the width of columns by dragging the right border of the column header. Double clicking the right border adjusts the size to the content width.
+
+To ensure the overall table size does not shrink, an empty filler column is added to the right if the columns do not take up the full width.
+
+:component-example{name="Resizing" layout="grow"}
+
+### Hide columns
+
+Allows the user to hide or show columns. Can also be used by the developer to hide specific columns by default that the user can show manually if needed.
+
+:component-example{name="HideColumns" layout="grow"}
+
+### Expandable rows
+
+Allows to expand additional content for each row. We do **NOT recommend** to show nested tables inside the expanded rows, prefer using e.g. a [modal](/components/feedback/modal) instead if needed.
+
+:component-example{name="ExpandableRows" layout="grow"}
+
 ## Build a custom feature
 
 ::info-card{headline="Coming Soon"}

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -4,3 +4,35 @@ componentName: OnyxDataGrid
 ---
 
 A highly customizable and modular table for displaying complex datasets. The data grid supports features like sorting, filtering, grouping columns and rows and much more, giving both developers and users extensive control.
+
+## Data grid vs. table
+
+- recommend data grid for most cases in general
+- table only in rare edge cases where max. flexibility and customization is required or data grid overhead is unwanted
+- if unsure what to use, use the data grid
+- if there is no reasonable concrete requirement for using the table, use the data grid
+
+## Examples
+
+- Link zu Code unserer features
+- sort features by how often they are used
+
+### Column types
+
+List native types
+
+
+## Build a custom feature
+
+Step by step guide...
+
+-
+
+### Common use cases build by projects
+
+1. Clickable row
+2. Custom column types
+3. Right aligned action column (with support for truncation + flyout menu)
+
+
+## Best Practices

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -1,0 +1,6 @@
+---
+title: Data grid
+componentName: OnyxDataGrid
+---
+
+A highly customizable and modular table for displaying complex datasets. The data grid supports features like sorting, filtering, grouping columns and rows and much more, giving both developers and users extensive control.

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -201,6 +201,46 @@ Alternatively, the pagination can be done asynchronously by an external service,
 
 </steps>
 
+### Sticky columns
+
+One or multiple columns can be made sticky on the left or right side of the data grid. We strongly recommend to use sticky columns sparely since they can block the whole data grid on smaller devices.
+
+<p style="color: var(--onyx-color-text-icons-info-intense)">Scroll the data grid horizontally below to see the sticky columns in action.</p>
+
+:component-example{name="StickyColumns" layout="grow"}
+
+### Selection
+
+Allows the user to select multiple rows. When dealing with large data sets that use pagination or filters, a standard "Select all" button doesn't always work because many rows are hidden from the view. To solve this, the data grid **automatically switches** between two selection modes.
+
+The data grid tracks the selection using a "contingent" - which is simply the specific list of rows the user has manually interacted with. How the selection behaves, depends on the mode:
+
+<steps>
+
+::step
+#headline
+Include mode <onyx-tag label="Default" />
+
+#default
+Only the rows that the user explicitly checked are included. The "contingent" is the list of checked rows.
+::
+
+::step
+#headline
+Exclude mode
+
+#default
+When checking the "Select all" checkbox in the column header, the data grid automatically switches to the "exclude" mode. It assumes the user wants to select _every single row_ in the entire dataset (even the ones on other pages). Everything **except** the rows the user manually unchecks is selected. The "contingent" becomes the "blacklist" of unchecked rows.
+
+ **Important Note for Developers**: The data grid only stores the rows that the user unchecked. You need to write custom logic to calculate the final list of selected rows based on your project's specific requirements.
+::
+
+</steps>
+
+:component-example{name="Selection" layout="grow"}
+
+The checkboxes can optionally be only shown on hover.
+
 ## Build a custom feature
 
 ::info-card{headline="Coming Soon"}

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -268,7 +268,9 @@ Exclude mode
 #default
 When checking the "Select all" checkbox in the column header, the data grid automatically switches to the "exclude" mode. It assumes the user wants to select _every single row_ in the entire dataset (even the ones on other pages). Everything **except** the rows the user manually unchecks is selected. The "contingent" becomes the "blacklist" of unchecked rows.
 
-**Important Note for Developers**: The data grid only stores the rows that the user unchecked. You need to write custom logic to calculate the final list of selected rows based on your project's specific requirements.
+  ::info-card{headline="Important note for developers"}
+  The data grid only stores the rows that the user unchecked. You need to write custom logic to calculate the final list of selected rows based on your project's specific requirements.
+  ::
 ::
 
 </steps>


### PR DESCRIPTION
Relates to #5497

Implement new examples and documentation for the data grid.

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
