### PR TITLE
bug(VerticalNavbar): fixed tooltip positions 

### DIFF
--- a/.changeset/quiet-carrots-jog.md
+++ b/.changeset/quiet-carrots-jog.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxVerticalNavbar): fix tooltip positions to be displayed next to nav items

--- a/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
+++ b/packages/sit-onyx/src/components/OnyxNavBar/modules/OnyxNavItem/OnyxNavItem.vue
@@ -127,7 +127,6 @@ const { componentRef, isVisible } = isTopLevel
   <!-- Desktop nav button directly in vertical navbar  -->
   <OnyxTooltip
     v-else-if="isExpanded === false && isTopLevel && isVisible"
-    alignment="right"
     position="right"
     without-wedge
   >

--- a/packages/sit-onyx/src/components/OnyxTooltip/OnyxTooltip.vue
+++ b/packages/sit-onyx/src/components/OnyxTooltip/OnyxTooltip.vue
@@ -124,6 +124,9 @@ const positionAndAlignment = computed(() => {
   if (toolTipPosition.value.includes(" ")) {
     return toolTipPosition.value;
   }
+  if (toolTipPosition.value === "left" || toolTipPosition.value === "right") {
+    return `${toolTipPosition.value} center`;
+  }
   return `${toolTipPosition.value} ${alignment.value === "right" ? "left" : alignment.value === "left" ? "right" : "center"}`;
 });
 


### PR DESCRIPTION
<!-- Is your PR related to an issue? Then please link it via the "Relates to #" below. Else, remove it. -->

Relates to #6033

- removed wrong alignment for the tooltip
- added an check inside the tooltip to ignore alignment when positioned left/right