### PR TITLE
docs: implement examples for calendar, empty, items per page, pagination and table

### DIFF
--- a/.changeset/bold-turkeys-push.md
+++ b/.changeset/bold-turkeys-push.md
@@ -2,4 +2,4 @@
 "sit-onyx": patch
 ---
 
-fix(OnyxCalendar): remove unintentional deprecation
+fix(OnyxCalendar): remove unintentional deprecation and add flex-grow so the calendar takes up the full width inside flex layouts

--- a/.changeset/bold-turkeys-push.md
+++ b/.changeset/bold-turkeys-push.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxCalendar): remove unintentional deprecation

--- a/apps/showcase/content/en/components/05.data/calendar/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/05.data/calendar/examples/Basic.example.vue
@@ -1,0 +1,57 @@
+<script lang="ts" setup>
+import { OnyxBadge, OnyxCalendar, OnyxColor } from "sit-onyx";
+
+type Event = { date: Date; color: OnyxColor; description: string };
+
+const getDummyDate = (dayOffset: number) => {
+  const today = new Date();
+  today.setDate(today.getDate() + dayOffset);
+  return today;
+};
+
+const events: Event[] = [
+  { date: getDummyDate(-2), color: "primary", description: "Meeting" },
+  { date: getDummyDate(-7), color: "success", description: "Anna's birthday" },
+  { date: getDummyDate(3), color: "info", description: "Dentist" },
+  { date: getDummyDate(7), color: "success", description: "Max's birthday" },
+  { date: getDummyDate(12), color: "primary", description: "Team-Event" },
+];
+
+const findEvent = (date: Date) => {
+  return events.find((event) => event.date.toDateString() === date.toDateString());
+};
+</script>
+
+<template>
+  <OnyxCalendar show-calendar-weeks>
+    <template #day="{ date, size }">
+      <div v-if="findEvent(date)" class="event">
+        <OnyxBadge :color="findEvent(date)?.color" dot />
+        <span
+          v-if="size === 'big'"
+          class="event__description onyx-text--small onyx-truncation-ellipsis"
+        >
+          {{ findEvent(date)?.description }}
+        </span>
+      </div>
+    </template>
+  </OnyxCalendar>
+</template>
+
+<style lang="scss" scoped>
+.event {
+  display: flex;
+  align-items: center;
+  gap: var(--onyx-density-xs);
+  text-align: left;
+  margin-top: var(--onyx-density-2xs);
+
+  &__description {
+    color: var(--onyx-color-text-icons-neutral-medium);
+  }
+
+  .onyx-calendar--small & {
+    justify-content: center;
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/05.data/calendar/examples/MinMax.example.vue
+++ b/apps/showcase/content/en/components/05.data/calendar/examples/MinMax.example.vue
@@ -1,0 +1,24 @@
+<script lang="ts" setup>
+import { OnyxCalendar } from "sit-onyx";
+import { ref } from "vue";
+
+const date = ref<Date>();
+
+// dynamically determine min and max date based on today
+const today = new Date();
+
+const min = new Date(today);
+min.setDate(min.getDate() - 7);
+
+const max = new Date(today);
+max.setDate(max.getDate() + 7);
+
+const disabledDays = (date: Date) => {
+  // disable individual days, e.g. every Wednesday
+  return date.getDay() === 3;
+};
+</script>
+
+<template>
+  <OnyxCalendar v-model="date" selection-mode="single" :min :max :disabled-days />
+</template>

--- a/apps/showcase/content/en/components/05.data/calendar/examples/Multiple.example.vue
+++ b/apps/showcase/content/en/components/05.data/calendar/examples/Multiple.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxCalendar } from "sit-onyx";
+import { ref } from "vue";
+
+const dates = ref<Date[]>([]);
+</script>
+
+<template>
+  <OnyxCalendar v-model="dates" selection-mode="multiple" />
+</template>

--- a/apps/showcase/content/en/components/05.data/calendar/examples/Range.example.vue
+++ b/apps/showcase/content/en/components/05.data/calendar/examples/Range.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { DateRange, OnyxCalendar } from "sit-onyx";
+import { ref } from "vue";
+
+const dateRange = ref<DateRange>();
+</script>
+
+<template>
+  <OnyxCalendar v-model="dateRange" selection-mode="range" show-calendar-weeks />
+</template>

--- a/apps/showcase/content/en/components/05.data/calendar/examples/Single.example.vue
+++ b/apps/showcase/content/en/components/05.data/calendar/examples/Single.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxCalendar } from "sit-onyx";
+import { ref } from "vue";
+
+const date = ref<Date>();
+</script>
+
+<template>
+  <OnyxCalendar v-model="date" selection-mode="single" />
+</template>

