### PR TITLE
chore: deactivate automatic snapshot release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@
 name: Release
 on:
   push:
-    branches:
-      - "main"
+    tags:
+      - "sit-onyx@*"
+      - "@sit-onyx@*"
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
- Deactivated release on push to main
- Instead, the pipeline can be triggered manual or by pushing release tags
- We do this to stop spamming the npm registry with development versions