### PR TITLE
fix(OnyxDataGrid): Fix column groups breaking lazy loading

### DIFF
--- a/.changeset/dull-oranges-enjoy.md
+++ b/.changeset/dull-oranges-enjoy.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(DataGridFeatures.usePagination): Fix Lazy Loading not working in combination with ColumnGrouping

--- a/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGridRenderer/OnyxDataGridRenderer.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGridRenderer/OnyxDataGridRenderer.vue
@@ -89,6 +89,12 @@ const columnStyle = computed(() => {
         grid-column: 1 / -1;
         grid-row: 1 / -1;
 
+        > colgroup {
+          // Prevents the "colgroup" element from participating in the CSS grid.
+          // This fixes the issue https://github.com/SchwarzIT/onyx/issues/5612
+          position: fixed;
+        }
+
         > thead {
           display: grid;
           grid-template-columns: subgrid;

--- a/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGridRenderer/OnyxDataGridRenderer.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/OnyxDataGridRenderer/OnyxDataGridRenderer.vue
@@ -92,7 +92,21 @@ const columnStyle = computed(() => {
         > colgroup {
           // Prevents the "colgroup" element from participating in the CSS grid.
           // This fixes the issue https://github.com/SchwarzIT/onyx/issues/5612
-          position: fixed;
+          display: grid;
+          grid-template-columns: subgrid;
+          grid-template-rows: subgrid;
+          grid-column: 1 / -1;
+          grid-row: 1 / -1;
+
+          > col {
+            grid-row: 1 / -1;
+          }
+
+          @for $i from 1 through 99 {
+            > col[span="#{$i}"] {
+              grid-column: span $i;
+            }
+          }
         }
 
         > thead {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/pagination/TestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/pagination/TestCase.ct.vue
@@ -7,7 +7,7 @@ import type { PaginationOptions } from "./types.js";
 
 const props = defineProps<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
-  Pick<OnyxDataGridProps<TEntry, any, any, any, any, any>, "data" | "skeleton"> & {
+  Pick<OnyxDataGridProps<TEntry, any, any, any, any, any>, "data" | "skeleton" | "columnGroups"> & {
     paginationOptions?: PaginationOptions;
     enabledFeatures?: ("filtering" | "selection")[];
   }
@@ -26,5 +26,5 @@ const features = computed(() => [
 </script>
 
 <template>
-  <OnyxDataGrid v-bind="props" :columns="['a']" :features />
+  <OnyxDataGrid v-bind="props" :columns="[{ key: 'a', columnGroupKey: 'group-1' }]" :features />
 </template>

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/pagination/TestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/pagination/TestCase.ct.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts" generic="TEntry extends DataGridEntry">
 import { computed } from "vue";
-import type { DataGridEntry, OnyxDataGridProps } from "../../../../index.js";
+import type { ColumnConfig, DataGridEntry, OnyxDataGridProps } from "../../../../index.js";
 import { DataGridFeatures, OnyxDataGrid } from "../../../../index.js";
 import { useFiltering, useSelection } from "../all.js";
 import type { PaginationOptions } from "./types.js";
 
 const props = defineProps<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
-  Pick<OnyxDataGridProps<TEntry, any, any, any, any, any>, "data" | "skeleton" | "columnGroups"> & {
+  Pick<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
+    OnyxDataGridProps<TEntry, any, any, any, any, any>,
+    "data" | "skeleton" | "columnGroups"
+  > & {
     paginationOptions?: PaginationOptions;
     enabledFeatures?: ("filtering" | "selection")[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- for simplicity we use any here
+    columns?: ColumnConfig<any, any, any>[];
   }
 >();
 
@@ -26,5 +31,5 @@ const features = computed(() => [
 </script>
 
 <template>
-  <OnyxDataGrid v-bind="props" :columns="[{ key: 'a', columnGroupKey: 'group-1' }]" :features />
+  <OnyxDataGrid v-bind="props" :columns="props.columns || ['a']" :features />
 </template>

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/pagination/pagination.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/pagination/pagination.ct.tsx
@@ -9,7 +9,7 @@ const getTestData = (length: number) =>
   Array.from({ length }, (_, index) => ({ id: index + 1, a: `A ${index + 1}` }));
 
 const expectRowCount = async (dataGrid: Locator, count: number, message?: string) => {
-  await expect(dataGrid.getByRole("row"), message).toHaveCount(count + 1); // +1 = header row
+  await expect(dataGrid.locator("tbody").getByRole("row"), message).toHaveCount(count);
 };
 
 test("should paginate rows", async ({ mount, page }) => {
@@ -272,6 +272,10 @@ test("should handle lazy loading", async ({ mount }) => {
       paginationOptions: {
         type: "lazy",
       },
+      columnGroups: {
+        // We include a column group here to test for a regression of https://github.com/SchwarzIT/onyx/issues/5612
+        group1: { label: "Group 1" },
+      },
     },
   });
 
@@ -279,25 +283,25 @@ test("should handle lazy loading", async ({ mount }) => {
   await expectRowCount(component, 25);
 
   // ACT
-  await scrollToRow(component, 24);
+  await scrollToRow(component, -1);
 
   // ASSERT
   await expectRowCount(component, 25, "scrolling to 2nth last row should not trigger lazy loading");
 
   // ACT
-  await scrollToRow(component, 25);
+  await scrollToRow(component, -1);
 
   // ASSERT
   await expectRowCount(component, 50, "scrolling to last row should trigger lazy loading");
 
   // ACT
-  await scrollToRow(component, 50);
+  await scrollToRow(component, -1);
 
   // ASSERT
   await expectRowCount(component, 52, "scrolling to last row should trigger lazy loading");
 
   // ACT
-  await scrollToRow(component, 52);
+  await scrollToRow(component, -1);
 
   // ASSERT
   await expectRowCount(component, 52, "should disable lazy loading when last page is reached");

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/pagination/pagination.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/pagination/pagination.ct.tsx
@@ -272,6 +272,7 @@ test("should handle lazy loading", async ({ mount }) => {
       paginationOptions: {
         type: "lazy",
       },
+      columns: [{ key: "a", columnGroupKey: "group-1" }],
       columnGroups: {
         // We include a column group here to test for a regression of https://github.com/SchwarzIT/onyx/issues/5612
         group1: { label: "Group 1" },

--- a/packages/sit-onyx/src/components/OnyxTable/OnyxTable.vue
+++ b/packages/sit-onyx/src/components/OnyxTable/OnyxTable.vue
@@ -73,11 +73,9 @@ const headlineId = computed(() => (slots.headline ? _headlineId : undefined));
         ]"
         :aria-labelledby="headlineId"
       >
-        <colgroup
-          v-for="group of props.columnGroups"
-          :key="group.key"
-          :span="group.span"
-        ></colgroup>
+        <colgroup>
+          <col v-for="group of props.columnGroups" :key="group.key" :span="group.span" />
+        </colgroup>
 
         <thead v-if="slots.head" class="onyx-table__header">
           <tr v-if="props.columnGroups?.length">

--- a/packages/sit-onyx/src/styles/z-indices.scss
+++ b/packages/sit-onyx/src/styles/z-indices.scss
@@ -1,15 +1,17 @@
-// all z-indices that are needed in the onyx design system
-:root {
-  // used for full app overlays, e.g. modals/pop-ups
-  --onyx-z-index-app-overlay: 60;
-  // used for the nav-bar of the application
-  --onyx-z-index-navigation: 50;
-  // used for overlays that cover the page (everything except the nav-bar)
-  --onyx-z-index-page-overlay: 40;
-  // used e.g. for toasts, floating buttons or messages from a notification-center
-  --onyx-z-index-notification: 30;
-  // used for sticky contents that dock on to the page, e.g. a breadcrumb bar, table header or headlines
-  --onyx-z-index-sticky-content: 20;
-  // used for tooltips and fly-outs of a nav menu or a combo-box
-  --onyx-z-index-flyout: 10;
+@layer onyx.utility {
+  // all z-indices that are needed in the onyx design system
+  :root {
+    // used for full app overlays, e.g. modals/pop-ups
+    --onyx-z-index-app-overlay: 60;
+    // used for the nav-bar of the application
+    --onyx-z-index-navigation: 50;
+    // used for overlays that cover the page (everything except the nav-bar)
+    --onyx-z-index-page-overlay: 40;
+    // used e.g. for toasts, floating buttons or messages from a notification-center
+    --onyx-z-index-notification: 30;
+    // used for sticky contents that dock on to the page, e.g. a breadcrumb bar, table header or headlines
+    --onyx-z-index-sticky-content: 20;
+    // used for tooltips and fly-outs of a nav menu or a combo-box
+    --onyx-z-index-flyout: 10;
+  }
 }

--- a/packages/sit-onyx/vite.config.prod.ts
+++ b/packages/sit-onyx/vite.config.prod.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     bundlerConfig,
     {
       build: {
+        cssMinify: true,
         sourcemap: false,
         lib: {
           fileName: "index",

--- a/packages/sit-onyx/vite.config.prod.ts
+++ b/packages/sit-onyx/vite.config.prod.ts
@@ -13,7 +13,6 @@ export default defineConfig({
     bundlerConfig,
     {
       build: {
-        cssMinify: true,
         sourcemap: false,
         lib: {
           fileName: "index",


### PR DESCRIPTION
Closes #5612 

*Cause:* The `colgroup` element is not explicitly into the grid and was therefor placed into the last cell. The scroll position was anchored to that element. This caused the scroll position always to be at the end, even when new rows were added. 

*Fix:* In a regular table the [`colgroup`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/colgroup) is a special element that can be used to group columns. To emulate this behavior in our `display: grid;` we use the fact, that the colgroup can also specify the groupings via [`col`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/col) elements. This way we can define the `colgroup` as a subgrid spanning the whole grid and the `col` elements spanning the relevant columns. 

Also:
- Enabled `css` minification for prod build
- Added missing `onyx.utility` layer for z-index specifications