### PR TITLE
fix(form-elements): prevent virtual keyboards when opening popover

### DIFF
--- a/.changeset/cool-ideas-yell.md
+++ b/.changeset/cool-ideas-yell.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(form-elements): prevent virtual keyboards when opening popover

--- a/packages/sit-onyx/src/components/OnyxFormElementV2/OnyxFormElementV2.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxFormElementV2/OnyxFormElementV2.ct.tsx
@@ -484,3 +484,21 @@ test("should correctly reserve message space", async ({ mount }) => {
   height = await bottom.evaluate((element) => element.clientHeight);
   expect(height).toBeGreaterThan(0);
 });
+
+test("should define inputmode if popover exists", async ({ mount }) => {
+  // ARRANGE
+  let component = await mount(
+    <TestCase label="Test label" popoverOptions={{ label: "Flyout label" }}>
+      <template v-slot:popover>Test</template>
+    </TestCase>,
+  );
+
+  // ASSERT
+  await expect(component.getByLabel("Test label")).toHaveAttribute("inputmode", "none");
+
+  // ACT
+  component = await mount(<TestCase label="Test label" />);
+
+  // ASSERT
+  await expect(component.getByLabel("Test label")).not.toHaveAttribute("inputmode");
+});

--- a/packages/sit-onyx/src/components/OnyxFormElementV2/OnyxFormElementV2.vue
+++ b/packages/sit-onyx/src/components/OnyxFormElementV2/OnyxFormElementV2.vue
@@ -7,7 +7,7 @@ export default {};
 </script>
 
 <script lang="ts" setup>
-import { computed, useId } from "vue";
+import { computed, useId, type HTMLAttributes } from "vue";
 import { useDensity } from "../../composables/density.js";
 import { useErrorClass } from "../../composables/useErrorClass.js";
 import {
@@ -69,7 +69,7 @@ const label = computed<FormElementV2LabelOptions>(() => {
   return { label: props.label };
 });
 
-const inputProps = computed(() => {
+const inputProps = computed<HTMLAttributes>(() => {
   return {
     id: props.id,
     class: ["onyx-form-element-v2__input", "onyx-truncation-ellipsis"],
@@ -81,6 +81,10 @@ const inputProps = computed(() => {
           "aria-label": label.value.label,
         }
       : {}),
+    // prevent showing virtual keyboards on e.g. smartphones
+    // since the input is not editable if a popover exists
+    // see: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode
+    ...(slots.popover ? { inputmode: "none" } : {}),
   };
 });
 


### PR DESCRIPTION
Currently when opening form elements that have a popover such as the date picker v2 or select on e.g. mobile devices, the virtual keyboard is opened by the browser which is not intended.

This PR fixes this by adding `inputmode="none"` in this case: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode.

Thanks to @LybraJS for reporting this bug 🙏 

## Checklist

- [x] The added / edited code has been documented with [JSDoc](https://jsdoc.app/about-getting-started)
- [x] If a new component is added, at least one [Playwright screenshot test](https://github.com/SchwarzIT/onyx/actions/workflows/playwright-screenshots.yml) or functional test is added
- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
