### PR TITLE
fix(OnyxButton): use correct border radius for skeleton

### DIFF
--- a/.changeset/strong-candies-wash.md
+++ b/.changeset/strong-candies-wash.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxButton): use correct border radius for skeleton

--- a/packages/sit-onyx/src/components/OnyxButton/OnyxButton.vue
+++ b/packages/sit-onyx/src/components/OnyxButton/OnyxButton.vue
@@ -74,6 +74,7 @@ const rippleEvents = computed(() => ripple.value?.events ?? {});
   @include layers.component() {
     --onyx-button-padding-vertical: var(--onyx-density-xs);
     --onyx-button-padding-inline: var(--onyx-density-sm);
+    --onyx-button-border-radius: var(--onyx-radius-component-button);
   }
 }
 
@@ -91,7 +92,6 @@ const rippleEvents = computed(() => ripple.value?.events ?? {});
     --onyx-button-border-color-disabled: transparent;
     --onyx-button-outline-color: var(--onyx-color-component-focus-primary);
     --onyx-button-border-width: var(--onyx-1px-in-rem);
-    --onyx-button-border-radius: var(--onyx-radius-component-button);
 
     &--primary {
       &.onyx-button--default {
@@ -243,6 +243,7 @@ const rippleEvents = computed(() => ripple.value?.events ?? {});
       height: calc(1.5rem + 2 * var(--onyx-button-padding-vertical));
       display: inline-block;
       vertical-align: middle;
+      border-radius: var(--onyx-button-border-radius);
     }
 
     .onyx-ripple {


### PR DESCRIPTION
Use same border radius variable as for the button also for the button skeleton (so its e.g. fully rounded in the lidl theme)

## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
