### PR TITLE
fix(nuxt-docs): correctly include module to register prose components

### DIFF
--- a/.changeset/stale-windows-talk.md
+++ b/.changeset/stale-windows-talk.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt-docs": patch
+---
+
+fix(nuxt-docs): correctly include module to register prose components

--- a/apps/docs/src/development/packages/nuxt-docs.md
+++ b/apps/docs/src/development/packages/nuxt-docs.md
@@ -54,9 +54,9 @@ When using another package manager, you can skip this step.
 ::: code-group
 
 ```yml [pnpm-workspace.yaml]
-# needed to correctly install the Nuxt content and Nuxt image module
-onlyBuiltDependencies:
-  - better-sqlite3
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true
 ```
 
 :::

--- a/packages/nuxt-docs/package.json
+++ b/packages/nuxt-docs/package.json
@@ -15,7 +15,8 @@
   "files": [
     "app",
     "content.config.ts",
-    "nuxt.config.ts"
+    "nuxt.config.ts",
+    "modules"
   ],
   "type": "module",
   "main": "./nuxt.config.ts",


### PR DESCRIPTION
The Nuxt documentation template does currently not define any prose components because the module that does it is not published during the release.