### PR TITLE
fix(OnyxTab): Fix incorrect font-family usage

### DIFF
--- a/.changeset/happy-tables-occur.md
+++ b/.changeset/happy-tables-occur.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxTab): Fix incorrect font-family

--- a/packages/sit-onyx/src/components/OnyxTab/OnyxTab.vue
+++ b/packages/sit-onyx/src/components/OnyxTab/OnyxTab.vue
@@ -106,7 +106,6 @@ const tab = computed(() =>
     --onyx-tab-color-active: var(--onyx-color-text-icons-primary-bold);
     --onyx-tab-color-disabled: var(--onyx-color-text-icons-neutral-soft);
 
-    font-family: var(--onyx-font-family-paragraph);
     color: var(--onyx-tab-color);
     border-radius: var(--onyx-radius-sm);
     padding: var(--onyx-tab-padding-vertical) var(--onyx-density-md);


### PR DESCRIPTION
The font-family for the OnyxTabs was incorrect.
We can just remove the definition, as It's already defined via the headline style.