--- a/apps/showcase/content/en/components/05.data/calendar/examples/Skeleton.example.vue
+++ b/apps/showcase/content/en/components/05.data/calendar/examples/Skeleton.example.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import { OnyxCalendar } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxCalendar skeleton />
+</template>

--- a/apps/showcase/content/en/components/05.data/calendar/index.md
+++ b/apps/showcase/content/en/components/05.data/calendar/index.md
@@ -1,6 +1,7 @@
 ---
 title: Calendar
 componentName: OnyxCalendar
+status: new
 ---
 
 The calendar is used to display or select date-related information. It supports multiple selection modes such as single, multiple, range and more. For selecting date and time, we recommend to use our dedicated components:

--- a/apps/showcase/content/en/components/05.data/calendar/index.md
+++ b/apps/showcase/content/en/components/05.data/calendar/index.md
@@ -37,3 +37,17 @@ Allows the user to select multiple dates.
 Allows the user to select a range with a start and end date. If calendar weeks are enabled, the user can click a specific calendar week to automatically select the whole week.
 
 :component-example{name="Range" layout="grow"}
+
+### Min, max and disabled dates
+
+Specific dates can be disabled by defining a minimum or maximum date where all dates before/after the given date will be disabled or by specifying individual dates (e.g. every Wednesday). Alternatively, the `disabled` property can be set to disabled all dates.
+
+In the example below, only the past and upcoming 7 days are selectable except Wednesdays.
+
+:component-example{name="MinMax" layout="grow"}
+
+### Skeleton
+
+The skeleton can be used on initial page load when the data for the page / calendar is initially loaded.
+
+:component-example{name="Skeleton" layout="grow"}

--- a/apps/showcase/content/en/components/05.data/calendar/index.md
+++ b/apps/showcase/content/en/components/05.data/calendar/index.md
@@ -1,0 +1,39 @@
+---
+title: Calendar
+componentName: OnyxCalendar
+---
+
+The calendar is used to display or select date-related information. It supports multiple selection modes such as single, multiple, range and more. For selecting date and time, we recommend to use our dedicated components:
+
+<div class="onyx-grid">
+<link-card class="onyx-grid-span-4" headline="Date picker" link="/components/form-elements/date-picker-v2"></link-card>
+<link-card class="onyx-grid-span-4" headline="Time picker" link="/components/form-elements/time-picker"></link-card>
+</div>
+
+## Examples
+
+### Default
+
+The calendar is display-only by default. Custom content can be added to specific dates if needed. The calendar sizes automatically adapts between small and big depending on the available width but can optionally be forced using the `size` property. When using custom content, make sure to consider the current calendar size so it is correctly visible on smaller devices.
+
+The calendar uses the current language of the application to automatically adapt weekdays, months and more.
+
+:component-example{name="Basic" layout="grow" style="--preview-max-width: 44rem"}
+
+### Single select
+
+Allows the user to select a single date.
+
+:component-example{name="Single" layout="grow"}
+
+### Multiselect
+
+Allows the user to select multiple dates.
+
+:component-example{name="Multiple" layout="grow"}
+
+### Range select
+
+Allows the user to select a range with a start and end date. If calendar weeks are enabled, the user can click a specific calendar week to automatically select the whole week.
+
+:component-example{name="Range" layout="grow"}

--- a/apps/showcase/content/en/components/05.data/empty/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/05.data/empty/examples/Basic.example.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import { OnyxButton, OnyxEmpty } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxEmpty>
+    No data found
+    <template #description> There is no data available that match your selected filters. </template>
+
+    <template #buttons>
+      <OnyxButton color="neutral" label="Button" />
+      <OnyxButton label="Button" />
+    </template>
+  </OnyxEmpty>
+</template>

