### PR TITLE
docs(showcase): add more examples for "Navigation" components

### DIFF
--- a/.changeset/solid-gifts-rule.md
+++ b/.changeset/solid-gifts-rule.md
@@ -3,3 +3,5 @@
 ---
 
 fix(nuxt-docs): show correct sidebar root when page is not found
+
+When a page is not found, the sidebar previously included all available pages, even if a custom sidebar root was defined. This is now fixed so that if e.g. a root is defined for "/components" and a non-existing page is opened (e.g. "/components/buttons/not-found"), the sidebar will still correctly show all items inside the "/components" root.

--- a/.changeset/solid-gifts-rule.md
+++ b/.changeset/solid-gifts-rule.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt-docs": patch
+---
+
+fix(nuxt-docs): show correct sidebar root when page is not found

--- a/apps/showcase/app/components/content/ComponentExample.vue
+++ b/apps/showcase/app/components/content/ComponentExample.vue
@@ -208,7 +208,7 @@ if (props.provide?.notifications) {
       }
 
       :deep(.onyx-app__page) {
-        border-bottom-left-radius: inherit;
+        border-radius: inherit;
       }
 
       :deep(.onyx-app__nav:has(.onyx-nav-bar--vertical)) {

--- a/apps/showcase/app/components/content/ComponentExample.vue
+++ b/apps/showcase/app/components/content/ComponentExample.vue
@@ -224,7 +224,12 @@ if (props.provide?.notifications) {
         }
       }
 
-      :deep(> .onyx-app__page > .onyx-page > .onyx-page__sidebar > .onyx-sidebar) {
+      :deep(
+        > .onyx-app__page
+          > .onyx-page
+          > .onyx-page__sidebar
+          > .onyx-sidebar:not(.onyx-sidebar--temporary)
+      ) {
         --onyx-sidebar-width: 16rem;
       }
     }

--- a/apps/showcase/content/en/components/08.navigation/color-scheme-dialog/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/color-scheme-dialog/examples/Basic.example.vue
@@ -1,0 +1,14 @@
+<script lang="ts" setup>
+import { ColorSchemeValue, OnyxButton, OnyxColorSchemeDialog } from "sit-onyx";
+import { ref } from "vue";
+
+const colorScheme = ref<ColorSchemeValue>("auto");
+const open = ref(false);
+</script>
+
+<template>
+  <div>
+    <OnyxButton label="Show dialog" @click="open = true" />
+    <OnyxColorSchemeDialog v-model="colorScheme" v-model:open="open" />
+  </div>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/color-scheme-dialog/index.md
+++ b/apps/showcase/content/en/components/08.navigation/color-scheme-dialog/index.md
@@ -1,0 +1,12 @@
+---
+title: Color scheme dialog
+componentName: OnyxColorSchemeDialog
+---
+
+Pre-built dialog where the user can select which color scheme (light/dark mode) to use for the application.
+
+## Examples
+
+### Basic
+
+:component-example{name="Basic"}

--- a/apps/showcase/content/en/components/08.navigation/color-scheme-dialog/index.md
+++ b/apps/showcase/content/en/components/08.navigation/color-scheme-dialog/index.md
@@ -1,6 +1,7 @@
 ---
 title: Color scheme dialog
 componentName: OnyxColorSchemeDialog
+navigation: false
 ---
 
 Pre-built dialog where the user can select which color scheme (light/dark mode) to use for the application.

--- a/apps/showcase/content/en/components/08.navigation/color-scheme-menu-item/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/color-scheme-menu-item/examples/Basic.example.vue
@@ -1,0 +1,12 @@
+<script lang="ts" setup>
+import { ColorSchemeValue, OnyxColorSchemeMenuItem, OnyxUserMenu } from "sit-onyx";
+import { ref } from "vue";
+
+const colorScheme = ref<ColorSchemeValue>("auto");
+</script>
+
+<template>
+  <OnyxUserMenu full-name="Jane Doe">
+    <OnyxColorSchemeMenuItem v-model="colorScheme" />
+  </OnyxUserMenu>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/color-scheme-menu-item/index.md
+++ b/apps/showcase/content/en/components/08.navigation/color-scheme-menu-item/index.md
@@ -1,0 +1,16 @@
+---
+title: Color scheme menu item
+componentName: OnyxColorSchemeMenuItem
+---
+
+Pre-built [menu item](/components/basic/menu-item) for the [user menu](/components/navigation/user-menu) that can be used inside the [nav bar](/components/navigation/nav-bar) to display the current color scheme (light/dark mode) to the user and allow changing it using a dialog.
+
+You can also use a custom trigger instead of this menu item by manually using the [color scheme dialog](/components/navigation/color-scheme-dialog) component.
+
+## Examples
+
+### Basic
+
+<p style="color: var(--onyx-color-text-icons-info-intense)">Hover the user menu to see the color scheme menu item.</p>
+
+:component-example{name="Basic"}

--- a/apps/showcase/content/en/components/08.navigation/color-scheme-menu-item/index.md
+++ b/apps/showcase/content/en/components/08.navigation/color-scheme-menu-item/index.md
@@ -1,6 +1,7 @@
 ---
 title: Color scheme menu item
 componentName: OnyxColorSchemeMenuItem
+navigation: false
 ---
 
 Pre-built [menu item](/components/basic/menu-item) for the [user menu](/components/navigation/user-menu) that can be used inside the [nav bar](/components/navigation/nav-bar) to display the current color scheme (light/dark mode) to the user and allow changing it using a dialog.

--- a/apps/showcase/content/en/components/08.navigation/language-menu-item/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/language-menu-item/examples/Basic.example.vue
@@ -1,0 +1,18 @@
+<script lang="ts" setup>
+import { flagUS, flagDE } from "@sit-onyx/flags";
+import { OnyxLanguageMenuItem, OnyxUserMenu, SelectDialogOption } from "sit-onyx";
+import { ref } from "vue";
+
+const locale = ref("en");
+
+const languages: SelectDialogOption[] = [
+  { label: "English", value: "en", icon: flagUS },
+  { label: "Deutsch", value: "de", icon: flagDE },
+];
+</script>
+
+<template>
+  <OnyxUserMenu full-name="Jane Doe">
+    <OnyxLanguageMenuItem v-model="locale" :options="languages" />
+  </OnyxUserMenu>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/language-menu-item/index.md
+++ b/apps/showcase/content/en/components/08.navigation/language-menu-item/index.md
@@ -1,0 +1,14 @@
+---
+title: Language menu item
+componentName: OnyxLanguageMenuItem
+---
+
+Pre-built [menu item](/components/basic/menu-item) for the [user menu](/components/navigation/user-menu) that can be used inside the [nav bar](/components/navigation/nav-bar) to display the current application language to the user and allow changing it using a dialog.
+
+## Examples
+
+### Basic
+
+<p style="color: var(--onyx-color-text-icons-info-intense)">Hover the user menu to see the language menu item.</p>
+
+:component-example{name="Basic"}

