### PR TITLE
fix(demo-app): preserve theme query on navigation

### DIFF
--- a/apps/demo-app/app/middleware/preserve-theme.global.ts
+++ b/apps/demo-app/app/middleware/preserve-theme.global.ts
@@ -1,0 +1,14 @@
+export default defineNuxtRouteMiddleware((to, from) => {
+  const theme = from.query.theme;
+
+  if (theme == null || "theme" in to.query) return;
+
+  return navigateTo(
+    {
+      path: to.path,
+      query: { ...to.query, theme },
+      hash: to.hash,
+    },
+    { replace: true },
+  );
+});


### PR DESCRIPTION
## Description

Adds a global Demo App route middleware that carries the current `theme` query value to the next route. It preserves the target route's existing query and hash, and it does not overwrite a theme explicitly set by the target navigation.

Closes #5573

## Checklist

- [x] Targeted formatting and ESLint checks pass
- [x] Verified theme inheritance, explicit target themes, and navigation without a source theme using a mocked Nuxt middleware runtime
- [x] No changeset needed because this only changes the private Demo App

## Validation

- `pnpm exec oxfmt --check apps/demo-app/app/middleware/preserve-theme.global.ts`
- `pnpm exec eslint apps/demo-app/app/middleware/preserve-theme.global.ts`
- `git diff --check`
- 3 focused middleware behavior cases passed

The full Demo App dependency build is blocked locally on Windows by the existing `@sit-onyx/vite-plugin-svg` build script invoking the POSIX-only `cp` command.