--- a/apps/showcase/content/en/components/05.data/empty/examples/Icon.example.vue
+++ b/apps/showcase/content/en/components/05.data/empty/examples/Icon.example.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import { iconCircleX } from "@sit-onyx/icons";
+import { OnyxEmpty, OnyxIcon } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxEmpty>
+    Access denied
+    <template #description> You don't have permissions to access this page. </template>
+
+    <template #icon>
+      <OnyxIcon :icon="iconCircleX" color="danger" size="48px" />
+    </template>
+  </OnyxEmpty>
+</template>

--- a/apps/showcase/content/en/components/05.data/empty/index.md
+++ b/apps/showcase/content/en/components/05.data/empty/index.md
@@ -1,0 +1,20 @@
+---
+title: Empty
+componentName: OnyxEmpty
+---
+
+The empty component is used to indicate to the user that there is currently no data available.
+
+## Examples
+
+### Basic
+
+A basic empty component contains at least a headline and can optionally include a description and buttons.
+
+:component-example{name="Basic"}
+
+### Custom icon
+
+Use the `icon` slot to override the default illustration, e.g. using the [icon component](/components/basic/icon).
+
+:component-example{name="Icon"}

--- a/apps/showcase/content/en/components/05.data/empty/index.md
+++ b/apps/showcase/content/en/components/05.data/empty/index.md
@@ -11,10 +11,10 @@ The empty component is used to indicate to the user that there is currently no d
 
 A basic empty component contains at least a headline and can optionally include a description and buttons.
 
-:component-example{name="Basic"}
+:component-example{name="Basic" layout="grow"}
 
 ### Custom icon
 
 Use the `icon` slot to override the default illustration, e.g. using the [icon component](/components/basic/icon).
 
-:component-example{name="Icon"}
+:component-example{name="Icon" layout="grow"}

--- a/apps/showcase/content/en/components/05.data/items-per-page/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/05.data/items-per-page/examples/Basic.example.vue
@@ -1,0 +1,12 @@
+<script lang="ts" setup>
+import { OnyxItemsPerPage } from "sit-onyx";
+import { ref } from "vue";
+
+const options = [25, 50, 100];
+const itemsPerPage = ref(options[0]);
+</script>
+
+<template>
+  <OnyxItemsPerPage v-model="itemsPerPage" :options />
+  <OnyxItemsPerPage v-model="itemsPerPage" :options :label="{ position: 'left' }" />
+</template>

--- a/apps/showcase/content/en/components/05.data/items-per-page/examples/Skeleton.example.vue
+++ b/apps/showcase/content/en/components/05.data/items-per-page/examples/Skeleton.example.vue
@@ -1,0 +1,11 @@
+<script lang="ts" setup>
+import { OnyxItemsPerPage } from "sit-onyx";
+import { ref } from "vue";
+
+const options = [25, 50, 100];
+const itemsPerPage = ref(options[0]);
+</script>
+
+<template>
+  <OnyxItemsPerPage v-model="itemsPerPage" :options skeleton />
+</template>

--- a/apps/showcase/content/en/components/05.data/items-per-page/index.md
+++ b/apps/showcase/content/en/components/05.data/items-per-page/index.md
@@ -1,0 +1,18 @@
+---
+title: Items per page
+componentName: OnyxItemsPerPage
+---
+
+The items per page component allows users to select how many items are displayed per page in a paginated list or table.
+
+## Examples
+
+### Basic
+
+:component-example{name="Basic" orientation="vertical"}
+
+### Skeleton
+
+The skeleton can be used on initial page load when the data for the page / component is initially loaded.
+
+:component-example{name="Skeleton"}

--- a/apps/showcase/content/en/components/05.data/items-per-page/index.md
+++ b/apps/showcase/content/en/components/05.data/items-per-page/index.md
@@ -1,6 +1,7 @@
 ---
 title: Items per page
 componentName: OnyxItemsPerPage
+status: new
 ---
 
 The items per page component allows users to select how many items are displayed per page in a paginated list or table.

--- a/apps/showcase/content/en/components/05.data/pagination/examples/Compact.example.vue
+++ b/apps/showcase/content/en/components/05.data/pagination/examples/Compact.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxPagination } from "sit-onyx";
+import { ref } from "vue";
+
+const page = ref(1);
+</script>
+
+<template>
+  <OnyxPagination v-model="page" :pages="42" type="compact" />
+</template>

