### PR TITLE
fix(OnyxSearch): inherit skeleton from parent by default

### DIFF
--- a/.changeset/gentle-dodos-beg.md
+++ b/.changeset/gentle-dodos-beg.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxSearch): inherit skeleton from parent by default

--- a/packages/sit-onyx/src/components/OnyxSearch/OnyxSearch.vue
+++ b/packages/sit-onyx/src/components/OnyxSearch/OnyxSearch.vue
@@ -1,7 +1,16 @@
+<script lang="ts">
+/**
+ * @experimental
+ * @deprecated This component is still under active development and its API might change in patch releases.
+ */
+export default {};
+</script>
+
 <script lang="ts" setup>
 import { iconFilter, iconSearch } from "@sit-onyx/icons";
 import { computed, useTemplateRef } from "vue";
 import { _unstableUseShortcut } from "../../composables/useShortcut.js";
+import { SKELETON_INJECTED_SYMBOL } from "../../composables/useSkeletonState.js";
 import { useVModel } from "../../composables/useVModel.js";
 import { injectI18n } from "../../i18n/index.js";
 import { useForwardProps } from "../../utils/props.js";
@@ -20,6 +29,7 @@ const props = withDefaults(defineProps<OnyxSearchProps>(), {
   showFilters: undefined,
   modelValue: undefined,
   filterPosition: "bottom",
+  skeleton: SKELETON_INJECTED_SYMBOL,
 });
 
 const emit = defineEmits<{


### PR DESCRIPTION
Fix OnyxSearch to inherit skeleton from parent by default + add missing experimental component info

## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