--- a/apps/showcase/content/en/components/08.navigation/language-menu-item/index.md
+++ b/apps/showcase/content/en/components/08.navigation/language-menu-item/index.md
@@ -1,6 +1,7 @@
 ---
 title: Language menu item
 componentName: OnyxLanguageMenuItem
+navigation: false
 ---
 
 Pre-built [menu item](/components/basic/menu-item) for the [user menu](/components/navigation/user-menu) that can be used inside the [nav bar](/components/navigation/nav-bar) to display the current application language to the user and allow changing it using a dialog.

--- a/apps/showcase/content/en/components/08.navigation/nav-bar/index.md
+++ b/apps/showcase/content/en/components/08.navigation/nav-bar/index.md
@@ -13,9 +13,19 @@ The nav bar is intended to be used within the [app layout](/components/layouts/a
 
 A basic nav bar contains the application name and logo (if one exists) and navigation items linking to the main pages of the application. On smaller screen sizes, the nav bar automatically switches to an optimized mobile mode.
 
-The individual nav items can either be standalone or contain nested children that are shown when hovering the parent nav item. For a full list of nav item examples, please refer to the [nav item](/components/navigation/nav-item) component. Nav items can also link to external applications.
+The individual nav items can either be standalone or contain nested children that are shown when hovering the parent nav item.
 
 :component-example{name="Basic" layout="fullWidth"}
+
+<br />
+
+<div class="onyx-grid">
+<link-card class="onyx-grid-span-4" headline="Nav item" link="/components/navigation/nav-item">
+For a full list of nav item examples, please refer to the nav item component.
+</link-card>
+</div>
+
+<br />
 
 ### Nested nav items
 
@@ -74,7 +84,7 @@ Display the currently logged in user with additional actions such as logout, set
 </link-card>
 
 <link-card class="onyx-grid-span-4" headline="Nav button" link="/components/navigation/nav-button">
-Button to provide additional nav bar context actions such as language selection, notifications and more. Supports text and icon.
+Button to provide additional nav bar context actions such as language selection, notifications and more.
 </link-card>
 
 <link-card class="onyx-grid-span-4" headline="Timer" link="/components/navigation/timer">
@@ -87,6 +97,18 @@ Manage global notifications for the application.
 
 <link-card class="onyx-grid-span-4" headline="Global search" link="/components/search-and-filter/global-search">
 Provide a global search to allow the user to quickly find relevant content.
+</link-card>
+
+<link-card class="onyx-grid-span-4" headline="Language menu item" link="/components/navigation/language-menu-item">
+Pre-built menu item to display and change the application language.
+</link-card>
+
+<link-card class="onyx-grid-span-4" headline="Color scheme menu item" link="/components/navigation/color-scheme-menu-item">
+Pre-built menu item to display and change the color scheme / appearance (light/dark) mode.
+</link-card>
+
+<link-card class="onyx-grid-span-4" headline="Color scheme dialog" link="/components/navigation/color-scheme-dialog">
+Pre-built modal to change the color scheme / appearance (light/dark) mode.
 </link-card>
 
 </div>

--- a/apps/showcase/content/en/components/08.navigation/nav-button/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/nav-button/examples/Basic.example.vue
@@ -1,0 +1,12 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxUnstableNavButton } from "sit-onyx";
+
+const handleClick = () => {
+  // handle click here...
+};
+</script>
+
+<template>
+  <OnyxUnstableNavButton label="Example action" :icon="iconPlaceholder" @click="handleClick" />
+</template>

--- a/apps/showcase/content/en/components/08.navigation/nav-button/examples/Icon.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/nav-button/examples/Icon.example.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxUnstableNavButton } from "sit-onyx";
+
+const handleClick = () => {
+  // handle click here...
+};
+</script>
+
+<template>
+  <OnyxUnstableNavButton
+    label="Example action"
+    :icon="iconPlaceholder"
+    hide-label
+    @click="handleClick"
+  />
+</template>

--- a/apps/showcase/content/en/components/08.navigation/nav-button/examples/Primary.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/nav-button/examples/Primary.example.vue
@@ -1,0 +1,12 @@
+<script lang="ts" setup>
+import { iconLogin } from "@sit-onyx/icons";
+import { OnyxUnstableNavButton } from "sit-onyx";
+
+const handleClick = () => {
+  // handle click here...
+};
+</script>
+
+<template>
+  <OnyxUnstableNavButton label="Login" :icon="iconLogin" color="primary" @click="handleClick" />
+</template>

--- a/apps/showcase/content/en/components/08.navigation/nav-button/index.md
+++ b/apps/showcase/content/en/components/08.navigation/nav-button/index.md
@@ -2,6 +2,7 @@
 title: Nav button
 componentName: OnyxNavButton
 status: experimental
