### PR TITLE
docs(showcase): increase max. memory

### DIFF
--- a/apps/showcase/.cloud-foundry/manifest-dev.yml
+++ b/apps/showcase/.cloud-foundry/manifest-dev.yml
@@ -2,7 +2,7 @@
 ---
 applications:
   - name: onyx-showcase-dev
-    memory: 96M
+    memory: 256M
     buildpacks:
       - https://github.com/cloudfoundry/nodejs-buildpack
     command: node dist/server/index.mjs


### PR DESCRIPTION
Currently, the showcase sometimes crashes due to an out of memory error.