### PR TITLE
fix(OnyxTooltip): Fix invisible box of tooltip wedge blocking mouse events like clicks and hover effects

### DIFF
--- a/.changeset/early-seals-trade.md
+++ b/.changeset/early-seals-trade.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxTooltip): Fix invisible box of tooltip wedge blocking mouse events like clicks and hover effects

--- a/packages/sit-onyx/src/components/OnyxTooltip/OnyxTooltip.vue
+++ b/packages/sit-onyx/src/components/OnyxTooltip/OnyxTooltip.vue
@@ -368,6 +368,8 @@ const tooltipStyles = computed<StyleValue>(() => {
         /* default styles target position "top": wedge points down, apex at trigger's top edge */
         top: calc(anchor(top) - var(--offset) - var(--onyx-tooltip-wedge-size));
         left: calc(anchor(center) - var(--onyx-tooltip-wedge-size));
+        // The box of the wedge blocks clicks and hover effects, so we disable its pointer-events
+        pointer-events: none;
       }
     }
 


### PR DESCRIPTION
_Cause:_ The box of the wedge reaches over the anchored element and is blocking the hover effect and clicking
_Fix:_ Disable pointer-events for the wedge