+navigation: false
 ---
 
 The nav button is intended to be used exclusively inside the [nav bar](/components/navigation/nav-bar#context-area) for providing (custom) actions inside the context area. Do NOT use the [icon button](/components/buttons/icon-button) inside the nav bar.

--- a/apps/showcase/content/en/components/08.navigation/nav-button/index.md
+++ b/apps/showcase/content/en/components/08.navigation/nav-button/index.md
@@ -1,0 +1,27 @@
+---
+title: Nav button
+componentName: OnyxNavButton
+status: experimental
+---
+
+The nav button is intended to be used exclusively inside the [nav bar](/components/navigation/nav-bar#context-area) for providing (custom) actions inside the context area. Do NOT use the [icon button](/components/buttons/icon-button) inside the nav bar.
+
+## Examples
+
+### Basic
+
+The button can either trigger a custom action or open a link.
+
+:component-example{name="Basic"}
+
+### Icon button
+
+The label can optionally be hidden to use an icon-only button.
+
+:component-example{name="Icon"}
+
+### Primary
+
+The `primary` color is exclusively intended for "Login" buttons.
+
+:component-example{name="Primary"}

--- a/apps/showcase/content/en/components/08.navigation/nav-item/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/nav-item/examples/Basic.example.vue
@@ -1,0 +1,14 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxBadge, OnyxIcon, OnyxNavItem } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxNavItem label="Example page" link="#example-page" />
+
+  <OnyxNavItem label="Example page" link="#example-page-2">
+    <OnyxIcon :icon="iconPlaceholder" />
+    Example page
+    <OnyxBadge color="warning" dot />
+  </OnyxNavItem>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/nav-item/examples/Nested.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/nav-item/examples/Nested.example.vue
@@ -1,0 +1,13 @@
+<script lang="ts" setup>
+import { OnyxNavItem } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxNavItem label="Page 1" link="/page-1">
+    <template #children>
+      <OnyxNavItem label="Page 1.1" link="/page-1/1" />
+      <OnyxNavItem label="Page 1.2" link="/page-1/2" />
+      <OnyxNavItem label="Page 1.3" link="/page-1/3" />
+    </template>
+  </OnyxNavItem>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/nav-item/examples/NestedExternal.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/nav-item/examples/NestedExternal.example.vue
@@ -1,0 +1,27 @@
+<script lang="ts" setup>
+import { OnyxNavItem } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxNavItem label="Page 1" link="/page-1" drilldown-mode="external">
+    <template #children>
+      <OnyxNavItem label="Page 1.1" link="/page-1/1">
+        <template #children>
+          <OnyxNavItem label="Page 1.1.1" link="/page-1/1/1" />
+          <OnyxNavItem label="Page 1.1.2" link="/page-1/1/2" />
+
+          <OnyxNavItem label="Page 1.1.3" link="/page-1/1/3">
+            <template #children>
+              <OnyxNavItem label="Page 1.1.3.1" link="/page-1/1/3/1" />
+              <OnyxNavItem label="Page 1.1.3.2" link="/page-1/1/3/2" />
+              <OnyxNavItem label="Page 1.1.3.3" link="/page-1/1/3/3" />
+            </template>
+          </OnyxNavItem>
+        </template>
+      </OnyxNavItem>
+
+      <OnyxNavItem label="Page 1.2" link="/page-1/2" />
+      <OnyxNavItem label="Page 1.3" link="/page-1/3" />
+    </template>
+  </OnyxNavItem>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/nav-item/examples/NestedInternal.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/nav-item/examples/NestedInternal.example.vue
@@ -1,0 +1,27 @@
+<script lang="ts" setup>
+import { OnyxNavItem } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxNavItem label="Page 1" link="/page-1">
+    <template #children>
+      <OnyxNavItem label="Page 1.1" link="/page-1/1">
+        <template #children>
+          <OnyxNavItem label="Page 1.1.1" link="/page-1/1/1" />
+          <OnyxNavItem label="Page 1.1.2" link="/page-1/1/2" />
+
+          <OnyxNavItem label="Page 1.1.3" link="/page-1/1/3">
+            <template #children>
+              <OnyxNavItem label="Page 1.1.3.1" link="/page-1/1/3/1" />
+              <OnyxNavItem label="Page 1.1.3.2" link="/page-1/1/3/2" />
+              <OnyxNavItem label="Page 1.1.3.3" link="/page-1/1/3/3" />
+            </template>
+          </OnyxNavItem>
+        </template>
+      </OnyxNavItem>
+
+      <OnyxNavItem label="Page 1.2" link="/page-1/2" />
+      <OnyxNavItem label="Page 1.3" link="/page-1/3" />
+    </template>
+  </OnyxNavItem>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/nav-item/index.md
+++ b/apps/showcase/content/en/components/08.navigation/nav-item/index.md
@@ -1,0 +1,14 @@
+---
+title: Nav item
+componentName: OnyxNavItem
+---
+
+The nav item is used to build the [navigation bar](/components/navigation/nav-bar) component and not intended to be used standalone.
+
+## Examples
+
+<div class="onyx-grid">
+<link-card class="onyx-grid-span-4" headline="Nav bar documentation" link="/components/navigation/nav-bar">
+Please refer to the nav bar component for examples on how to use nav items.
+</link-card>
+</div>

--- a/apps/showcase/content/en/components/08.navigation/nav-item/index.md
+++ b/apps/showcase/content/en/components/08.navigation/nav-item/index.md
@@ -6,10 +6,34 @@ navigation: false
 
 The nav item is used to build the [navigation bar](/components/navigation/nav-bar) component and not intended to be used standalone.
 
-## Examples
-
 <div class="onyx-grid">
 <link-card class="onyx-grid-span-4" headline="Nav bar documentation" link="/components/navigation/nav-bar">
-Please refer to the nav bar component for examples on how to use nav items.
+Please refer to the nav bar component for a full list of examples.
 </link-card>
 </div>
+
+## Examples
+
+### Basic
+
+The nav item is automatically highlighted active if the current page matches the nav item link. Custom content is supported.
+
+:component-example{name="Basic"}
+
+### Children
+
+Hierarchical page structures can be displayed using children that are shown when hovering the parent item.
+
+:component-example{name="Nested"}
+
+### Internal drilldown
+
+When multiple layers of children are defined, an internal drilldown is used by default that supports navigation between the child layers.
+
+:component-example{name="NestedInternal"}
+
+### External drilldown
+
+Additional, the drilldown can be external which displays the nested child layers using multiple flyouts. Please only use a limit amount of layers with the external drilldown since the available screen size can be limited on smaller screens.
+
+:component-example{name="NestedExternal"}

--- a/apps/showcase/content/en/components/08.navigation/nav-item/index.md
+++ b/apps/showcase/content/en/components/08.navigation/nav-item/index.md
@@ -1,6 +1,7 @@
 ---
 title: Nav item
 componentName: OnyxNavItem
+navigation: false
 ---
 
 The nav item is used to build the [navigation bar](/components/navigation/nav-bar) component and not intended to be used standalone.

--- a/apps/showcase/content/en/components/08.navigation/segmented-control/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/segmented-control/examples/Basic.example.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxSegmentedControl, OnyxSegmentedControlOption } from "sit-onyx";
+import { ref } from "vue";
+
+const options: OnyxSegmentedControlOption[] = [
+  { label: "Option 1", value: "option-1", icon: iconPlaceholder },
+  { label: "Option 2", value: "option-2", icon: iconPlaceholder },
+  { label: "Option 3", value: "option-3", icon: iconPlaceholder },
+];
+
+const selectedOption = ref(options[0].value);
+</script>
+
+<template>
+  <OnyxSegmentedControl v-model="selectedOption" :options />
+</template>

--- a/apps/showcase/content/en/components/08.navigation/segmented-control/examples/Disabled.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/segmented-control/examples/Disabled.example.vue
@@ -1,0 +1,16 @@
+<script lang="ts" setup>
+import { OnyxSegmentedControl, OnyxSegmentedControlOption } from "sit-onyx";
+import { ref } from "vue";
+
+const options: OnyxSegmentedControlOption[] = [
+  { label: "Option 1", value: "option-1" },
+  { label: "Option 2", value: "option-2", disabled: true },
+  { label: "Option 3", value: "option-3" },
+];
+
+const selectedOption = ref(options[0].value);
+</script>
+
+<template>
+  <OnyxSegmentedControl v-model="selectedOption" :options />
+</template>

