### PR TITLE
feat: mcp implement docs resources

### DIFF
--- a/.changeset/eager-rats-win.md
+++ b/.changeset/eager-rats-win.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/modelcontextprotocol": minor
+---
+
+feat: Implement support for providing and writing skills via onyx-mcp CLI

--- a/.changeset/yellow-flies-fail.md
+++ b/.changeset/yellow-flies-fail.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/modelcontextprotocol": minor
+---
+
+feat: Implement `list-css-design-tokens` resource

--- a/packages/modelcontextprotocol/env.d.ts
+++ b/packages/modelcontextprotocol/env.d.ts
@@ -1,0 +1,19 @@
+/// <reference types="vite/client" />
+
+export type SkillFrontmatter = {
+  name: string;
+  description: string;
+};
+
+export type SkillMarkdown = {
+  default: string;
+  raw: string;
+  frontmatter: SkillFrontmatter;
+};
+
+declare module "*.md" {
+  const markdown: string;
+  export default markdown;
+  export const raw: string;
+  export const frontmatter: SkillFrontmatter;
+}

--- a/packages/modelcontextprotocol/env.d.ts
+++ b/packages/modelcontextprotocol/env.d.ts
@@ -1,8 +1,29 @@
 /// <reference types="vite/client" />
 
+/**
+ * Agent skills specification based on https://agentskills.io/specification
+ */
 export type SkillFrontmatter = {
+  /**
+   * 	Max 64 characters. Lowercase letters, numbers, and hyphens only. Must not start or end with a hyphen.
+   */
   name: string;
+  /**
+   * Max 1024 characters. Non-empty. Describes what the skill does and when to use it.
+   */
   description: string;
+  /**
+   * 	License name or reference to a bundled license file.
+   */
+  license?: string;
+  /**
+   * 	Max 500 characters. Indicates environment requirements (intended product, system packages, network access, etc.).
+   */
+  compatibility?: string;
+  /**
+   * 	Arbitrary key-value mapping for additional metadata.
+   */
+  metadata?: object;
 };
 
 export type SkillMarkdown = {

--- a/packages/modelcontextprotocol/package.json
+++ b/packages/modelcontextprotocol/package.json
@@ -34,14 +34,22 @@
   "devDependencies": {
     "@adobe/css-tools": "^4.5.0",
     "@sit-onyx/shared": "workspace:^",
+    "@types/mdast": "^4.0.4",
     "@types/node": "catalog:",
     "@types/tar-stream": "^3.1.4",
+    "@types/unist": "^3.0.3",
     "query-registry": "^4.3.0",
+    "remark": "^15.0.1",
+    "remark-frontmatter": "^5.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
     "tar-stream": "^3.2.0",
     "typescript": "catalog:",
+    "unified": "^11.0.5",
     "unplugin-dts": "catalog:",
     "vite": "catalog:",
     "vue-component-meta": "catalog:",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "engines": {

--- a/packages/modelcontextprotocol/package.json
+++ b/packages/modelcontextprotocol/package.json
@@ -32,6 +32,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
+    "@adobe/css-tools": "^4.5.0",
     "@sit-onyx/shared": "workspace:^",
     "@types/node": "catalog:",
     "@types/tar-stream": "^3.1.4",

--- a/packages/modelcontextprotocol/skill-md.vite.ts
+++ b/packages/modelcontextprotocol/skill-md.vite.ts
@@ -1,0 +1,68 @@
+import { Root, type RootContent } from "mdast";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import { unified } from "unified";
+import type { Plugin } from "vite";
+import yaml from "yaml";
+import type { SkillFrontmatter } from "./env.d.js";
+
+const isValidSkillFrontmatter = (object: unknown): object is SkillFrontmatter => {
+  if (typeof object !== "object" || object === null) {
+    return false;
+  }
+  if (
+    !("name" in object && typeof object.name === "string") ||
+    !("description" in object && typeof object.description === "string")
+  ) {
+    return false;
+  }
+  return true;
+};
+
+const parseMarkdown = (raw: string) => unified().use(remarkParse).use(remarkFrontmatter).parse(raw);
+const findAndRemoveFrontmatter = (root: Root) => {
+  const frontmatterIndex = root.children.findIndex(({ type }) => type === "yaml");
+  const [frontmatter] = root.children.splice(frontmatterIndex, 1);
+  return frontmatter;
+};
+const parseFrontmatter = (node: RootContent) => {
+  const parsed = yaml.parse((node as unknown as { value: string }).value);
+  if (!isValidSkillFrontmatter(parsed)) {
+    throw new Error(
+      'Skill markdown file must define "name" and "description" attribute in their frontmatter yaml!',
+    );
+  }
+  return parsed;
+};
+const toMarkdown = (root: Root) => unified().use(remarkStringify).stringify(root);
+
+/**
+ * Plugin for parsing markdown files as LLM skill definition.
+ * Will error if the markdown doesn't have a yaml frontmatter or the frontmatter doesn't include the `name` or `description` property.
+ *
+ * @param include Optional regex for matching file imports.
+ */
+export const skillMdPlugin = (include: RegExp = /\.md$/): Plugin<undefined> => ({
+  name: "skill-md-plugin",
+  load: {
+    filter: { id: { include } },
+    async handler(id) {
+      if (new RegExp(include).test(id)) {
+        const markdown = await this.fs.readFile(id, { encoding: "utf8" });
+        const file = parseMarkdown(markdown);
+        const frontmatter = findAndRemoveFrontmatter(file);
+        const data = parseFrontmatter(frontmatter);
+
+        const content = toMarkdown(file);
+        const frontMatterData = data && typeof data === "object" ? data : {};
+
+        const code = `export default ${JSON.stringify(content)};
+export const raw = ${JSON.stringify(markdown)};
+export const frontmatter = ${JSON.stringify(frontMatterData)};`;
+
+        return { moduleType: "js", moduleSideEffects: false, code };
+      }
+    },
+  },
+});

--- a/packages/modelcontextprotocol/src/config.ts
+++ b/packages/modelcontextprotocol/src/config.ts
@@ -9,6 +9,8 @@ export const REGISTRY_URL = process.env.REGISTRY_URL ?? "https://registry.npmjs.
  */
 export const SIT_ONYX_MIN_VERSION = "1.12.0";
 export const SIT_ONYX_COMPONENT_META_FILE = "package/dist/component-meta.json";
+export const SIT_ONYX_DESIGN_TOKENS_FILE = "package/src/styles/variables/themes/onyx.css";
+export const SIT_ONYX_DESIGN_TOKENS_SPACINGS_FILE = "package/src/styles/variables/spacing.css";
 /**
  * Minimum `@sit-onyx/icons` version that provides the `metadata.json` file
  */

--- a/packages/modelcontextprotocol/src/index.ts
+++ b/packages/modelcontextprotocol/src/index.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import { log } from "node:console";
+import { stat } from "node:fs/promises";
 import { parseArgs, type ParseArgsOptionsConfig } from "node:util";
 import packageJson from "../package.json" with { type: "json" };
+import { writeSkillFiles } from "./resources/skills.js";
 import { run as http } from "./server/http.js";
 import { createServer } from "./server/server.js";
 import { run as stdio } from "./server/stdio.js";
@@ -25,6 +27,10 @@ if (import.meta.main) {
       short: "r",
       default: false,
     },
+    writeSkills: {
+      type: "string",
+      short: "w",
+    },
     help: {
       type: "boolean",
       short: "h",
@@ -38,7 +44,7 @@ if (import.meta.main) {
   } satisfies ParseArgsOptionsConfig;
 
   const {
-    values: { transport, version, help, resourcesAsTools },
+    values: { transport, version, help, resourcesAsTools, writeSkills },
   } = parseArgs({
     args: process.argv.slice(2),
     options,
@@ -54,15 +60,23 @@ Usage:
     onyx-mcp [options]
 
 Options:
- -t, --transport <stdio|http> Which kind of MCP server should be started (default: stdio). 
-                              The "http" transport considers PORT and HOST environment variables, when starting the server.
- -r, --resourcesAsTools       Some LLM Coding Assistants (e.g. Gemini) are not able to to use MCP resources (yet). 
-                              This setting makes resources also available as tools to support these Coding Assistants.
- -h, --help                   Show this help text and quit.
- -v, --version                Show version number and quit.`);
+ -t, --transport <"stdio"|"http"> Which kind of MCP server should be started (default: stdio). 
+                                  The "http" transport considers PORT and HOST environment variables, when starting the server.
+ -r, --resourcesAsTools           Some LLM Coding Assistants (e.g. Gemini) are not able to to use MCP resources (yet). 
+                                  This setting makes resources also available as tools to support these Coding Assistants.
+ -w, --write-skills <directory>     Write resources to SKILL.md files in the specified directory.
+ -h, --help                       Show this help text and quit.
+ -v, --version                    Show version number and quit.`);
     process.exit(0);
   } else if (version) {
     log(packageJson.version);
+    process.exit(0);
+  } else if (writeSkills) {
+    const stats = await stat(writeSkills);
+    if (!stats.isDirectory()) {
+      throw new Error(`${writeSkills} is not a directory`);
+    }
+    await writeSkillFiles(writeSkills);
     process.exit(0);
   } else {
     if (!Object.keys(SUPPORTED_TRANSPORTS).includes(transport)) {

--- a/packages/modelcontextprotocol/src/index.ts
+++ b/packages/modelcontextprotocol/src/index.ts
@@ -64,7 +64,7 @@ Options:
                                   The "http" transport considers PORT and HOST environment variables, when starting the server.
  -r, --resourcesAsTools           Some LLM Coding Assistants (e.g. Gemini) are not able to to use MCP resources (yet). 
                                   This setting makes resources also available as tools to support these Coding Assistants.
- -w, --write-skills <directory>     Write resources to SKILL.md files in the specified directory.
+ -w, --write-skills <directory>   Write skill resources to SKILL.md files in the specified directory.
  -h, --help                       Show this help text and quit.
  -v, --version                    Show version number and quit.`);
     process.exit(0);

--- a/packages/modelcontextprotocol/src/resources/get-component-api.ts
+++ b/packages/modelcontextprotocol/src/resources/get-component-api.ts
@@ -19,9 +19,9 @@ const tagsToList = (tags: Tag[]) =>
     .map(({ text, name }) => `- ${name}: ${text}`)
     .join("\n");
 
-export const getComponentApi: RegisterableResource = [
+export const getComponentApi: RegisterableResource<true> = [
   "get-component-api",
-  new ResourceTemplate("components://sit-onyx/{version}/{component}", {
+  new ResourceTemplate("sit-onyx://components/{version}/{component}", {
     list: undefined,
   }),
   {

--- a/packages/modelcontextprotocol/src/resources/index.ts
+++ b/packages/modelcontextprotocol/src/resources/index.ts
@@ -1,0 +1,13 @@
+import { getComponentApi } from "./get-component-api.js";
+import { listComponents } from "./list-components.js";
+import { listCssDesignTokens } from "./list-css-design-tokens.js";
+import { listIcons } from "./list-icons.js";
+import { allSkills } from "./skills.js";
+
+export const resources = [
+  getComponentApi,
+  listComponents,
+  listIcons,
+  listCssDesignTokens,
+  ...allSkills,
+];

--- a/packages/modelcontextprotocol/src/resources/list-components.ts
+++ b/packages/modelcontextprotocol/src/resources/list-components.ts
@@ -5,9 +5,9 @@ import type { RegisterableResource } from "../types.js";
 import { retrieveComponentMetaJsonFile } from "../util/component-meta-json.js";
 import { versionCompare } from "../util/version-compare.js";
 
-export const listComponents: RegisterableResource = [
+export const listComponents: RegisterableResource<true> = [
   "list-components",
-  new ResourceTemplate("components://sit-onyx/{version}", {
+  new ResourceTemplate("sit-onyx://components/{version}", {
     list: async () => {
       const { versions } = await getAbbreviatedPackument("sit-onyx", REGISTRY_URL);
       const relevantVersions = Object.keys(versions).filter(

--- a/packages/modelcontextprotocol/src/resources/list-css-design-tokens.ts
+++ b/packages/modelcontextprotocol/src/resources/list-css-design-tokens.ts
@@ -1,0 +1,34 @@
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { RegisterableResource } from "../types.js";
+import { cached } from "../util/cached.js";
+import { retrieveOnyxDesignTokens } from "../util/onyx-css-design-tokens.js";
+
+export const listCssDesignTokens: RegisterableResource = [
+  "list-css-design-tokens",
+  new ResourceTemplate("css-design-token://sit-onyx/{version}", {
+    list: undefined,
+  }),
+  {
+    title: "List @sit-onyx/icons design-tokens by their CSS custom property name",
+    description:
+      "List all allowed design tokens with their CSS custom property name in a specific version of sit-onyx",
+    mimeType: "text/markdown",
+  },
+  cached(async (uri, { version: _version }) => {
+    const version = Array.isArray(_version) ? _version[0] : _version;
+    const tokens = await retrieveOnyxDesignTokens(version);
+
+    const title = `# Design Tokens for \`sit-onyx@${version}\`\n\n`;
+    const content = tokens.map((n) => `- \`${n}\``).join("\n");
+    const text = `${title}${content}`;
+    return {
+      contents: [
+        {
+          uri: uri.href,
+          text,
+          mimeType: "text/markdown",
+        },
+      ],
+    };
+  }),
+];

--- a/packages/modelcontextprotocol/src/resources/list-css-design-tokens.ts
+++ b/packages/modelcontextprotocol/src/resources/list-css-design-tokens.ts
@@ -3,9 +3,9 @@ import type { RegisterableResource } from "../types.js";
 import { cached } from "../util/cached.js";
 import { retrieveOnyxDesignTokens } from "../util/onyx-css-design-tokens.js";
 
-export const listCssDesignTokens: RegisterableResource = [
+export const listCssDesignTokens: RegisterableResource<true> = [
   "list-css-design-tokens",
-  new ResourceTemplate("css-design-token://sit-onyx/{version}", {
+  new ResourceTemplate("sit-onyx://css-design-tokens/{version}", {
     list: undefined,
   }),
   {

--- a/packages/modelcontextprotocol/src/resources/list-icons.ts
+++ b/packages/modelcontextprotocol/src/resources/list-icons.ts
@@ -3,9 +3,9 @@ import type { IconMetadata, RegisterableResource } from "../types.js";
 import { cached } from "../util/cached.js";
 import { retrieveIconsMetadataJsonFile } from "../util/icons-metadata-json.js";
 
-export const listIcons: RegisterableResource = [
+export const listIcons: RegisterableResource<true> = [
   "list-icons",
-  new ResourceTemplate("icons://sit-onyx/{version}", {
+  new ResourceTemplate("sit-onyx://icons/{version}", {
     list: undefined,
   }),
   {

--- a/packages/modelcontextprotocol/src/resources/skills.ts
+++ b/packages/modelcontextprotocol/src/resources/skills.ts
@@ -1,30 +1,39 @@
-import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { log } from "node:console";
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import type { SkillMarkdown } from "../../env.js";
 import type { RegisterableResource } from "../types.js";
 
-const skills = import.meta.glob<SkillMarkdown>("./skills/*.md", { eager: true });
+const skills = import.meta.glob<SkillMarkdown>("./skills/**/SKILL.md", { eager: true });
 
-export const allSkills = Object.values(skills).map<RegisterableResource>(
-  ({ default: text, frontmatter: { description, name } }) => {
-    return [
-      name,
-      new ResourceTemplate(`skills://${name}/{version}`, {
-        list: undefined,
-      }),
-      {
-        title: name,
-        description,
-        mimeType: "text/markdown",
-      },
-      async (uri, { version: _version }) => ({
-        contents: [
-          {
-            uri: uri.href,
-            text,
-            mimeType: "text/markdown",
-          },
-        ],
-      }),
-    ];
-  },
+export const allSkills = Object.values(skills).map<RegisterableResource<false>>(
+  ({ default: text, frontmatter: { description, name } }) => [
+    name,
+    `sit-onyx://skill/${name}`,
+    {
+      title: name,
+      description,
+      mimeType: "text/markdown",
+    },
+    (uri: URL) => ({
+      contents: [
+        {
+          uri: uri.href,
+          text,
+          mimeType: "text/markdown",
+        },
+      ],
+    }),
+  ],
 );
+
+export const writeSkillFiles = async (skillsDirectory: string) => {
+  const promises = Object.values(skills).map(async (skill) => {
+    const directory = resolve(skillsDirectory, skill.frontmatter.name);
+    await mkdir(directory, { recursive: true });
+    const file = resolve(directory, "SKILL.md");
+    await writeFile(file, skill.raw);
+    log(`Skill ${skill.frontmatter.name} written to ${directory}`);
+  });
+  return Promise.all(promises);
+};

--- a/packages/modelcontextprotocol/src/resources/skills.ts
+++ b/packages/modelcontextprotocol/src/resources/skills.ts
@@ -1,0 +1,30 @@
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SkillMarkdown } from "../../env.js";
+import type { RegisterableResource } from "../types.js";
+
+const skills = import.meta.glob<SkillMarkdown>("./skills/*.md", { eager: true });
+
+export const allSkills = Object.values(skills).map<RegisterableResource>(
+  ({ default: text, frontmatter: { description, name } }) => {
+    return [
+      name,
+      new ResourceTemplate(`skills://${name}/{version}`, {
+        list: undefined,
+      }),
+      {
+        title: name,
+        description,
+        mimeType: "text/markdown",
+      },
+      async (uri, { version: _version }) => ({
+        contents: [
+          {
+            uri: uri.href,
+            text,
+            mimeType: "text/markdown",
+          },
+        ],
+      }),
+    ];
+  },
+);

--- a/packages/modelcontextprotocol/src/resources/skills/onyx-components/SKILL.md
+++ b/packages/modelcontextprotocol/src/resources/skills/onyx-components/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: onyx-components
+description: Best practices and dynamic API lookup instructions for Onyx UI components. Use when implementing UI features, forms, or building Vue templates.
+license: Apache-2.0
+---
+
+# Onyx Components
+
+Implement and configure Onyx Vue 3 UI components using authoritative API definitions.
+
+## Rule: Mandatory Dynamic API Lookups (MCP)
+
+Onyx component APIs are dynamic and change across versions. **NEVER guess or assume props, events, or slots.**
+
+## Onyx MCP Server Installation & Setup
+
+To allow coding-agents to dynamically query component API specifications and icons, install and configure the official Onyx Model Context Protocol (MCP) server.
+
+### 1. Global Installation
+
+Install the package globally using your package manager:
+
+```bash
+# Using npm
+npm install -g @sit-onyx/modelcontextprotocol
+
+# Using pnpm
+pnpm install -g @sit-onyx/modelcontextprotocol
+```
+
+Verify the installation is successful:
+
+```bash
+onyx-mcp -h
+```
+
+### 2. General MCP Client Configuration
+
+Configure the server in your preferred MCP-compliant client (such as Cursor, Claude Desktop, VS Code plugins, or general command-line utilities) using these standard parameters:
+
+- **Command:** `onyx-mcp`
+- **Arguments:** `["-r"]` (Optional: Use the recursive flag depending on environment)
+- **Description:** `"Information about components of the onyx UI component library"`
+
+### Step 1: Version Autodiscovery
+
+Before querying the MCP server, you **MUST** discover the exact Onyx version used in the project:
+
+1. Open and parse the root `package.json`.
+2. Find the version defined under `dependencies` or `devDependencies` for `sit-onyx`.
+3. Use this parsed version number (e.g. `"1.2.3"`) as the required `version` parameter for all subsequent MCP tool calls.
+
+### Step 2: Query the MCP Server
+
+Use the connected `onyx-mcp` tools using your discovered version:
+
+- `mcp_onyx-mcp_list-components`: Discover the exact names of available components in this version.
+- `mcp_onyx-mcp_get-component-api`: Retrieve authoritative props, events, and slots for a specific component before writing code.
+- `mcp_onyx-mcp_list-icons`: Retrieve available icon names when implementing components with icon properties.
+
+---
+
+## Component Implementation Rules
+
+### Action Components (Buttons & Links)
+
+- **Props-based Links:** Components like `OnyxButton`, `OnyxIconButton`, `OnyxSystemButton`, `OnyxMenuItem`, and `OnyxNavItem` support a `link` prop. Do not wrap these components in raw `<a>` tags; pass the URL to the `link` prop.
+- **Headless Links:** Use the `useLink` composable (`const { navigate, isActive } = useLink()`) or `OnyxRouterLink` for custom unstyled navigation components.
+
+### Form Elements
+
+- **Labels & Messages:** Always configure standard `Message` and `LabelPositions` properties consistently.
+- **Loading State:** Implement built-in `Skeleton` loading states when loading form data.
+- **Accessibility:** Use proper labels and fieldsets for complex multi-input forms (`date-picker`, `radio-group`, `checkbox-group`).
+
+### Cards & Layout Structure
+
+- Nest and structure basic components (`Accordion`, `Cards`, `Badge`, `Tag`) inside the Onyx grid layout (see `onyx-foundation`) to prevent layout breaking.
+
+---
+
+## Validation & Quality Check
+
+After writing or updating components, you **MUST** run the following verification steps:
+
+1. **Type Check:** Run TypeScript verification (e.g., `npx vue-tsc --noEmit` or `npm run type-check`) to confirm no invalid props or event bindings exist.
+2. **Linter Check:** Run standard project linters (e.g., `npm run lint` or `eslint .`) to confirm code style and rules are respected.
+3. **Manual Verification:** Confirm all slots and custom events mapped conform to the authoritative API fetched from the MCP.

--- a/packages/modelcontextprotocol/src/resources/skills/onyx-foundation/SKILL.md
+++ b/packages/modelcontextprotocol/src/resources/skills/onyx-foundation/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: onyx-foundation
+description: Styling foundations, CSS variables, layout grid, breakpoints, and responsive mixins for Onyx. Use when writing custom CSS, designing layouts, or ensuring theme compliance.
+license: Apache-2.0
+---
+
+# Onyx Foundation & Theming
+
+Apply Onyx styling foundations, CSS variables, responsive grid, and layout rules.
+
+## Theming & Colors
+
+Onyx supports light and dark themes out-of-the-box. Theme switching is handled automatically.
+
+### Rule: CSS Variables Only
+
+**NEVER hardcode hex, rgb, or hsl color values.** Always use semantic Onyx CSS variables (prefixed with `--onyx-`).
+
+- **Base backgrounds:** `var(--onyx-color-base-background-tinted)`, `var(--onyx-color-base-background-blank)`
+- **Primary brand:** `var(--onyx-color-base-primary-500)`, `var(--onyx-color-base-primary-100)`
+- **Text & icons:** `var(--onyx-color-text-icons-primary-soft)`, `var(--onyx-color-text-icons-primary-medium)`, `var(--onyx-color-text-icons-primary-intense)`
+- **Component states:** `var(--onyx-color-component-cta-default)`, `var(--onyx-color-component-border-primary)`, `var(--onyx-color-component-focus-primary)`
+
+_Note: Access ONLY Semantic variables. Do NOT use global or component variables directly in applications._
+
+## Density
+
+Density levels control the vertical white space and heights (base heights: Compact = 32px, Default = 40px, Cozy = 48px).
+Apply density via properties on supported components or by adding these CSS classes to any element:
+
+- `.onyx-density-compact`
+- `.onyx-density-default`
+- `.onyx-density-cozy`
+
+## Breakpoints
+
+The design system defines six standard breakpoints:
+
+- `2xs`: `320px` to `576px` (Max 4 columns)
+- `xs`: `577px` to `768px` (Max 8 columns)
+- `sm`: `769px` to `992px` (Max 8 columns)
+- `md`: `993px` to `1440px` (Max 12 columns)
+- `lg`: `1441px` to `1920px` (Max 12 or 16 columns)
+- `xl`: `1921px` and beyond (Max 12, 16, or 20 columns)
+
+### Responsive SCSS Mixins
+
+Import `"sit-onyx/breakpoints.scss"` to apply media or container queries:
+
+```scss
+@use "sit-onyx/breakpoints.scss";
+
+// Media queries (compares against whole screen width)
+.my-screen-class {
+  @include breakpoints.screen(max, sm) {
+    /* styles for sm and smaller */
+  }
+  @include breakpoints.screen(min, md) {
+    /* styles for md and larger */
+  }
+}
+
+// Container queries (compares against nearest container width)
+// MUST set container-type on the parent element
+.my-container-class {
+  container-type: inline-size;
+
+  @include breakpoints.container(max, md) {
+    /* styles for md container and smaller */
+  }
+  @include breakpoints.container(min, lg) {
+    /* styles for lg container and larger */
+  }
+}
+```
+
+## Grid System
+
+Onyx uses container-query-based grids. The nearest parent component with `container-type: inline-size;` (automatically set by `OnyxPageLayout`, `OnyxAppLayout`, `OnyxSidebar`) determines the active grid width.
+
+### Grid Classes
+
+- **Container:** `.onyx-grid` (Defines a grid container)
+- **Spanning Columns:** `.onyx-grid-span-<number>` (Define exact span from 1 to 12)
+- **Full Width:** `.onyx-grid-span-full` (Span all available columns)
+- **Breakpoint-Specific Span:** `.onyx-grid-<breakpoint>-span-<number>` (Define column span for a specific breakpoint **and larger**)
+
+### Grid Margin
+
+Apply `.onyx-grid-layout` manually to wrap page contents and add outer page margins if not using `OnyxPageLayout`.
+
+```vue
+<template>
+  <div class="onyx-grid">
+    <!-- Spans 4 cols on smaller screens, 6 on md and larger -->
+    <OnyxCard class="onyx-grid-span-4 onyx-grid-md-span-6">Content</OnyxCard>
+
+    <!-- Spans full width always -->
+    <OnyxCard class="onyx-grid-span-full">Footer / Hero</OnyxCard>
+  </div>
+</template>
+```
+
+### Grid Customization
+
+Set these CSS classes on the root element of your application (e.g. `OnyxAppLayout`):
+
+- **Limit Max Width:** `onyx-grid-max-md` (max 1440px) or `onyx-grid-max-lg` (max 1920px)
+- **Alignment:** `onyx-grid-center` (Centers the layout when screen size exceeds max width)
+- **Max Columns (lg and beyond):** `onyx-grid-lg-16` (16 columns) or `onyx-grid-xl-20` (20 columns)
+
+## Page Layout (`OnyxPageLayout`)
+
+Implement the `OnyxPageLayout` component as the root element on every individual page/view to ensure standardized paddings, page-level scroll behavior, and unified outer page margins.
+
+```vue
+<template>
+  <OnyxPageLayout>
+    <OnyxHeadline is="h1">Page Title</OnyxHeadline>
+  </OnyxPageLayout>
+</template>
+```
+
+For recurring page elements (like sidebars, footers, or sub-navigation), wrap the `OnyxPageLayout` in a reusable component or a Nuxt layout.
+
+## Layout Principles & Page Anatomy
+
+All custom layout constructions must align with the core Onyx layout guidelines:
+
+### Core Principles
+
+- **Responsive:** Layouts must fluidly adapt to maintain usability and visual hierarchy across all device sizes.
+- **Content-Driven:** Prioritize structural layout decisions based on the content's hierarchy and user needs, not vice versa.
+
+### The Four Page Anatomy Regions
+
+1. **Main Navigation (`OnyxNavBar`):** Persistent top/left area independent of scroll containers, providing access to top-level views.
+2. **Sidebar (`OnyxSidebar`):** Persistent left/right sidebar used for secondary navigation or master-detail detail panels.
+3. **Page Content (`OnyxPageLayout`):** The flexible central area governed by the grid system and acting as the primary scroll container.
+4. **Bottom Bar (`OnyxBottomBar`):** Scroll-independent sticky bar at the bottom for status confirmations or primary page-level triggers.
+
+### Component Alignment Rule
+
+- **STRICT Left-Alignment:** All internal component layout structures must be left-aligned to preserve scannability.
+- **Exception:** Tables and data grids may utilize center/right alignment within specific columns depending on data type formats (e.g. numeric currencies).
+
+### Visual Rhythm & Grouping
+
+- **Spatial Grouping:** Group functionally related components together using generous empty space (white space), typography, or dividers to minimize cognitive load. Ensure balanced proportions across all section distributions.
+
+---
+
+## Validation & Quality Check
+
+After writing custom layouts or styling overrides, you **MUST** run the following verification steps:
+
+1. **CSS Variables Audit:** Scan your stylesheets for any hardcoded hex, rgb, or hsl values, or direct global/component variable usages. Replace them with proper `--onyx-` semantic variables.
+2. **Layout Alignment Check:** Verify all custom component interiors are left-aligned (with the exception of specific table/data grid columns).
+3. **Responsive Verification:** Verify your CSS container-query selectors are properly paired with a parent `container-type: inline-size;`. Ensure no breakpoint styles break responsive fluidity.

--- a/packages/modelcontextprotocol/src/resources/skills/onyx-setup/SKILL.md
+++ b/packages/modelcontextprotocol/src/resources/skills/onyx-setup/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: onyx-setup
+description: One-time configuration, initialization, CSS/font imports, i18n, and layout scaffolding for the Onyx design system. Use when setting up a new project or integrating Vue Router.
+license: Apache-2.0
+---
+
+# Onyx Setup & Integration
+
+Configure and initialize the Onyx Vue 3 design system, mandatory styles, fonts, internationalization, and root layout scaffolding.
+
+## Setup & Initialization
+
+### Vue 3 Setup
+
+1. Install `sit-onyx`.
+2. Import style files and initialize the Onyx plugin.
+
+```typescript
+import { createApp } from "vue";
+import { createOnyx } from "sit-onyx";
+import App from "./App.vue";
+
+// Mandatory component styles
+import "sit-onyx/style.css";
+
+// Highly recommended global application styles (sets body background, font, etc.)
+import "sit-onyx/global.css";
+
+const onyx = createOnyx({
+  // router: routerInstance // Option: Pass router instance here
+});
+
+const app = createApp(App);
+app.use(onyx);
+```
+
+### Nuxt Setup
+
+1. Install `@sit-onyx/nuxt`.
+2. Register the module in `nuxt.config.ts`. Do not manually call `createOnyx()`.
+
+```typescript
+export default defineNuxtConfig({
+  modules: ["@sit-onyx/nuxt"],
+  onyx: {
+    // optional module options here
+  },
+});
+```
+
+## Internationalization (i18n) Setup
+
+English (`en-US`) is default and registered out-of-the-box. Additional languages must be registered manually.
+
+### Vue 3 Integration with `vue-i18n`
+
+To sync translations, import the JSON file from Onyx and register it in the `createOnyx` initialization options:
+
+```typescript
+import { createApp } from "vue";
+import { createI18n } from "vue-i18n";
+import { createOnyx } from "sit-onyx";
+import App from "./App.vue";
+
+// Import required Onyx translation file
+import onyxDE from "sit-onyx/locales/de-DE.json";
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "de-DE",
+  // your messages setup
+});
+
+const onyx = createOnyx({
+  i18n: {
+    // Syncs initial language
+    locale: i18n.global.locale,
+    // Message locale name MUST exactly match the code in vue-i18n
+    messages: {
+      "de-DE": onyxDE,
+    },
+  },
+});
+
+const app = createApp(App);
+app.use(i18n).use(onyx);
+```
+
+_Note: Onyx translations update automatically whenever you change the active language inside `vue-i18n`._
+
+### Nuxt Integration with `@nuxtjs/i18n`
+
+The `@sit-onyx/nuxt` module automatically registers the corresponding Onyx languages for you.
+
+**Strict BCP 47 Rule:**
+If you use 2-digit locale codes (e.g. `es` instead of `es-ES`), you **MUST** configure the `language` property inside `nuxt.config.ts` so Onyx can map the translation correctly:
+
+```typescript
+export default defineNuxtConfig({
+  modules: ["@sit-onyx/nuxt", "@nuxtjs/i18n"],
+  i18n: {
+    locales: [
+      { code: "de-DE" }, // Standard 4-digit code works automatically
+      { code: "es", language: "es-ES" }, // 2-digit code requires language mapping
+    ],
+  },
+});
+```
+
+## Recommended Font Setup
+
+Install font packages `@fontsource-variable/source-sans-3` and `@fontsource-variable/source-code-pro`. Import them into your main entrypoint:
+
+### Vue (`main.ts`)
+
+```typescript
+import "@fontsource-variable/source-code-pro";
+import "@fontsource-variable/source-sans-3";
+```
+
+### Nuxt (`nuxt.config.ts`)
+
+```typescript
+export default defineNuxtConfig({
+  css: ["@fontsource-variable/source-code-pro", "@fontsource-variable/source-sans-3"],
+});
+```
+
+## App Layout Scaffolding (Boilerplate)
+
+Use Onyx layout components to manage structural complexity, scroll behaviors, and responsive constraints.
+
+### Root Shell (`OnyxAppLayout`)
+
+Place `OnyxAppLayout` at the root of the application (e.g. `App.vue` or `app/app.vue`). Use class modifiers to cap maximum width on large screens.
+
+```vue
+<template>
+  <!-- Cap width at 1920px (lg breakpoint) and center align the layout -->
+  <OnyxAppLayout class="onyx-grid-max-lg onyx-grid-center">
+    <template #navBar>
+      <OnyxNavBar app-name="Example App">
+        <OnyxNavItem label="Home" link="/" />
+      </OnyxNavBar>
+    </template>
+
+    <!-- Render pages inside the root layout shell -->
+    <RouterView />
+  </OnyxAppLayout>
+</template>
+```
+
+## Vue Router Integration
+
+Pass the Vue router instance to `createOnyx({ router })` to enable native routing integration:
+
+- Internal links (e.g., `/my-page`) passed to navigation components (`OnyxLink`, `OnyxNavBar`, `OnyxNavItem`, `OnyxMenuItem`) navigate via Vue Router automatically.
+- Active states on `OnyxNavItem` and `OnyxMenuItem` update automatically depending on the active route.
+- Mobile flyouts close automatically upon navigation.
+- **Fallback:** Uses native browser navigation for external links, links with `target="_blank"`, or when no router is registered.

--- a/packages/modelcontextprotocol/src/server/server.ts
+++ b/packages/modelcontextprotocol/src/server/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import packageJson from "../../package.json" with { type: "json" };
 import { resources } from "../resources/index.js";
+import type { RegisterableResource } from "../types.js";
 import { resourceToTool } from "../util/mcp-server.js";
 
 const { name, version, description } = packageJson;
@@ -18,7 +19,10 @@ export const createServer = ({ resourcesAsTools }: CreateServerOptions) => {
     websiteUrl: "https://onyx.schwarz",
   });
 
-  resources.forEach((resource) => server.registerResource(...resource));
+  resources.forEach((resource) =>
+    // typescript is unable to merge the type parameters of the overloaded function
+    server.registerResource(...(resource as RegisterableResource)),
+  );
 
   if (resourcesAsTools) {
     resources.map((r) => resourceToTool(r)).forEach((t) => server.registerTool(...t));

--- a/packages/modelcontextprotocol/src/server/server.ts
+++ b/packages/modelcontextprotocol/src/server/server.ts
@@ -1,16 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import packageJson from "../../package.json" with { type: "json" };
-import { getComponentApi } from "../resources/get-component-api.js";
-import { listComponents } from "../resources/list-components.js";
-import { listCssDesignTokens } from "../resources/list-css-design-tokens.js";
-import { listIcons } from "../resources/list-icons.js";
+import { resources } from "../resources/index.js";
 import { resourceToTool } from "../util/mcp-server.js";
 
 const { name, version, description } = packageJson;
 
 type CreateServerOptions = { resourcesAsTools: boolean };
-
-export const resources = [listComponents, getComponentApi, listIcons, listCssDesignTokens];
 
 export const createServer = ({ resourcesAsTools }: CreateServerOptions) => {
   /**

--- a/packages/modelcontextprotocol/src/server/server.ts
+++ b/packages/modelcontextprotocol/src/server/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import packageJson from "../../package.json" with { type: "json" };
 import { getComponentApi } from "../resources/get-component-api.js";
 import { listComponents } from "../resources/list-components.js";
+import { listCssDesignTokens } from "../resources/list-css-design-tokens.js";
 import { listIcons } from "../resources/list-icons.js";
 import { resourceToTool } from "../util/mcp-server.js";
 
@@ -9,7 +10,7 @@ const { name, version, description } = packageJson;
 
 type CreateServerOptions = { resourcesAsTools: boolean };
 
-export const resources = [listComponents, getComponentApi, listIcons];
+export const resources = [listComponents, getComponentApi, listIcons, listCssDesignTokens];
 
 export const createServer = ({ resourcesAsTools }: CreateServerOptions) => {
   /**

--- a/packages/modelcontextprotocol/src/types.ts
+++ b/packages/modelcontextprotocol/src/types.ts
@@ -2,11 +2,15 @@ import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/m
 import type { AnySchema, ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types";
 import { type ComponentMeta, type MetaCheckerOptions } from "vue-component-meta";
+import type { GetFunctionOverloads } from "./util/types.js";
 
 /**
  * Necessary Parameters to register a resource via `mcpServer.registerResource`
  */
-export type RegisterableResource = Parameters<McpServer["registerResource"]>;
+export type RegisterableResource<WithTemplate extends boolean = false> = GetFunctionOverloads<
+  McpServer["registerResource"]
+>[WithTemplate extends true ? 1 : 0]["parameters"];
+
 /**
  * Necessary Parameters to register a resource via `mcpServer.registerTool`
  */

--- a/packages/modelcontextprotocol/src/util/component-meta-json.ts
+++ b/packages/modelcontextprotocol/src/util/component-meta-json.ts
@@ -7,7 +7,7 @@ export const retrieveComponentMetaJsonFile = cached(
   async (versionOrTag: string): Promise<MetaSource[]> => {
     const [file] = await getFilesFromPackage(
       { name: "sit-onyx", versionOrTag },
-      [(header) => header.name === SIT_ONYX_COMPONENT_META_FILE],
+      [SIT_ONYX_COMPONENT_META_FILE],
       USER_AGENT,
     );
     return JSON.parse(file.data.toString("utf-8") ?? "");

--- a/packages/modelcontextprotocol/src/util/component-meta-json.ts
+++ b/packages/modelcontextprotocol/src/util/component-meta-json.ts
@@ -1,15 +1,15 @@
 import { SIT_ONYX_COMPONENT_META_FILE, USER_AGENT } from "../config.js";
 import type { MetaSource } from "../types.js";
 import { cached } from "./cached.js";
-import { getSingleFileFromPackage } from "./package.js";
+import { getFilesFromPackage } from "./package.js";
 
 export const retrieveComponentMetaJsonFile = cached(
   async (versionOrTag: string): Promise<MetaSource[]> => {
-    const data = await getSingleFileFromPackage(
+    const [file] = await getFilesFromPackage(
       { name: "sit-onyx", versionOrTag },
-      (header) => header.name === SIT_ONYX_COMPONENT_META_FILE,
+      [(header) => header.name === SIT_ONYX_COMPONENT_META_FILE],
       USER_AGENT,
     );
-    return JSON.parse(data.toString("utf-8"));
+    return JSON.parse(file.data.toString("utf-8") ?? "");
   },
 );

--- a/packages/modelcontextprotocol/src/util/icons-metadata-json.ts
+++ b/packages/modelcontextprotocol/src/util/icons-metadata-json.ts
@@ -1,15 +1,15 @@
 import { SIT_ONYX_ICONS_METADATA_FILE, USER_AGENT } from "../config.js";
 import type { IconMetadata } from "../types.js";
 import { cached } from "./cached.js";
-import { getSingleFileFromPackage } from "./package.js";
+import { getFilesFromPackage } from "./package.js";
 
 export const retrieveIconsMetadataJsonFile = cached(
   async (versionOrTag: string): Promise<IconMetadata> => {
-    const data = await getSingleFileFromPackage(
+    const [file] = await getFilesFromPackage(
       { name: "@sit-onyx/icons", versionOrTag },
-      (header) => header.name === SIT_ONYX_ICONS_METADATA_FILE,
+      [(header) => header.name === SIT_ONYX_ICONS_METADATA_FILE],
       USER_AGENT,
     );
-    return JSON.parse(data.toString("utf-8"));
+    return JSON.parse(file.data.toString("utf-8") ?? "");
   },
 );

--- a/packages/modelcontextprotocol/src/util/icons-metadata-json.ts
+++ b/packages/modelcontextprotocol/src/util/icons-metadata-json.ts
@@ -7,7 +7,7 @@ export const retrieveIconsMetadataJsonFile = cached(
   async (versionOrTag: string): Promise<IconMetadata> => {
     const [file] = await getFilesFromPackage(
       { name: "@sit-onyx/icons", versionOrTag },
-      [(header) => header.name === SIT_ONYX_ICONS_METADATA_FILE],
+      [SIT_ONYX_ICONS_METADATA_FILE],
       USER_AGENT,
     );
     return JSON.parse(file.data.toString("utf-8") ?? "");

--- a/packages/modelcontextprotocol/src/util/mcp-server.spec.ts
+++ b/packages/modelcontextprotocol/src/util/mcp-server.spec.ts
@@ -4,8 +4,8 @@ import type { RegisterableResource } from "../types.js";
 import { resourceToTool } from "./mcp-server.js";
 
 describe("resourceToTool", () => {
-  test("should map resource to tool correctly", async () => {
-    const testResource: RegisterableResource = [
+  test("should map resource with template to tool correctly", async () => {
+    const testResource: RegisterableResource<true> = [
       "test-title",
       new ResourceTemplate("test://sit-onyx/{parameter-1}/{parameter-2}", {
         list: undefined,
@@ -53,6 +53,57 @@ describe("resourceToTool", () => {
             mimeType: "text/markdown",
             text: "# Test Text",
             uri: "test://sit-onyx/value-1/value-2",
+          },
+          type: "resource",
+        },
+      ],
+    });
+  });
+
+  test("should map resource without template to tool correctly", async () => {
+    const testResource: RegisterableResource<false> = [
+      "test-title",
+      "test://sit-onyx/static",
+      {
+        title: "Test Title",
+        description: "Test Description",
+        mimeType: "text/markdown",
+      },
+      async (uri: URL) => ({
+        contents: [
+          {
+            uri: uri.href,
+            text: "# Test Text",
+            mimeType: "text/markdown",
+          },
+        ],
+      }),
+    ];
+
+    const [name, config, handler] = resourceToTool(testResource);
+
+    expect(name).toBe("test-title");
+    expect(config).toMatchObject({
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        readOnlyHint: true,
+      },
+      description: "Test Description",
+      title: "Test Title",
+    });
+    expect(config.inputSchema).toBeUndefined();
+    await expect(
+      handler({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Simplify testing
+      } as any),
+    ).resolves.toMatchObject({
+      content: [
+        {
+          resource: {
+            mimeType: "text/markdown",
+            text: "# Test Text",
+            uri: "test://sit-onyx/static",
           },
           type: "resource",
         },

--- a/packages/modelcontextprotocol/src/util/mcp-server.ts
+++ b/packages/modelcontextprotocol/src/util/mcp-server.ts
@@ -7,10 +7,10 @@ export const resourceToTool = <
   OutputArgs extends ZodRawShapeCompat | AnySchema,
   InputArgs extends undefined | ZodRawShapeCompat | AnySchema = undefined,
 >(
-  resource: RegisterableResource,
+  resource: RegisterableResource<boolean>,
 ): RegisterableTool<OutputArgs, InputArgs> => {
   const [name, template, { title, description }, cb] = resource;
-  const hasInputSchema = !!template.uriTemplate.variableNames.length;
+  const hasInputSchema = typeof template === "object" && template.uriTemplate.variableNames.length;
 
   const inputSchema = hasInputSchema
     ? (Object.fromEntries(
@@ -33,7 +33,11 @@ export const resourceToTool = <
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- The amount of parameters varies based on the `inputSchema`
     (async (...args: any[]) => {
       const [vars, extra] = hasInputSchema ? args : [{}, args.at(0)];
-      const { contents } = await cb(new URL(template.uriTemplate.expand(vars)), vars, extra);
+      const { contents } = await cb(
+        new URL(hasInputSchema ? template.uriTemplate.expand(vars) : template),
+        vars,
+        extra,
+      );
       return {
         content: contents.map((resource) => ({
           type: "resource",

--- a/packages/modelcontextprotocol/src/util/onyx-css-design-tokens.ts
+++ b/packages/modelcontextprotocol/src/util/onyx-css-design-tokens.ts
@@ -1,0 +1,29 @@
+import { CssTypes, parse } from "@adobe/css-tools";
+import {
+  SIT_ONYX_DESIGN_TOKENS_FILE,
+  SIT_ONYX_DESIGN_TOKENS_SPACINGS_FILE,
+  USER_AGENT,
+} from "../config.js";
+import { cached } from "./cached.js";
+import { getFilesFromPackage } from "./package.js";
+
+export const retrieveOnyxDesignTokens = cached(async (versionOrTag: string) => {
+  const files = await getFilesFromPackage(
+    { name: "sit-onyx", versionOrTag },
+    [
+      (header) => header.name === SIT_ONYX_DESIGN_TOKENS_FILE,
+      (header) => header.name === SIT_ONYX_DESIGN_TOKENS_SPACINGS_FILE,
+    ],
+    USER_AGENT,
+  );
+
+  return files.flatMap(({ data }) => {
+    const css = data.toString();
+    return parse(css)
+      .stylesheet.rules.filter((e) => e.type === CssTypes.rule)
+      .flatMap((r) => r.declarations)
+      .map((d) => (d.type === CssTypes.declaration ? d.property : undefined))
+      .filter((p) => p !== undefined)
+      .filter((p) => p.startsWith("--"));
+  });
+});

--- a/packages/modelcontextprotocol/src/util/onyx-css-design-tokens.ts
+++ b/packages/modelcontextprotocol/src/util/onyx-css-design-tokens.ts
@@ -10,10 +10,7 @@ import { getFilesFromPackage } from "./package.js";
 export const retrieveOnyxDesignTokens = cached(async (versionOrTag: string) => {
   const files = await getFilesFromPackage(
     { name: "sit-onyx", versionOrTag },
-    [
-      (header) => header.name === SIT_ONYX_DESIGN_TOKENS_FILE,
-      (header) => header.name === SIT_ONYX_DESIGN_TOKENS_SPACINGS_FILE,
-    ],
+    [SIT_ONYX_DESIGN_TOKENS_FILE, SIT_ONYX_DESIGN_TOKENS_SPACINGS_FILE],
     USER_AGENT,
   );
 

--- a/packages/modelcontextprotocol/src/util/package.ts
+++ b/packages/modelcontextprotocol/src/util/package.ts
@@ -7,8 +7,12 @@ import { getPackageManifest } from "query-registry";
 import tarStream, { type Headers } from "tar-stream";
 
 class SuccessfulAbort {
-  constructor(public readonly data: Buffer) {}
+  constructor() {}
 }
+
+type Matcher = (headers: Headers) => boolean;
+
+type Result = { headers: Headers; data: Buffer };
 
 type PackageIdentifier = {
   name: string;
@@ -17,9 +21,9 @@ type PackageIdentifier = {
 };
 
 // TODO: It's quite fast, but we should add caching nevertheless.
-export async function getSingleFileFromPackage(
+export async function getFilesFromPackage(
   packageIdent: PackageIdentifier,
-  matcher: (headers: Headers) => boolean,
+  matchers: Matcher[],
   userAgent: string,
 ) {
   const { dist } = await getPackageManifest(
@@ -37,13 +41,17 @@ export async function getSingleFileFromPackage(
    * We also use the abort reason to emit the result.
    */
   const abortController = new AbortController();
+  const results: Result[] = [];
 
   const archiveDownload = Readable.fromWeb(body as ReadableStream<Uint8Array>); // Incorrect typing, see: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65542#discussioncomment-6071004
   const decompress = createGunzip();
-  const fileSearcher = createTarFileSearcher(matcher, abortController);
+  const fileSearcher = createTarFileSearcher(matchers, results, abortController);
 
   try {
     await pipeline(archiveDownload, decompress, fileSearcher, { signal: abortController.signal });
+    if (results.length) {
+      return results;
+    }
     throw new Error("No matching file found!");
   } catch (error: unknown) {
     if (
@@ -51,8 +59,7 @@ export async function getSingleFileFromPackage(
       error.name === "AbortError" &&
       error.cause instanceof SuccessfulAbort
     ) {
-      // Return the found data as parsed JSON
-      return error.cause.data;
+      return results;
     }
     // Re-throw any other error
     throw error;
@@ -64,16 +71,20 @@ export async function getSingleFileFromPackage(
  * If found, will call the AbortController with the file content as reason.
  */
 function createTarFileSearcher(
-  matcher: (headers: Headers) => boolean,
+  matchers: Matcher[],
+  results: Result[],
   abortController: AbortController,
 ): Writable {
   const searchFile = tarStream.extract();
 
   searchFile.on("entry", async (headers, stream, next) => {
-    if (matcher(headers)) {
+    if (matchers.some((m) => m(headers))) {
       const data = await buffer(stream);
-      // found the relevant file, stop further processing
-      abortController.abort(new SuccessfulAbort(data));
+      results.push({ headers, data });
+    }
+    if (results.length === matchers.length) {
+      // found the relevant files, stop further processing
+      abortController.abort(new SuccessfulAbort());
     } else {
       // continue searching
       stream.resume();

--- a/packages/modelcontextprotocol/src/util/package.ts
+++ b/packages/modelcontextprotocol/src/util/package.ts
@@ -10,8 +10,6 @@ class SuccessfulAbort {
   constructor() {}
 }
 
-type Matcher = (headers: Headers) => boolean;
-
 type Result = { headers: Headers; data: Buffer };
 
 type PackageIdentifier = {
@@ -23,7 +21,7 @@ type PackageIdentifier = {
 // TODO: It's quite fast, but we should add caching nevertheless.
 export async function getFilesFromPackage(
   packageIdent: PackageIdentifier,
-  matchers: Matcher[],
+  filenames: string[],
   userAgent: string,
 ) {
   const { dist } = await getPackageManifest(
@@ -31,7 +29,9 @@ export async function getFilesFromPackage(
     packageIdent.versionOrTag,
     packageIdent.registry,
   );
-  const { body } = await fetch(dist.tarball, { headers: { "User-Agent": userAgent } });
+  const { body } = await fetch(dist.tarball, {
+    headers: { "User-Agent": userAgent },
+  });
   if (!body) {
     throw new Error(`No body in response for tarball request to "${dist.tarball}"!`);
   }
@@ -45,10 +45,12 @@ export async function getFilesFromPackage(
 
   const archiveDownload = Readable.fromWeb(body as ReadableStream<Uint8Array>); // Incorrect typing, see: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65542#discussioncomment-6071004
   const decompress = createGunzip();
-  const fileSearcher = createTarFileSearcher(matchers, results, abortController);
+  const fileSearcher = createTarFileSearcher(filenames, results, abortController);
 
   try {
-    await pipeline(archiveDownload, decompress, fileSearcher, { signal: abortController.signal });
+    await pipeline(archiveDownload, decompress, fileSearcher, {
+      signal: abortController.signal,
+    });
     if (results.length) {
       return results;
     }
@@ -71,18 +73,18 @@ export async function getFilesFromPackage(
  * If found, will call the AbortController with the file content as reason.
  */
 function createTarFileSearcher(
-  matchers: Matcher[],
+  filenames: string[],
   results: Result[],
   abortController: AbortController,
 ): Writable {
   const searchFile = tarStream.extract();
 
   searchFile.on("entry", async (headers, stream, next) => {
-    if (matchers.some((m) => m(headers))) {
+    if (filenames.includes(headers.name)) {
       const data = await buffer(stream);
       results.push({ headers, data });
     }
-    if (results.length === matchers.length) {
+    if (results.length === filenames.length) {
       // found the relevant files, stop further processing
       abortController.abort(new SuccessfulAbort());
     } else {

--- a/packages/modelcontextprotocol/src/util/types.ts
+++ b/packages/modelcontextprotocol/src/util/types.ts
@@ -1,0 +1,49 @@
+// Source - https://stackoverflow.com/a/79299137
+// Posted by David Archibald
+// Retrieved 2026-06-26, License - CC BY-SA 4.0
+
+interface FunctionSignature {
+  parameters: AnyArray;
+  returnType: unknown;
+}
+
+// May look like a no-op but in actuality strips out everything except properties.
+// This means it removes function signatures, constructor signatures, etc.
+type ToObject<T extends object> = {
+  [K in keyof T]: T[K];
+};
+
+// @ts-expect-error - This is a core type that unfortunately intrinsically has an error.
+// The issue with a type like this is in theory they could overlap and the resulting type
+// could become something like `never` or something ill-behaved.
+// Fortunately this is used to add an overload which can never really conflict
+// and so is pretty safe.
+interface AddSignature<T extends object, Params extends AnyArray, Return> extends T {
+  //    ^ Interface 'AddSignature<T, Params, Return>' incorrectly extends interface 'T'.
+  //        'AddSignature<T, Params, Return>' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'object'.
+  // The above is the suppressed error
+
+  (...args: Params): Return;
+}
+
+export type GetFunctionOverloads<
+  T extends AnyFunction,
+  Shape extends object = ToObject<T>,
+  Signatures extends FunctionSignature[] = [],
+> = Shape extends T
+  ? Signatures
+  : T extends AddSignature<Shape, infer Params, infer Return>
+    ? GetFunctionOverloads<
+        T,
+        AddSignature<Shape, Params, Return>,
+        // This would be the second.
+        [{ parameters: Params; returnType: Return }, ...Signatures]
+      >
+    : Signatures;
+
+// This type is written this way intentionally.
+// It does truly allow any function to be assigned to it.
+// However `...args: any[]` can be very type unsafe, this is much safer.
+type AnyFunction = (arg0: never, ...args: never[]) => unknown;
+
+type AnyArray = readonly unknown[];

--- a/packages/modelcontextprotocol/tsconfig.json
+++ b/packages/modelcontextprotocol/tsconfig.json
@@ -5,5 +5,5 @@
     "resolveJsonModule": true,
     "module": "node20"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "env.d.ts"]
 }

--- a/packages/modelcontextprotocol/vite.config.ts
+++ b/packages/modelcontextprotocol/vite.config.ts
@@ -3,12 +3,12 @@ import { DiagnosticCategory } from "typescript";
 import dts from "unplugin-dts/vite";
 import { defineConfig } from "vite";
 import { dependencies } from "./package.json" with { type: "json" };
+import { skillMdPlugin } from "./skill-md.vite.js";
 
 export default defineConfig({
   plugins: [
+    skillMdPlugin(),
     dts({
-      processor: "vue",
-      rollupTypes: true,
       afterDiagnostic: async (diagnostics) => {
         if (diagnostics.some((d) => d.category === DiagnosticCategory.Error)) {
           throw new Error("Build aborted due to TypeScript errors in the library!");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,19 @@ settings:
 
 catalogs:
   default:
+    '@types/node':
+      specifier: 24.13.2
+      version: 24.13.2
+    chart.js:
+      specifier: 4.5.1
+      version: 4.5.1
+    unplugin-dts:
+      specifier: 1.0.2
+      version: 1.0.2
     vue-component-meta:
+      specifier: 3.3.5
+      version: 3.3.5
+    vue-tsc:
       specifier: 3.3.5
       version: 3.3.5
 
@@ -592,21 +604,42 @@ importers:
       '@sit-onyx/shared':
         specifier: workspace:^
         version: link:../shared
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
       '@types/tar-stream':
         specifier: ^3.1.4
         version: 3.1.4
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
       query-registry:
         specifier: ^4.3.0
         version: 4.3.0(zod@4.4.3)
+      remark:
+        specifier: ^15.0.1
+        version: 15.0.1
+      remark-frontmatter:
+        specifier: ^5.0.0
+        version: 5.0.0
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-stringify:
+        specifier: ^11.0.0
+        version: 11.0.0
       tar-stream:
         specifier: ^3.2.0
         version: 3.2.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       unplugin-dts:
         specifier: 'catalog:'
         version: 1.0.2(esbuild@0.28.1)(rolldown@1.1.1)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -616,6 +649,9 @@ importers:
       vue-component-meta:
         specifier: 'catalog:'
         version: 3.3.5(typescript@6.0.3)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -6270,6 +6306,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -6352,6 +6391,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -7245,6 +7288,9 @@ packages:
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
@@ -7305,6 +7351,9 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -8588,6 +8637,9 @@ packages:
     resolution: {integrity: sha512-IyIqGELcyK5AVdLFafoiNww+Eaw/F+rGrNSXoKucjo95uL267zrddgxGM83GN1wFIb68pyDuAsY3m5t2Cav1pQ==}
     engines: {node: '>=18'}
 
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -8602,6 +8654,9 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remark@15.0.1:
+    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -15535,6 +15590,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -15625,6 +15684,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  format@0.2.2: {}
 
   forwarded@0.2.0: {}
 
@@ -16623,6 +16684,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-autolink-literal@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -16747,6 +16819,13 @@ snapshots:
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
@@ -18577,6 +18656,15 @@ snapshots:
       node-emoji: 2.2.0
       unified: 11.0.5
 
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -18633,6 +18721,15 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  remark@15.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   require-directory@2.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,19 +6,7 @@ settings:
 
 catalogs:
   default:
-    '@types/node':
-      specifier: 24.13.2
-      version: 24.13.2
-    chart.js:
-      specifier: 4.5.1
-      version: 4.5.1
-    unplugin-dts:
-      specifier: 1.0.2
-      version: 1.0.2
     vue-component-meta:
-      specifier: 3.3.5
-      version: 3.3.5
-    vue-tsc:
       specifier: 3.3.5
       version: 3.3.5
 
@@ -598,6 +586,9 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
     devDependencies:
+      '@adobe/css-tools':
+        specifier: ^4.5.0
+        version: 4.5.0
       '@sit-onyx/shared':
         specifier: workspace:^
         version: link:../shared


### PR DESCRIPTION
Relates to #5569 

- Implement vite plugin for reading and parsing `SKILL.md` files and their `yaml` frontmatter at build time.
  - This avoids the need for parsing the markdown at run-time and thus the user doesn't need to install any additional dependencies
- Implement `--write-skills` flag for writing `SKILL.md` files to the users system.
- Implement `list-css-design-tokens` resource for listing relevant CSS custom properties
  - Will use `onyx.css` and `spacing.css`
  - Updated ´getFilesFromPackage´ function to be able to find multiple files
- Added some basic, AI-generated skills
  - Will be improved, so don't pay too much attention to their content for now