### PR TITLE
chore: set up publishing for the @sit-onyx/assets package

### DIFF
--- a/.changeset/humble-bobcats-marry.md
+++ b/.changeset/humble-bobcats-marry.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/assets": minor
+---
+
+feat: initial publish of onyx-brand assets

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@sit-onyx/assets",
   "version": "0.0.0",
-  "private": true,
-  "description": "onyx brand assets",
+  "private": false,
+  "description": "Assets for the onyx brand and related to the sit-onyx package",
   "homepage": "https://onyx.schwarz",
   "license": "Apache-2.0",
   "author": "Schwarz Digits IT KG",
@@ -11,6 +11,9 @@
     "url": "https://github.com/SchwarzIT/onyx",
     "directory": "packages/assets"
   },
+  "files": [
+    "src/"
+  ],
   "type": "module",
   "exports": {
     "./*": "./src/*"


### PR DESCRIPTION
Relates to #5575

- Add initial changeset for `@sit-onyx/assets`
- oidc integration has been set-up
- update description