--- a/apps/showcase/content/en/components/08.navigation/segmented-control/examples/Icons.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/segmented-control/examples/Icons.example.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxSegmentedControl, OnyxSegmentedControlOption } from "sit-onyx";
+import { ref } from "vue";
+
+const options: OnyxSegmentedControlOption[] = [
+  { label: "Option 1", value: "option-1", icon: iconPlaceholder, hideLabel: true },
+  { label: "Option 2", value: "option-2", icon: iconPlaceholder, hideLabel: true },
+  { label: "Option 3", value: "option-3", icon: iconPlaceholder, hideLabel: true },
+];
+
+const selectedOption = ref(options[0].value);
+</script>
+
+<template>
+  <OnyxSegmentedControl v-model="selectedOption" :options />
+</template>

--- a/apps/showcase/content/en/components/08.navigation/segmented-control/examples/Skeleton.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/segmented-control/examples/Skeleton.example.vue
@@ -1,0 +1,16 @@
+<script lang="ts" setup>
+import { OnyxSegmentedControl, OnyxSegmentedControlOption } from "sit-onyx";
+import { ref } from "vue";
+
+const options: OnyxSegmentedControlOption[] = [
+  { label: "Option 1", value: "option-1" },
+  { label: "Option 2", value: "option-2" },
+  { label: "Option 3", value: "option-3" },
+];
+
+const selectedOption = ref(options[0].value);
+</script>
+
+<template>
+  <OnyxSegmentedControl v-model="selectedOption" :options skeleton />
+</template>

--- a/apps/showcase/content/en/components/08.navigation/segmented-control/index.md
+++ b/apps/showcase/content/en/components/08.navigation/segmented-control/index.md
@@ -1,0 +1,32 @@
+---
+title: Segmented control
+componentName: OnyxSegmentedControl
+---
+
+The segmented control is an interactive element that allow users to make a single selection from a set of mutually exclusive options. Users can choose only one option at the time. It is commonly used for building filters, queries or toggles (e.g. to switch a layout between a card and table view).
+
+## Examples
+
+### Basic
+
+The segmented control consists out of at least two options that display a label and an option icon. We recommend to either show an icon for all options or to use only labels but not to mix those two options.
+
+:component-example{name="Basic" layout="grow"}
+
+### Icons only
+
+The option label can optionally be hidden so only an icon is shown. In this mode, the component only takes up the width that the options need and does not stretch to the available width.
+
+:component-example{name="Icons"}
+
+### Disabled
+
+Individual options can be disabled to prevent user selection.
+
+:component-example{name="Disabled" layout="grow"}
+
+### Skeleton
+
+Use the skeleton on initial page load while the data for the segmented control options are being loaded.
+
+:component-example{name="Skeleton" layout="grow"}

--- a/apps/showcase/content/en/components/08.navigation/sidebar/examples/Grid.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/sidebar/examples/Grid.example.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import {
+  OnyxAppLayout,
+  OnyxButton,
+  OnyxHeadline,
+  OnyxPageLayout,
+  OnyxSidebar,
+  OnyxCard,
+} from "sit-onyx";
+</script>
+
+<template>
+  <OnyxAppLayout>
+    <OnyxPageLayout>
+      <template #sidebar>
+        <OnyxSidebar label="Example sidebar">
+          <template #header> Header content </template>
+          <div class="onyx-grid-layout">
+            <div class="onyx-grid">
+              <OnyxCard v-for="i in 6" :key="i" class="card"> {{ i }} </OnyxCard>
+              <OnyxCard class="card onyx-grid-span-2">2 columns</OnyxCard>
+              <OnyxCard class="card onyx-grid-span-full">full width</OnyxCard>
+            </div>
+          </div>
+
+          <template #footer>
+            <OnyxButton color="neutral" label="Button" />
+            <OnyxButton label="Button" />
+          </template>
+        </OnyxSidebar>
+      </template>
+
+      <!-- page content -->
+      <OnyxHeadline is="h1">Page content</OnyxHeadline>
+    </OnyxPageLayout>
+  </OnyxAppLayout>
+</template>
+
+<style lang="scss" scoped>
+.card {
+  flex-direction: row;
+  justify-content: center;
+}
+</style>

