### PR TITLE
docs: update notification center example

### DIFF
--- a/apps/showcase/app/components/content/ComponentExample.vue
+++ b/apps/showcase/app/components/content/ComponentExample.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { iconUndo } from "@sit-onyx/icons";
+import { createNotificationsProvider, NOTIFICATIONS_PROVIDER_INJECTION_KEY } from "sit-onyx";
 import type { Component } from "vue";
 import type { ComponentExampleOptions } from "../ComponentExampleOptions.vue";
 
@@ -20,6 +21,10 @@ const props = withDefaults(
      * The orientation of the example if multiple components are used.
      */
     orientation?: "horizontal" | "vertical";
+    /**
+     * Whether to override specific onyx provide/inject keys.
+     */
+    provide?: { notifications?: boolean };
   }>(),
   {
     layout: "default",
@@ -88,6 +93,11 @@ const options = ref<ComponentExampleOptions>({});
 
 defineOptions({ inheritAttrs: false });
 const attrs = useAttrs();
+
+if (props.provide?.notifications) {
+  const provider = createNotificationsProvider();
+  provide(NOTIFICATIONS_PROVIDER_INJECTION_KEY, provider);
+}
 </script>
 
 <template>
@@ -185,6 +195,7 @@ const attrs = useAttrs();
     .onyx-app {
       width: 100%;
       height: 100%;
+      min-height: 32rem;
       background-color: var(--onyx-color-base-background-tinted);
       border: var(--onyx-1px-in-rem) solid var(--onyx-color-component-border-neutral);
       border-radius: var(--onyx-radius-md);

--- a/apps/showcase/app/components/content/ComponentExample.vue
+++ b/apps/showcase/app/components/content/ComponentExample.vue
@@ -23,6 +23,7 @@ const props = withDefaults(
     orientation?: "horizontal" | "vertical";
     /**
      * Whether to override specific onyx provide/inject keys.
+     * Useful if e.g. notifications should not be shown globally inside the showcase itself.
      */
     provide?: { notifications?: boolean };
   }>(),

--- a/apps/showcase/content/en/components/07.notifications/01.notification-center/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/07.notifications/01.notification-center/examples/Basic.example.vue
@@ -2,6 +2,7 @@
 import logoUrl from "@sit-onyx/assets/onyx-brand/signet.svg";
 import {
   iconBell,
+  iconBellRing,
   iconCheckRead,
   iconCircleAttention,
   iconInbox,
@@ -154,7 +155,7 @@ const addExampleNotification = () => {
         the top of the page to open the notification center.
       </p>
 
-      <OnyxButton label="Add example notification" @click="addExampleNotification" />
+      <OnyxButton label="Show notification" :icon="iconBellRing" @click="addExampleNotification" />
     </div>
 
     <!-- NOTIFICATION CENTER -->

--- a/apps/showcase/content/en/components/07.notifications/01.notification-center/index.md
+++ b/apps/showcase/content/en/components/07.notifications/01.notification-center/index.md
@@ -12,4 +12,11 @@ Since a notification center is very specific to an application, we only provide 
 
 To show a new temporary notification, use the [useNotifications()](/components/notifications/notifications) composable.
 
-:component-example{name="Basic" layout="fullWidth"}
+::component-example
+---
+name: Basic
+layout: fullWidth
+provide:
+    notifications: true
+---
+::


### PR DESCRIPTION
Relates to #5499

Implement UX feedback for notification center example:
- show notifications only once
- increase example height
- update button label + icon