--- a/apps/showcase/content/en/components/05.data/pagination/examples/Disabled.example.vue
+++ b/apps/showcase/content/en/components/05.data/pagination/examples/Disabled.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxPagination } from "sit-onyx";
+import { ref } from "vue";
+
+const page = ref(1);
+</script>
+
+<template>
+  <OnyxPagination v-model="page" :pages="42" disabled />
+</template>

--- a/apps/showcase/content/en/components/05.data/pagination/examples/Inline.example.vue
+++ b/apps/showcase/content/en/components/05.data/pagination/examples/Inline.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxPagination } from "sit-onyx";
+import { ref } from "vue";
+
+const page = ref(1);
+</script>
+
+<template>
+  <OnyxPagination v-model="page" :pages="42" type="inline" />
+</template>

--- a/apps/showcase/content/en/components/05.data/pagination/examples/Select.example.vue
+++ b/apps/showcase/content/en/components/05.data/pagination/examples/Select.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxPagination } from "sit-onyx";
+import { ref } from "vue";
+
+const page = ref(1);
+</script>
+
+<template>
+  <OnyxPagination v-model="page" :pages="42" />
+</template>

--- a/apps/showcase/content/en/components/05.data/pagination/examples/Skeleton.example.vue
+++ b/apps/showcase/content/en/components/05.data/pagination/examples/Skeleton.example.vue
@@ -1,0 +1,10 @@
+<script lang="ts" setup>
+import { OnyxPagination } from "sit-onyx";
+import { ref } from "vue";
+
+const page = ref(1);
+</script>
+
+<template>
+  <OnyxPagination v-model="page" :pages="42" skeleton />
+</template>