--- a/apps/showcase/content/en/components/08.navigation/sidebar/examples/Left.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/sidebar/examples/Left.example.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxAppLayout, OnyxButton, OnyxHeadline, OnyxPageLayout, OnyxSidebar } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxAppLayout>
+    <OnyxPageLayout>
+      <template #sidebar>
+        <OnyxSidebar class="sidebar" label="Example sidebar">
+          <template #header> Header content </template>
+
+          <div class="sidebar__content">
+            <OnyxSidebarItem v-for="i in 6" :key="i" :link="`#link-${i}`">
+              <OnyxIcon :icon="iconPlaceholder" />
+              Item {{ i }}
+            </OnyxSidebarItem>
+          </div>
+
+          <template #footer>
+            <OnyxButton color="neutral" label="Button" />
+            <OnyxButton label="Button" />
+          </template>
+        </OnyxSidebar>
+      </template>
+
+      <!-- page content -->
+      <OnyxHeadline is="h1">Page content</OnyxHeadline>
+    </OnyxPageLayout>
+  </OnyxAppLayout>
+</template>
+
+<style lang="scss" scoped>
+.sidebar {
+  &__content {
+    padding: var(--onyx-sidebar-padding);
+    display: flex;
+    flex-direction: column;
+    gap: var(--onyx-density-2xs);
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/08.navigation/sidebar/examples/Right.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/sidebar/examples/Right.example.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxAppLayout, OnyxButton, OnyxHeadline, OnyxPageLayout, OnyxSidebar } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxAppLayout>
+    <OnyxPageLayout>
+      <template #sidebarRight>
+        <OnyxSidebar class="sidebar" label="Example sidebar" alignment="right">
+          <template #header> Header content </template>
+
+          <div class="sidebar__content">
+            <OnyxSidebarItem v-for="i in 6" :key="i" :link="`#link-${i}`">
+              <OnyxIcon :icon="iconPlaceholder" />
+              Item {{ i }}
+            </OnyxSidebarItem>
+          </div>
+
+          <template #footer>
+            <OnyxButton color="neutral" label="Button" />
+            <OnyxButton label="Button" />
+          </template>
+        </OnyxSidebar>
+      </template>
+
+      <!-- page content -->
+      <OnyxHeadline is="h1">Page content</OnyxHeadline>
+    </OnyxPageLayout>
+  </OnyxAppLayout>
+</template>
+
+<style lang="scss" scoped>
+.sidebar {
+  &__content {
+    padding: var(--onyx-sidebar-padding);
+    display: flex;
+    flex-direction: column;
+    gap: var(--onyx-density-2xs);
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/08.navigation/sidebar/examples/Temporary.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/sidebar/examples/Temporary.example.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxAppLayout, OnyxButton, OnyxPageLayout, OnyxSidebar } from "sit-onyx";
+import { ref } from "vue";
+
+const isOpen = ref(false);
+</script>
+
+<template>
+  <OnyxAppLayout>
+    <OnyxPageLayout>
+      <template #sidebar>
+        <OnyxSidebar
+          class="sidebar"
+          label="Example sidebar"
+          :temporary="{ open: isOpen }"
+          alignment="right"
+          @close="isOpen = false"
+        >
+          <template #header> Header content </template>
+          <template #description>
+            Lorem ipsum dolor sit amet consectetur. Dui purus quisque est.
+          </template>
+
+          <div class="sidebar__content">
+            <OnyxSidebarItem v-for="i in 6" :key="i" :link="`#link-${i}`">
+              <OnyxIcon :icon="iconPlaceholder" />
+              Item {{ i }}
+            </OnyxSidebarItem>
+          </div>
+
+          <template #footer>
+            <OnyxButton color="neutral" label="Button" />
+            <OnyxButton label="Button" />
+          </template>
+        </OnyxSidebar>
+      </template>
+
+      <!-- page content -->
+      <OnyxButton label="Open sidebar" @click="isOpen = true" />
+    </OnyxPageLayout>
+  </OnyxAppLayout>
+</template>
+
+<style lang="scss" scoped>
+.sidebar {
+  &__content {
+    padding: var(--onyx-sidebar-padding);
+    display: flex;
+    flex-direction: column;
+    gap: var(--onyx-density-2xs);
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/08.navigation/sidebar/examples/TreeView.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/sidebar/examples/TreeView.example.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { iconPlaceholder } from "@sit-onyx/icons";
+import {
+  OnyxAppLayout,
+  OnyxButton,
+  OnyxHeadline,
+  OnyxIcon,
+  OnyxPageLayout,
+  OnyxSidebar,
+  OnyxSidebarItem,
+  OnyxUnstableTreeView,
+  OnyxUnstableTreeViewItem,
+} from "sit-onyx";
+</script>
+
+<template>
+  <OnyxAppLayout>
+    <OnyxPageLayout>
+      <template #sidebar>
+        <OnyxSidebar label="Example sidebar">
+          <template #header> Header content </template>
+
+          <div class="sidebar__content">
+            <OnyxUnstableTreeView label="Example tree view">
+              <OnyxSidebarItem link="#link-1">
+                <OnyxIcon :icon="iconPlaceholder" />
+                Item 1
+              </OnyxSidebarItem>
+
+              <OnyxUnstableTreeViewItem label="Item 2" :icon="iconPlaceholder">
+                <OnyxSidebarItem link="#link-2.1">
+                  <OnyxIcon :icon="iconPlaceholder" />
+                  Item 2.1
+                </OnyxSidebarItem>
+
+                <OnyxUnstableTreeViewItem label="Item 2.2" :icon="iconPlaceholder">
+                  <OnyxSidebarItem link="#link-2.2.1">
+                    <OnyxIcon :icon="iconPlaceholder" />
+                    Item 2.2.1
+                  </OnyxSidebarItem>
+                  <OnyxSidebarItem link="#link-2.2.2">
+                    <OnyxIcon :icon="iconPlaceholder" />
+                    Item 2.2.2
+                  </OnyxSidebarItem>
+                </OnyxUnstableTreeViewItem>
+              </OnyxUnstableTreeViewItem>
+
+              <OnyxUnstableTreeViewItem label="Item 3" :icon="iconPlaceholder">
+                <OnyxSidebarItem link="#link-3.1">
+                  <OnyxIcon :icon="iconPlaceholder" />
+                  Item 3.1
+                </OnyxSidebarItem>
+                <OnyxSidebarItem link="#link-3.2">
+                  <OnyxIcon :icon="iconPlaceholder" />
+                  Item 3.2
+                </OnyxSidebarItem>
+                <OnyxSidebarItem link="#link-3.3">
+                  <OnyxIcon :icon="iconPlaceholder" />
+                  Item 3.3
+                </OnyxSidebarItem>
+              </OnyxUnstableTreeViewItem>
+
+              <OnyxSidebarItem link="#link-4">
+                <OnyxIcon :icon="iconPlaceholder" />
+                Item 4
+              </OnyxSidebarItem>
+            </OnyxUnstableTreeView>
+          </div>
+
+          <template #footer>
+            <OnyxButton color="neutral" label="Button" />
+            <OnyxButton label="Button" />
+          </template>
+        </OnyxSidebar>
+      </template>
+
+      <!-- page content -->
+      <OnyxHeadline is="h1">Page content</OnyxHeadline>
+    </OnyxPageLayout>
+  </OnyxAppLayout>
+</template>
+
+<style lang="scss" scoped>
+.sidebar {
+  &__content {
+    padding: var(--onyx-sidebar-padding);
+    display: flex;
+    flex-direction: column;
+    gap: var(--onyx-density-2xs);
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/08.navigation/sidebar/index.md
+++ b/apps/showcase/content/en/components/08.navigation/sidebar/index.md
@@ -3,13 +3,13 @@ title: Sidebar
 componentName: OnyxSidebar
 ---
 
-A sidebar is displayed either on the left or right edge of the application to show additional information. It can shown either permanently or only temporarily after user interaction.
+A sidebar is displayed either on the left or right edge of the application to show additional information. It can be shown either permanently or only temporarily based on the user interaction.
 
 ## Examples
 
 ### Alignments
 
-A basic sidebar is shown permanently on the left or right side of the application. It can contain up to three sections: header, body and footer. The header and footer are sticky while the body becomes scrollable if the content is too large for the available screen height.
+A basic sidebar is shown permanently on the left or right side of the application. It contains up to three sections: header, body and footer. The header and footer are sticky while the body becomes scrollable if the content is too large for the available height.
 
 The sidebar can manually be resized by the user by dragging the border. Double clicking the border will reset the width to the default. Resizing can be disabling using the `resizable` property.
 

--- a/apps/showcase/content/en/components/08.navigation/sidebar/index.md
+++ b/apps/showcase/content/en/components/08.navigation/sidebar/index.md
@@ -1,0 +1,56 @@
+---
+title: Sidebar
+componentName: OnyxSidebar
+---
+
+A sidebar is displayed either on the left or right edge of the application to show additional information. It can shown either permanently or only temporarily after user interaction.
+
+## Examples
+
+### Alignments
+
+A basic sidebar is shown permanently on the left or right side of the application. It can contain up to three sections: header, body and footer. The header and footer are sticky while the body becomes scrollable if the content is too large for the available screen height.
+
+The sidebar can manually be resized by the user by dragging the border. Double clicking the border will reset the width to the default. Resizing can be disabling using the `resizable` property.
+
+<steps>
+
+::step
+#headline
+Left
+
+#default
+:component-example{name="Left" layout="fullWidth"}
+::
+
+::step
+#headline
+Right
+
+#default
+:component-example{name="Right" layout="fullWidth"}
+::
+
+</steps>
+
+<br />
+
+### Temporary
+
+Use a temporary sidebar to show the additional content only after user interaction, e.g. when clicking a row inside a [data grid](/components/data/data-grid).
+
+:component-example{name="Temporary" layout="fullWidth"}
+
+### Tree view
+
+To display hierarchical data, use a [tree view](/components/navigation/tree-view) component inside the sidebar.
+
+:component-example{name="TreeView" layout="fullWidth"}
+
+### Grid
+
+The sidebar also supports using our grid system to easy build responsive layouts. For further information, please refer to our [grid documentation](/introduction/foundation/breakpoints-and-grid).
+
+<p style="color: var(--onyx-color-text-icons-info-intense)">Resize the sidebar by dragging the border to see the grid in action.</p>
+
+:component-example{name="Grid" layout="fullWidth"}

--- a/apps/showcase/content/en/components/08.navigation/table-of-contents/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/table-of-contents/examples/Basic.example.vue
@@ -1,0 +1,71 @@
+<script lang="ts" setup>
+import {
+  OnyxAppLayout,
+  OnyxHeadline,
+  OnyxPageLayout,
+  OnyxTableOfContents,
+  OnyxTableOfContentsItem,
+} from "sit-onyx";
+</script>
+
+<template>
+  <OnyxAppLayout>
+    <OnyxPageLayout>
+      <div class="layout">
+        <div class="layout__content">
+          <OnyxHeadline is="h1">Page content</OnyxHeadline>
+        </div>
+
+        <OnyxTableOfContents class="layout__toc">
+          <OnyxTableOfContentsItem link="#section-1"> Section 1 </OnyxTableOfContentsItem>
+          <OnyxTableOfContentsItem link="#section-2">
+            Section 2
+
+            <template #children>
+              <OnyxTableOfContentsItem link="#section-2-1">
+                Sub section 2.1
+              </OnyxTableOfContentsItem>
+              <OnyxTableOfContentsItem link="#section-2-2">
+                Sub section 2.2
+              </OnyxTableOfContentsItem>
+            </template>
+          </OnyxTableOfContentsItem>
+          <OnyxTableOfContentsItem link="#section-3"> Section 3 </OnyxTableOfContentsItem>
+        </OnyxTableOfContents>
+      </div>
+    </OnyxPageLayout>
+  </OnyxAppLayout>
+</template>
+
+<style lang="scss" scoped>
+@use "sit-onyx/breakpoints.scss";
+
+.layout {
+  display: grid;
+  // gap between page content and TOC. Equivalent to one grid column + 2 * grid gutter/gap
+  gap: calc(2 * var(--onyx-grid-gutter) + (100 / var(--onyx-grid-columns)) * 1%);
+  grid-template-columns: 1fr minmax(8rem, 15rem);
+
+  &__toc {
+    position: sticky;
+    top: var(--onyx-grid-margin-vertical);
+    max-height: calc(100vh - var(--onyx-nav-bar-height) - 2 * var(--onyx-grid-margin-vertical));
+  }
+
+  &__content {
+    // when using a grid inside the content, it should reflect only the available
+    // content width as breakpoint instead of the whole page (including the TOC)
+    container-type: inline-size;
+  }
+
+  // hide TOC on smaller screens
+  @include breakpoints.container(max, md) {
+    display: flex;
+    flex-direction: column;
+
+    .layout__toc {
+      display: none;
+    }
+  }
+}
+</style>

--- a/apps/showcase/content/en/components/08.navigation/table-of-contents/examples/Skeleton.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/table-of-contents/examples/Skeleton.example.vue
@@ -1,0 +1,9 @@
+<script lang="ts" setup>
+import { OnyxTableOfContents } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxTableOfContents skeleton>
+    <!-- place the OnyxTableOfContentsItem components here once loaded -->
+  </OnyxTableOfContents>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/table-of-contents/index.md
+++ b/apps/showcase/content/en/components/08.navigation/table-of-contents/index.md
@@ -9,7 +9,7 @@ The table of contents component is used to display a list of sections/headings i
 
 ### Basic
 
-We recommend to position the table of contents on the right of the content with a minimum width of 8rem and a maximum width of 15rem. It should also be fixed so it does not scroll with the page content. The links are highlighted as active automatically based on the current link and scroll position (requires [headline](/components/navigation/headline) components inside the page content with the corresponding hash).
+The table of contents should be on the right of the content with a minimum width of `8rem` and a maximum width of `15rem`. It should also use `position: fixed`, so it does not scroll with the page content. The links are highlighted as active automatically based on the current link and scroll position (requires [headline](/components/navigation/headline) components inside the page content with a matching [hash](/components/navigation/headline#hash) property).
 
 :component-example{name="Basic" layout="fullWidth"}
 

--- a/apps/showcase/content/en/components/08.navigation/table-of-contents/index.md
+++ b/apps/showcase/content/en/components/08.navigation/table-of-contents/index.md
@@ -1,0 +1,20 @@
+---
+title: Table Of Contents
+componentName: OnyxTableOfContents
+---
+
+The table of contents component is used to display a list of sections/headings in a page with links to the corresponding sections.
+
+## Examples
+
+### Basic
+
+We recommend to position the table of contents on the right of the content with a minimum width of 8rem and a maximum width of 15rem. It should also be fixed so it does not scroll with the page content. The links are highlighted as active automatically based on the current link and scroll position (requires [headline](/components/navigation/headline) components inside the page content with the corresponding hash).
+
+:component-example{name="Basic" layout="fullWidth"}
+
+### Skeleton
+
+Use the skeleton on initial page load while the data for the table of contents is loading. Can be set on either the whole table of contents or only individual items.
+
+:component-example{name="Skeleton" layout="grow"}

--- a/apps/showcase/content/en/components/08.navigation/tabs/examples/Actions.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/tabs/examples/Actions.example.vue
@@ -1,0 +1,19 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxTab, OnyxTabs, OnyxTag } from "sit-onyx";
+import { ref } from "vue";
+
+const tab = ref("tab-1");
+</script>
+
+<template>
+  <OnyxTabs v-model="tab" label="Example tabs">
+    <template #actions>
+      <OnyxTag label="Tag" color="primary" />
+      <OnyxSystemButton label="Example action" :icon="iconPlaceholder" />
+    </template>
+
+    <OnyxTab label="Tab 1" value="tab-1">Content for tab 1...</OnyxTab>
+    <OnyxTab label="Tab 2" value="tab-2">Content for tab 2...</OnyxTab>
+  </OnyxTabs>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/tabs/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/tabs/examples/Basic.example.vue
@@ -1,0 +1,33 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxBadge, OnyxIcon, OnyxTab, OnyxTabs } from "sit-onyx";
+import { ref } from "vue";
+
+const tab = ref("tab-1");
+</script>
+
+<template>
+  <OnyxTabs v-model="tab" label="Example tabs">
+    <OnyxTab value="tab-1">
+      <template #tab>
+        <OnyxIcon :icon="iconPlaceholder" />
+        Tab 1
+      </template>
+
+      Content for tab 1...
+    </OnyxTab>
+
+    <OnyxTab label="Tab 2" value="tab-2">Content for tab 2...</OnyxTab>
+
+    <OnyxTab value="tab-3">
+      <template #tab>
+        Tab 3
+        <OnyxBadge color="warning" dot />
+      </template>
+
+      Content for tab 3...
+    </OnyxTab>
+
+    <OnyxTab label="Tab 4" value="tab-4" disabled> Content for tab 4... </OnyxTab>
+  </OnyxTabs>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/tabs/examples/Skeleton.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/tabs/examples/Skeleton.example.vue
@@ -1,0 +1,18 @@
+<script lang="ts" setup>
+import { OnyxTab, OnyxTabs } from "sit-onyx";
+import { ref } from "vue";
+
+const tab = ref("tab-1");
+</script>
+
+<template>
+  <OnyxTabs v-model="tab" label="Example tabs" skeleton>
+    <OnyxTab label="Tab 1" value="tab-1">
+      <!-- place content here once loaded -->
+    </OnyxTab>
+
+    <OnyxTab label="Tab 2" value="tab-2">
+      <!-- place content here once loaded -->
+    </OnyxTab>
+  </OnyxTabs>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/tabs/examples/Stretched.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/tabs/examples/Stretched.example.vue
@@ -1,0 +1,13 @@
+<script lang="ts" setup>
+import { OnyxTab, OnyxTabs } from "sit-onyx";
+import { ref } from "vue";
+
+const tab = ref("tab-1");
+</script>
+
+<template>
+  <OnyxTabs v-model="tab" label="Example tabs" stretched>
+    <OnyxTab label="Tab 1" value="tab-1">Content for tab 1...</OnyxTab>
+    <OnyxTab label="Tab 2" value="tab-2">Content for tab 2...</OnyxTab>
+  </OnyxTabs>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/tabs/index.md
+++ b/apps/showcase/content/en/components/08.navigation/tabs/index.md
@@ -1,0 +1,32 @@
+---
+title: Tabs
+componentName: OnyxTabs
+---
+
+Tabs organize content into separate views within the same page, helping users to navigate and manage large sets of information without page reloads, improving accessibility and flow. They are perfect for single page web applications, or for web pages capable of displaying different subjects.
+
+## Examples
+
+### Basic
+
+Each tab has a required label and can optionally show an icon or custom content such as a badge indicator. Specific tabs can be disabled if the user should not be able to view and interact with it. One tab must always be active.
+
+:component-example{name="Basic" layout="grow"}
+
+### Actions
+
+Custom actions or content can be placed at the end of the tabs if needed.
+
+:component-example{name="Actions" layout="grow"}
+
+### Stretched
+
+Stretch tabs to make them occupy the full available width.
+
+:component-example{name="Stretched" layout="grow"}
+
+### Skeleton
+
+Use the skeleton on initial page load to indicate that the data for the tabs is currently loading. Can also be defined only for specific tabs.
+
+:component-example{name="Skeleton"}

--- a/apps/showcase/content/en/components/08.navigation/timer/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/timer/examples/Basic.example.vue
@@ -1,0 +1,14 @@
+<script lang="ts" setup>
+import { OnyxTimer } from "sit-onyx";
+
+const endTime = new Date();
+endTime.setMinutes(endTime.getMinutes() + 15);
+
+const handleTimerEnd = () => {
+  // your logic when the timer has ended...
+};
+</script>
+
+<template>
+  <OnyxTimer label="Logged out in:" :end-time @timer-ended="handleTimerEnd" />
+</template>

--- a/apps/showcase/content/en/components/08.navigation/timer/index.md
+++ b/apps/showcase/content/en/components/08.navigation/timer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Timer
 componentName: OnyxTimer
+navigation: false
 ---
 
 Countdown timer, e.g. for when the user's login session expires.

--- a/apps/showcase/content/en/components/08.navigation/timer/index.md
+++ b/apps/showcase/content/en/components/08.navigation/timer/index.md
@@ -1,0 +1,14 @@
+---
+title: Timer
+componentName: OnyxTimer
+---
+
+Countdown timer, e.g. for when the user's login session expires.
+
+## Examples
+
+### Basic
+
+The timer automatically shows the remaining time in an appropriate format, e.g. hours, minutes or seconds, depending on the time.
+
+:component-example{name="Basic"}

--- a/apps/showcase/content/en/components/08.navigation/tree-view/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/tree-view/examples/Basic.example.vue
@@ -1,0 +1,26 @@
+<script lang="ts" setup>
+import { iconPlaceholder } from "@sit-onyx/icons";
+import { OnyxUnstableTreeView, OnyxUnstableTreeViewItem } from "sit-onyx";
+</script>
+
+<template>
+  <OnyxUnstableTreeView label="Example tree view">
+    <OnyxUnstableTreeViewItem label="Item 1" :icon="iconPlaceholder">
+      <OnyxUnstableTreeViewItem label="Item 1.1" :icon="iconPlaceholder">
+        <OnyxUnstableTreeViewItem label="Item 1.1.1" :icon="iconPlaceholder" />
+        <OnyxUnstableTreeViewItem label="Item 1.1.2" :icon="iconPlaceholder" />
+      </OnyxUnstableTreeViewItem>
+
+      <OnyxUnstableTreeViewItem label="Item 1.2" :icon="iconPlaceholder" />
+    </OnyxUnstableTreeViewItem>
+
+    <OnyxUnstableTreeViewItem label="Item 2" :icon="iconPlaceholder">
+      <OnyxUnstableTreeViewItem label="Item 2.1" :icon="iconPlaceholder" />
+      <OnyxUnstableTreeViewItem label="Item 2.2" :icon="iconPlaceholder" />
+    </OnyxUnstableTreeViewItem>
+
+    <OnyxUnstableTreeViewItem label="Item 3" :icon="iconPlaceholder" disabled>
+      <OnyxUnstableTreeViewItem label="Item 3.1" :icon="iconPlaceholder" />
+    </OnyxUnstableTreeViewItem>
+  </OnyxUnstableTreeView>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/tree-view/index.md
+++ b/apps/showcase/content/en/components/08.navigation/tree-view/index.md
@@ -1,0 +1,18 @@
+---
+title: Tree view
+componentName: OnyxTreeView
+---
+
+A tree view is used to display hierarchical data such as products grouped by category, files inside folders etc.
+
+## Examples
+
+### Basic
+
+A tree view can display an arbitrary amount of nested levels that can be collapsed and expanded. Each tree view item supports a label and optional icon or custom content. The displayed content at the end of the hierarchy can be fully customized.
+
+:component-example{name="Basic" layout="grow"}
+
+### Sidebar
+
+Refer to the [sidebar](/components/navigation/sidebar#tree-view) documentation for an example on how to use the tree view within a sidebar.

--- a/apps/showcase/content/en/components/08.navigation/user-menu/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/user-menu/examples/Basic.example.vue
@@ -15,16 +15,8 @@ const colorScheme = ref<ColorSchemeValue>("auto");
 const locale = ref("en");
 
 const languages: SelectDialogOption[] = [
-  {
-    label: "English",
-    value: "en",
-    icon: flagUS,
-  },
-  {
-    label: "Deutsch",
-    value: "de",
-    icon: flagDE,
-  },
+  { label: "English", value: "en", icon: flagUS },
+  { label: "Deutsch", value: "de", icon: flagDE },
 ];
 
 const handleLogout = () => {

--- a/apps/showcase/content/en/components/08.navigation/user-menu/examples/Basic.example.vue
+++ b/apps/showcase/content/en/components/08.navigation/user-menu/examples/Basic.example.vue
@@ -1,0 +1,47 @@
+<script lang="ts" setup>
+import { flagUS, flagDE } from "@sit-onyx/flags";
+import { iconLogout, iconSettings } from "@sit-onyx/icons";
+import {
+  ColorSchemeValue,
+  OnyxColorSchemeMenuItem,
+  OnyxLanguageMenuItem,
+  OnyxMenuItem,
+  OnyxUserMenu,
+  SelectDialogOption,
+} from "sit-onyx";
+import { ref } from "vue";
+
+const colorScheme = ref<ColorSchemeValue>("auto");
+const locale = ref("en");
+
+const languages: SelectDialogOption[] = [
+  {
+    label: "English",
+    value: "en",
+    icon: flagUS,
+  },
+  {
+    label: "Deutsch",
+    value: "de",
+    icon: flagDE,
+  },
+];
+
+const handleLogout = () => {
+  // your logout logic here...
+};
+</script>
+
+<template>
+  <OnyxUserMenu full-name="Jane Doe" description="Company Name">
+    <OnyxMenuItem label="Settings" :icon="iconSettings" link="/settings" />
+    <OnyxColorSchemeMenuItem v-model="colorScheme" />
+    <OnyxLanguageMenuItem v-model="locale" :options="languages" />
+    <OnyxMenuItem label="Logout" :icon="iconLogout" color="danger" @click="handleLogout" />
+
+    <template #footer>
+      App version
+      <span class="onyx-text--monospace">1.0.0</span>
+    </template>
+  </OnyxUserMenu>
+</template>

--- a/apps/showcase/content/en/components/08.navigation/user-menu/index.md
+++ b/apps/showcase/content/en/components/08.navigation/user-menu/index.md
@@ -1,0 +1,16 @@
+---
+title: User menu
+componentName: OnyxUserMenu
+---
+
+The user menu displays user-related information and actions and is intended to be used inside the [navigation bar](/components/navigation/nav-bar).
+
+## Examples
+
+### Basic
+
+Refer to the [menu item](/components/basic/menu-item) component for further information on how to customize the flyout options.
+
+<p style="color: var(--onyx-color-text-icons-info-intense)">Hover over the user menu to open the flyout with actions.</p>
+
+:component-example{name="Basic"}

--- a/apps/showcase/content/en/components/08.navigation/user-menu/index.md
+++ b/apps/showcase/content/en/components/08.navigation/user-menu/index.md
@@ -1,6 +1,7 @@
 ---
 title: User menu
 componentName: OnyxUserMenu
+navigation: false
 ---
 
 The user menu displays user-related information and actions and is intended to be used inside the [navigation bar](/components/navigation/nav-bar).

--- a/packages/nuxt-docs/app/composables/useSidebarNavigation.ts
+++ b/packages/nuxt-docs/app/composables/useSidebarNavigation.ts
@@ -98,7 +98,17 @@ export const useSidebarNavigation = async <
 
   const navigation = computed(() => {
     // support multiple sidebars / roots so different pages can have their own sub-sidebar
-    const root = findDeepestRoot(allItems.value, route.path);
+    let root = findDeepestRoot(allItems.value, route.path);
+
+    // if the current path is not found in the navigation, fall back to parent paths
+    // e.g. /components/buttons/not-found -> /components/buttons -> /components
+    if (!root) {
+      for (const path of getPathAncestors(route.path)) {
+        root = findDeepestRoot(allItems.value, path);
+        if (root) break;
+      }
+    }
+
     if (!root) return allItems.value;
     return root.children ?? [root];
   });
@@ -193,3 +203,18 @@ export const useSidebarNavigation = async <
 
   return { navigation, allItems, previousRootItem };
 };
+
+/**
+ * Returns all ancestor paths of the given path, from deepest to shallowest.
+ * e.g. "/components/buttons/icon-button"
+ * -> ["/components/buttons/icon-button", "/components/buttons", "/components", "/"]
+ */
+function getPathAncestors(path: string): string[] {
+  const segments = path.split("/").filter(Boolean).slice(0, -1);
+  const ancestors: string[] = [];
+  for (let i = segments.length; i > 0; i--) {
+    ancestors.push("/" + segments.slice(0, i).join("/"));
+  }
+  ancestors.push("/");
+  return ancestors;
+}


### PR DESCRIPTION
Relates to #6048

Add all remaining component examples for the "Navigation" category:
- segmented control
- sidebar
- table of contents
- tabs
- tree view
- timer
- color scheme menu item + color scheme dialog
- language menu item
- nav item
- nav button
- user menu

## Checklist

- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
