### PR TITLE
chore: fix Storybook

### DIFF
--- a/packages/sit-onyx/src/index.ts
+++ b/packages/sit-onyx/src/index.ts
@@ -332,7 +332,12 @@ export { createOnyx } from "./utils/plugin.js";
 
 export * from "./components/illustrations/index.js";
 export * from "./composables/themeTransition.js";
-export * from "./composables/useMoreList.js";
+export {
+  useMoreList,
+  useMoreListChild,
+  type MoreListInjectionKey,
+  type UseMoreListOptions,
+} from "./composables/useMoreList.js";
 export { useResizeObserver } from "./composables/useResizeObserver.js";
 export * from "./utils/attrs.js";
 export * from "./utils/props.js";


### PR DESCRIPTION
Storybook does currently work due to an error: https://onyx-storybook-dev.apps.01.cf.eu01.stackit.cloud/

Fixed by updating the new more list import