--- a/apps/showcase/content/en/components/05.data/pagination/index.md
+++ b/apps/showcase/content/en/components/05.data/pagination/index.md
@@ -1,0 +1,40 @@
+---
+title: Pagination
+componentName: OnyxPagination
+---
+
+Pagination can be used in cases where a lot of data exists that should not be shown or loaded all at once. The user can select a page for which data should be shown, e.g. inside a [data grid](/components/data/data-grid).
+
+## Examples
+
+### Select
+
+The pagination supports different display types. The default "select" allows the user to either navigate using a previous/next button or jump to a specific page using a select which can optionally be disabled.
+
+:component-example{name="Select"}
+
+### Inline
+
+The inline type is a more classic-style pagination. When using it, keep in mind that the component might not work ideally on small screen sizes.
+
+:component-example{name="Inline"}
+
+### Compact
+
+A compact type of the pagination, ideally for small screen sizes. It supports a previous/next button and page select which can optionally be disabled.
+
+For all pagination types, you can enable the `autoCompact` property which will automatically switch to the compact type when the available width is smaller than the specified [breakpoint](/introduction/foundation/breakpoints-and-grid#breakpoints).
+
+:component-example{name="Compact"}
+
+### Disabled
+
+The pagination can be disabled to prevent the user to switch to another page. For types that include a page select (such as [select](#select) and [compact](#compact)), the select can be disabled individually if needed using the `disableFlyout` property.
+
+:component-example{name="Disabled"}
+
+### Skeleton
+
+The skeleton can be used on initial page load when the data for the page / pagination is initially loaded.
+
+:component-example{name="Skeleton"}

--- a/apps/showcase/content/en/components/05.data/table/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/05.data/table/examples/Basic.example.vue
@@ -1,0 +1,31 @@
+<script lang="ts" setup>
+import { OnyxTable } from "sit-onyx";
+
+const data = [
+  { fruit: "Strawberry", price: 4.5, weight: 200, quantity: 100, rating: 5 },
+  { fruit: "Apple", price: 1.99, weight: 3_000, quantity: 200, rating: 3 },
+  { fruit: "Banana", price: 3.75, weight: 18_000, quantity: 300, rating: 4 },
+];
+</script>
+
+<template>
+  <OnyxTable>
+    <template #head>
+      <tr>
+        <th>Fruit</th>
+        <th>Price (€/kg)</th>
+        <th>Inventory (kg)</th>
+        <th>Inventory (pieces)</th>
+        <th>Rating</th>
+      </tr>
+    </template>
+
+    <tr v-for="row in data" :key="row.fruit">
+      <td>{{ row.fruit }}</td>
+      <td>{{ row.price }}</td>
+      <td>{{ row.weight }}</td>
+      <td>{{ row.quantity }}</td>
+      <td>{{ row.rating }}</td>
+    </tr>
+  </OnyxTable>
+</template>

--- a/apps/showcase/content/en/components/05.data/table/examples/ColumnGroups.example.vue
+++ b/apps/showcase/content/en/components/05.data/table/examples/ColumnGroups.example.vue
@@ -1,0 +1,37 @@
+<script lang="ts" setup>
+import { OnyxTable, TableColumnGroup } from "sit-onyx";
+
+const data = [
+  { fruit: "Strawberry", price: 4.5, weight: 200, quantity: 100, rating: 5 },
+  { fruit: "Apple", price: 1.99, weight: 3_000, quantity: 200, rating: 3 },
+  { fruit: "Banana", price: 3.75, weight: 18_000, quantity: 300, rating: 4 },
+];
+
+const columnGroups: TableColumnGroup[] = [
+  { key: "general", header: "General", span: 2 },
+  { key: "inventory", header: "Inventory", span: 2 },
+  { key: "rest", span: 1 },
+];
+</script>
+
+<template>
+  <OnyxTable :column-groups with-vertical-borders>
+    <template #head>
+      <tr>
+        <th>Fruit</th>
+        <th>Price (€/kg)</th>
+        <th>Inventory (kg)</th>
+        <th>Inventory (pieces)</th>
+        <th>Rating</th>
+      </tr>
+    </template>
+
+    <tr v-for="row in data" :key="row.fruit">
+      <td>{{ row.fruit }}</td>
+      <td>{{ row.price }}</td>
+      <td>{{ row.weight }}</td>
+      <td>{{ row.quantity }}</td>
+      <td>{{ row.rating }}</td>
+    </tr>
+  </OnyxTable>
+</template>

--- a/apps/showcase/content/en/components/05.data/table/examples/Slots.example.vue
+++ b/apps/showcase/content/en/components/05.data/table/examples/Slots.example.vue
@@ -1,0 +1,52 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxButton, OnyxHeadline, OnyxIconButton, OnyxPagination, OnyxTable } from "sit-onyx";
+import { ref } from "vue";
+
+const data = [
+  { fruit: "Strawberry", price: 4.5, weight: 200, quantity: 100, rating: 5 },
+  { fruit: "Apple", price: 1.99, weight: 3_000, quantity: 200, rating: 3 },
+  { fruit: "Banana", price: 3.75, weight: 18_000, quantity: 300, rating: 4 },
+];
+
+const page = ref(1);
+</script>
+
+<template>
+  <OnyxTable>
+    <template #head>
+      <tr>
+        <th>Fruit</th>
+        <th>Price (€/kg)</th>
+        <th>Inventory (kg)</th>
+        <th>Inventory (pieces)</th>
+        <th>Rating</th>
+      </tr>
+    </template>
+
+    <tr v-for="row in data" :key="row.fruit">
+      <td>{{ row.fruit }}</td>
+      <td>{{ row.price }}</td>
+      <td>{{ row.weight }}</td>
+      <td>{{ row.quantity }}</td>
+      <td>{{ row.rating }}</td>
+    </tr>
+
+    <template #headline>
+      <OnyxHeadline is="h3">Example headline</OnyxHeadline>
+    </template>
+
+    <template #actions>
+      <OnyxIconButton :icon="iconPlaceholder" label="Example action" />
+      <OnyxButton label="Button" :icon="iconPlaceholder" />
+    </template>
+
+    <template #bottomLeft>
+      <p class="onyx-text--small">Additional example description.</p>
+    </template>
+
+    <template #pagination>
+      <OnyxPagination v-model="page" :pages="42" />
+    </template>
+  </OnyxTable>
+</template>

--- a/apps/showcase/content/en/components/05.data/table/examples/Striped.example.vue
+++ b/apps/showcase/content/en/components/05.data/table/examples/Striped.example.vue
@@ -1,0 +1,31 @@
+<script lang="ts" setup>
+import { OnyxTable } from "sit-onyx";
+
+const data = [
+  { fruit: "Strawberry", price: 4.5, weight: 200, quantity: 100, rating: 5 },
+  { fruit: "Apple", price: 1.99, weight: 3_000, quantity: 200, rating: 3 },
+  { fruit: "Banana", price: 3.75, weight: 18_000, quantity: 300, rating: 4 },
+];
+</script>
+
+<template>
+  <OnyxTable striped>
+    <template #head>
+      <tr>
+        <th>Fruit</th>
+        <th>Price (€/kg)</th>
+        <th>Inventory (kg)</th>
+        <th>Inventory (pieces)</th>
+        <th>Rating</th>
+      </tr>
+    </template>
+
+    <tr v-for="row in data" :key="row.fruit">
+      <td>{{ row.fruit }}</td>
+      <td>{{ row.price }}</td>
+      <td>{{ row.weight }}</td>
+      <td>{{ row.quantity }}</td>
+      <td>{{ row.rating }}</td>
+    </tr>
+  </OnyxTable>
+</template>

--- a/apps/showcase/content/en/components/05.data/table/examples/VerticalBorders.example.vue
+++ b/apps/showcase/content/en/components/05.data/table/examples/VerticalBorders.example.vue
@@ -1,0 +1,31 @@
+<script lang="ts" setup>
+import { OnyxTable } from "sit-onyx";
+
+const data = [
+  { fruit: "Strawberry", price: 4.5, weight: 200, quantity: 100, rating: 5 },
+  { fruit: "Apple", price: 1.99, weight: 3_000, quantity: 200, rating: 3 },
+  { fruit: "Banana", price: 3.75, weight: 18_000, quantity: 300, rating: 4 },
+];
+</script>
+
+<template>
+  <OnyxTable with-vertical-borders>
+    <template #head>
+      <tr>
+        <th>Fruit</th>
+        <th>Price (€/kg)</th>
+        <th>Inventory (kg)</th>
+        <th>Inventory (pieces)</th>
+        <th>Rating</th>
+      </tr>
+    </template>
+
+    <tr v-for="row in data" :key="row.fruit">
+      <td>{{ row.fruit }}</td>
+      <td>{{ row.price }}</td>
+      <td>{{ row.weight }}</td>
+      <td>{{ row.quantity }}</td>
+      <td>{{ row.rating }}</td>
+    </tr>
+  </OnyxTable>
+</template>

--- a/apps/showcase/content/en/components/05.data/table/index.md
+++ b/apps/showcase/content/en/components/05.data/table/index.md
@@ -1,0 +1,42 @@
+---
+title: Table
+componentName: OnyxTable
+---
+
+A streamlined way to display smaller data sets. The table component focuses on simplicity, making it easy for users to view and interact with data without overwhelming them.
+
+::info-card{headline="Data grid vs. table" color="warning"}
+For most cases, we recommend to use the data grid instead. Please refer to the [data grid documentation](/components/data/table) for further information when to use the data grid and the table.
+::
+
+## Examples
+
+### Basic
+
+A basic table displays rows in a pre-defined set of columns. The table header is optional. The cell content is fully customizable.
+
+:component-example{name="Basic" layout="fullWidth"}
+
+### Striped
+
+Striped rows can be enabled where every even row has a different background color.
+
+:component-example{name="Striped" layout="fullWidth"}
+
+### Vertical borders
+
+Use vertical borders to separate the columns more clearly and achieve a grid look.
+
+:component-example{name="VerticalBorders" layout="fullWidth"}
+
+### Slots
+
+The table supports four custom slots around the main table to add custom content such as headline, actions or pagination.
+
+:component-example{name="Slots" layout="fullWidth"}
+
+### Column groups
+
+Columns can be grouped to visually group related columns.
+
+:component-example{name="ColumnGroups" layout="fullWidth"}

--- a/packages/sit-onyx/src/components/OnyxCalendar/OnyxCalendar.vue
+++ b/packages/sit-onyx/src/components/OnyxCalendar/OnyxCalendar.vue
@@ -1,11 +1,3 @@
-<script lang="ts">
-/**
- * @experimental
- * @deprecated This component is still under active development and its API might change in patch releases.
- */
-export default {};
-</script>
-
 <script lang="ts" setup generic="TSelection extends OnyxCalendarSelectionMode">
 import {
   createCalendar,
@@ -371,6 +363,7 @@ useOutsideClick({
     --onyx-calendar-border-radius: var(--onyx-radius-md);
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
     gap: var(--onyx-density-sm);
     color: var(--onyx-color-text-icons-neutral-medium);
     font-family: var(--onyx-font-family-paragraph);


### PR DESCRIPTION
Relates to #5707

Implement new showcase examples/documentation for "Data" components (except data grid): Calendar, empty, items per page, pagination and table
