### PR TITLE
feat: implement basic Figma data grid plugin UI

### DIFF
--- a/packages/figma-plugin-data-grid/manifest.json
+++ b/packages/figma-plugin-data-grid/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "Onyx - DataGrid Studio",
+  "id": "1674034444595259620",
+  "api": "1.0.0",
+  "main": "./dist/plugin/index.js",
+  "ui": "dist/ui/index.html",
+  "enableProposedApi": false,
+  "documentAccess": "dynamic-page",
+  "editorType": ["figma", "dev"],
+  "capabilities": ["inspect"]
+}

--- a/packages/figma-plugin-data-grid/package.json
+++ b/packages/figma-plugin-data-grid/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@sit-onyx/figma-plugin-data-grid",
+  "version": "0.0.0",
+  "private": true,
+  "description": "This Figma plugin supports creating and editing data grid components for the Onyx Design System.",
+  "license": "Apache-2.0",
+  "author": "Schwarz Digits IT KG",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "pnpm build:ui && pnpm build:figma",
+    "build:ui": "vite build && vue-tsc -b",
+    "build:figma": "rimraf ./dist/plugin && pnpm tsc -p tsconfig.figma.json",
+    "watch": "pnpm run build --watch"
+  },
+  "dependencies": {
+    "@sit-onyx/icons": "workspace:^",
+    "sit-onyx": "workspace:^",
+    "vue": "catalog:"
+  },
+  "devDependencies": {
+    "@figma/plugin-typings": "^1.134.0",
+    "@fontsource-variable/source-code-pro": "^5.3.0",
+    "@fontsource-variable/source-sans-3": "^5.3.0",
+    "@sit-onyx/shared": "workspace:^",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vite-plugin-singlefile": "^2.3.3"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/figma-plugin-data-grid/plugin/index.ts
+++ b/packages/figma-plugin-data-grid/plugin/index.ts
@@ -25,7 +25,6 @@ async function runPlugin() {
 
 async function generateDataGrid(_message: unknown) {
   throw new Error("Not implemented yet");
-  // figma.closePlugin();
 }
 
 /**

--- a/packages/figma-plugin-data-grid/plugin/index.ts
+++ b/packages/figma-plugin-data-grid/plugin/index.ts
@@ -1,0 +1,41 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- needed for typing
+const MESSAGE_HANDLERS: Record<string, (data?: any) => Promise<void>> = {
+  "generate-data-grid": generateDataGrid,
+};
+
+runPlugin();
+
+async function runPlugin() {
+  figma.showUI(__html__, { width: 475, height: 400 });
+
+  figma.ui.onmessage = async (msg) => {
+    const handler = MESSAGE_HANDLERS[msg.type];
+    if (!handler) return;
+
+    try {
+      await handler(msg.data);
+    } catch (e) {
+      // eslint-disable-next-line no-console -- error should be logged
+      console.error(e);
+      showToast(e as Error);
+      figma.closePlugin();
+    }
+  };
+}
+
+async function generateDataGrid(_message: unknown) {
+  throw new Error("Not implemented yet");
+  // figma.closePlugin();
+}
+
+/**
+ * Shows a Figma notification / toast.
+ */
+function showToast(message: string | Error) {
+  const msg = typeof message === "string" ? message : message.message;
+
+  figma.notify(msg, {
+    timeout: 6_000,
+    error: message instanceof Error,
+  });
+}

--- a/packages/figma-plugin-data-grid/plugin/index.ts
+++ b/packages/figma-plugin-data-grid/plugin/index.ts
@@ -6,7 +6,7 @@ const MESSAGE_HANDLERS: Record<string, (data?: any) => Promise<void>> = {
 runPlugin();
 
 async function runPlugin() {
-  figma.showUI(__html__, { width: 475, height: 400 });
+  figma.showUI(__html__, { width: 720, height: 560 });
 
   figma.ui.onmessage = async (msg) => {
     const handler = MESSAGE_HANDLERS[msg.type];

--- a/packages/figma-plugin-data-grid/tsconfig.figma.json
+++ b/packages/figma-plugin-data-grid/tsconfig.figma.json
@@ -1,0 +1,13 @@
+{
+  "include": ["plugin"],
+  "compilerOptions": {
+    "rootDir": "./plugin",
+    "outDir": "./dist/plugin",
+    "target": "es6",
+    "lib": ["es6"],
+    "strict": true,
+    "declaration": false,
+    "types": ["plugin-typings"],
+    "typeRoots": ["./node_modules/@figma"]
+  }
+}

--- a/packages/figma-plugin-data-grid/tsconfig.json
+++ b/packages/figma-plugin-data-grid/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.ui.json" }, { "path": "./tsconfig.figma.json" }]
+}

--- a/packages/figma-plugin-data-grid/tsconfig.ui.json
+++ b/packages/figma-plugin-data-grid/tsconfig.ui.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["@vue/tsconfig/tsconfig.dom.json", "@sit-onyx/shared/tsconfig.json"],
+  "include": ["ui/**/*"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "./ui",
+    "lib": ["ES2022", "DOM"]
+  }
+}

--- a/packages/figma-plugin-data-grid/ui/App.vue
+++ b/packages/figma-plugin-data-grid/ui/App.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import {
+  OnyxAppLayout,
+  OnyxBottomBar,
+  OnyxButton,
+  OnyxPageLayout,
+  OnyxSegmentedControl,
+  type OnyxSegmentedControlOption,
+} from "sit-onyx";
+import { ref } from "vue";
+import ColumnsDataGrid from "./components/ColumnsDataGrid.vue";
+import { postPluginMessage } from "./composables/usePluginMessage.js";
+import type { GenerateDataGridPayload } from "./types/index.js";
+
+const isLoading = ref(false);
+
+const handleGenerate = () => {
+  isLoading.value = true;
+  postPluginMessage({
+    type: "generate-data-grid",
+    data: {},
+  });
+};
+
+const data = ref<GenerateDataGridPayload>({
+  mode: "basic",
+  columns: [],
+});
+
+const modeOptions: OnyxSegmentedControlOption<GenerateDataGridPayload["mode"]>[] = [
+  { label: "Basic", value: "basic" },
+  { label: "Advanced", value: "advanced" },
+];
+</script>
+
+<template>
+  <OnyxAppLayout>
+    <OnyxPageLayout>
+      <div class="content onyx-density-compact">
+        <OnyxSegmentedControl v-model="data.mode" :options="modeOptions" />
+
+        <ColumnsDataGrid v-model="data.columns" />
+      </div>
+
+      <template #footer>
+        <OnyxBottomBar>
+          <OnyxButton
+            label="Generate data grid"
+            type="submit"
+            :loading="isLoading"
+            @click="handleGenerate"
+          />
+        </OnyxBottomBar>
+      </template>
+    </OnyxPageLayout>
+  </OnyxAppLayout>
+</template>
+
+<style lang="scss" scoped>
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--onyx-density-xl);
+}
+
+:deep(.onyx-grid-layout) {
+  padding-block: var(--onyx-grid-margin);
+}
+</style>

--- a/packages/figma-plugin-data-grid/ui/App.vue
+++ b/packages/figma-plugin-data-grid/ui/App.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { iconToolTable } from "@sit-onyx/icons";
 import {
   OnyxAppLayout,
   OnyxBottomBar,
@@ -9,6 +10,8 @@ import {
 } from "sit-onyx";
 import { ref } from "vue";
 import ColumnsDataGrid from "./components/ColumnsDataGrid.vue";
+import ExtraSection from "./components/sections/ExtraSection.vue";
+import RowSection from "./components/sections/RowSection.vue";
 import { postPluginMessage } from "./composables/usePluginMessage.js";
 import type { GenerateDataGridPayload } from "./types/index.js";
 
@@ -24,7 +27,12 @@ const handleGenerate = () => {
 
 const data = ref<GenerateDataGridPayload>({
   mode: "basic",
-  columns: [],
+  columns: [{ headline: "Headline", type: "text" }],
+  rows: {
+    count: 5,
+    stroke: "grid",
+    style: "striped",
+  },
 });
 
 const modeOptions: OnyxSegmentedControlOption<GenerateDataGridPayload["mode"]>[] = [
@@ -40,6 +48,10 @@ const modeOptions: OnyxSegmentedControlOption<GenerateDataGridPayload["mode"]>[]
         <OnyxSegmentedControl v-model="data.mode" :options="modeOptions" />
 
         <ColumnsDataGrid v-model="data.columns" />
+
+        <RowSection v-model="data" />
+
+        <ExtraSection v-if="data.mode === 'advanced'" v-model="data" />
       </div>
 
       <template #footer>
@@ -48,6 +60,7 @@ const modeOptions: OnyxSegmentedControlOption<GenerateDataGridPayload["mode"]>[]
             label="Generate data grid"
             type="submit"
             :loading="isLoading"
+            :icon="iconToolTable"
             @click="handleGenerate"
           />
         </OnyxBottomBar>

--- a/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
+++ b/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { iconPlus, iconTrash } from "@sit-onyx/icons";
+import {
+  createFeature,
+  DataGridFeatures,
+  OnyxDataGrid,
+  OnyxIconButton,
+  type ColumnConfig,
+} from "sit-onyx";
+import { computed, h, ref } from "vue";
+import type { ColumnDefinition } from "../types/index.js";
+import { useRowActions } from "../utils/data-grid/useRowActions/useRowActions.js";
+
+type Entry = ColumnDefinition & {
+  id: number;
+};
+
+const props = defineProps<{
+  modelValue: ColumnDefinition[];
+  skeleton?: boolean;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [columns: ColumnDefinition[]];
+}>();
+
+const data = computed(() => {
+  return props.modelValue.map<Entry>((column, index) => {
+    return { ...column, id: index + 1 };
+  });
+});
+
+const columns = computed<ColumnConfig<Entry>[]>(() => {
+  return [
+    { key: "id", label: "Order", width: "max-content" },
+    { key: "headline", label: "Headline" },
+  ];
+});
+
+const withCustomTypes = createFeature(() => ({
+  name: Symbol("customTypes"),
+  actions: () => {
+    return [
+      {
+        label: "Add new column",
+        icon: iconPlus,
+        displayAs: "button",
+        color: "neutral",
+        onClick: handleAddColumn,
+      },
+    ];
+  },
+}));
+
+const editState = ref<DataGridFeatures.EditState<Entry>>({});
+
+const withEditing = DataGridFeatures.useEditing<Entry>({
+  mode: "manual",
+  editState,
+  columns: {
+    id: { enabled: false },
+  },
+});
+
+const withRowActions = useRowActions<Entry>({
+  actions: (row) => {
+    return [
+      h(OnyxIconButton, {
+        label: "Delete",
+        icon: iconTrash,
+        color: "danger",
+        onClick: handleDelete(row),
+      }),
+    ];
+  },
+});
+
+function handleAddColumn() {
+  const newColumns: ColumnDefinition[] = [...props.modelValue, { headline: "Headline" }];
+  emit("update:modelValue", newColumns);
+}
+
+function handleDelete(row: Entry) {
+  const newColumns = data.value.filter((column) => column.id !== row.id);
+  emit("update:modelValue", newColumns);
+}
+
+const features = [withCustomTypes, withEditing, withRowActions];
+</script>
+
+<template>
+  <OnyxDataGrid :headline="{ text: 'Columns', rowCount: true }" :columns :data :features />
+</template>

--- a/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
+++ b/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
@@ -34,6 +34,22 @@ const columns = computed<ColumnConfig<Entry>[]>(() => {
   return [
     { key: "id", label: "Order", width: "max-content" },
     { key: "headline", label: "Headline" },
+    {
+      key: "type",
+      label: "Typ",
+      type: {
+        name: "select",
+        options: {
+          options: [
+            { label: "Text", value: "text" },
+            { label: "Checkbox", value: "checkbox" },
+            { label: "Icon", value: "icon" },
+            { label: "System button", value: "systemButton" },
+            { label: "Tag", value: "tag" },
+          ],
+        },
+      },
+    },
   ];
 });
 
@@ -69,14 +85,17 @@ const withRowActions = useRowActions<Entry>({
         label: "Delete",
         icon: iconTrash,
         color: "danger",
-        onClick: handleDelete(row),
+        onClick: () => handleDelete(row),
       }),
     ];
   },
 });
 
 function handleAddColumn() {
-  const newColumns: ColumnDefinition[] = [...props.modelValue, { headline: "Headline" }];
+  const newColumns: ColumnDefinition[] = [
+    ...props.modelValue,
+    { headline: "Headline", type: "text" },
+  ];
   emit("update:modelValue", newColumns);
 }
 
@@ -91,3 +110,9 @@ const features = [withCustomTypes, withEditing, withRowActions];
 <template>
   <OnyxDataGrid :headline="{ text: 'Columns', rowCount: true }" :columns :data :features />
 </template>
+
+<style lang="scss" scoped>
+:deep(td) {
+  align-content: center;
+}
+</style>

--- a/packages/figma-plugin-data-grid/ui/components/SegmentedControl.vue
+++ b/packages/figma-plugin-data-grid/ui/components/SegmentedControl.vue
@@ -1,0 +1,39 @@
+<script lang="ts" setup generic="TValue extends SelectOptionValue">
+import {
+  OnyxSegmentedControl,
+  type OnyxSegmentedControlOption,
+  type SelectOptionValue,
+} from "sit-onyx";
+
+const props = defineProps<{
+  label: string;
+  options: OnyxSegmentedControlOption<TValue>[];
+}>();
+
+const value = defineModel<TValue>({ required: true });
+</script>
+
+<template>
+  <div class="wrapper">
+    <span class="label onyx-text--small">{{ props.label }}</span>
+    <OnyxSegmentedControl v-model="value" class="control" :options="props.options" />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.wrapper {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--onyx-density-lg);
+}
+
+.label {
+  color: var(--onyx-color-text-icons-neutral-medium);
+  min-width: 3rem;
+}
+
+.control {
+  flex-grow: 1;
+}
+</style>

--- a/packages/figma-plugin-data-grid/ui/components/sections/ExtraSection.vue
+++ b/packages/figma-plugin-data-grid/ui/components/sections/ExtraSection.vue
@@ -1,0 +1,43 @@
+<script lang="ts" setup>
+import { OnyxCard, OnyxHeadline, OnyxSelect, type SelectOption } from "sit-onyx";
+import type { GenerateDataGridPayload } from "../../types/index.js";
+
+const data = defineModel<GenerateDataGridPayload>({ required: true });
+
+const listLabel = "Available options";
+
+const headlineOptions = (["h1", "h2", "h3", "h4"] as const).map((headline) => {
+  return { label: headline, value: headline } satisfies SelectOption;
+});
+
+const paginationOptions = [
+  { label: "Select", value: "select" },
+  { label: "Button", value: "button" },
+] as const satisfies SelectOption[];
+</script>
+
+<template>
+  <OnyxCard>
+    <OnyxHeadline is="h3">Extra</OnyxHeadline>
+
+    <div class="onyx-grid">
+      <OnyxSelect
+        v-model="data.headline"
+        class="onyx-grid-span-4"
+        label="Headline"
+        :list-label
+        :options="headlineOptions"
+        placeholder="none"
+      />
+
+      <OnyxSelect
+        v-model="data.pagination"
+        class="onyx-grid-span-4"
+        label="Pagination"
+        :list-label
+        :options="paginationOptions"
+        placeholder="none"
+      />
+    </div>
+  </OnyxCard>
+</template>

--- a/packages/figma-plugin-data-grid/ui/components/sections/RowSection.vue
+++ b/packages/figma-plugin-data-grid/ui/components/sections/RowSection.vue
@@ -1,0 +1,53 @@
+<script lang="ts" setup>
+import { OnyxCard, OnyxHeadline, OnyxStepper, type OnyxSegmentedControlOption } from "sit-onyx";
+import type { GenerateDataGridPayload } from "../../types/index.js";
+import SegmentedControl from "../SegmentedControl.vue";
+
+const data = defineModel<GenerateDataGridPayload>({ required: true });
+
+const styleOptions = [
+  { label: "Striped", value: "striped" },
+  { label: "Flat", value: "flat" },
+] as const satisfies OnyxSegmentedControlOption[];
+
+const strokeOptions = [
+  { label: "Grid", value: "grid" },
+  { label: "Horizontal", value: "horizontal" },
+] as const satisfies OnyxSegmentedControlOption[];
+</script>
+
+<template>
+  <OnyxCard>
+    <div class="onyx-grid">
+      <div class="onyx-grid-span-4 container">
+        <OnyxHeadline is="h3">Rows</OnyxHeadline>
+
+        <div class="onyx-grid">
+          <OnyxStepper
+            v-model="data.rows.count"
+            class="onyx-grid-span-2"
+            label="Count"
+            :min="1"
+            :precision="0"
+            required
+          />
+        </div>
+      </div>
+
+      <div v-if="data.mode === 'advanced'" class="onyx-grid-span-4 container">
+        <OnyxHeadline is="h3">Appearance</OnyxHeadline>
+        <SegmentedControl v-model="data.rows.style" label="Style" :options="styleOptions" />
+        <SegmentedControl v-model="data.rows.stroke" label="Stroke" :options="strokeOptions" />
+      </div>
+    </div>
+  </OnyxCard>
+</template>
+
+<style lang="scss" scoped>
+.container {
+  container-type: inline-size;
+  display: flex;
+  flex-direction: column;
+  gap: var(--onyx-density-sm);
+}
+</style>

--- a/packages/figma-plugin-data-grid/ui/composables/usePluginMessage.ts
+++ b/packages/figma-plugin-data-grid/ui/composables/usePluginMessage.ts
@@ -1,0 +1,32 @@
+import { onMounted, onUnmounted } from "vue";
+
+export type UsePluginMessageOptions<T> = {
+  type: string;
+  onMessage: (data: T) => void;
+};
+
+export type PostPluginMessageOptions = {
+  type: string;
+  data?: unknown;
+};
+
+/**
+ * Composable for listening to a specific plugin message
+ */
+export const usePluginMessage = <T>(options: UsePluginMessageOptions<T>) => {
+  const listener = (event: MessageEvent) => {
+    const message = event.data.pluginMessage;
+    if (message?.type !== options.type) return;
+    options.onMessage(message.data);
+  };
+
+  onMounted(() => window.addEventListener("message", listener));
+  onUnmounted(() => window.removeEventListener("message", listener));
+};
+
+/**
+ * Sends a message to the Figma plugin.
+ */
+export function postPluginMessage(options: PostPluginMessageOptions) {
+  parent.postMessage({ pluginMessage: { type: options.type, data: options.data } }, "*");
+}

--- a/packages/figma-plugin-data-grid/ui/env.d.ts
+++ b/packages/figma-plugin-data-grid/ui/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/figma-plugin-data-grid/ui/index.html
+++ b/packages/figma-plugin-data-grid/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UI</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/main.ts"></script>
+  </body>
+</html>

--- a/packages/figma-plugin-data-grid/ui/main.ts
+++ b/packages/figma-plugin-data-grid/ui/main.ts
@@ -1,0 +1,8 @@
+import "@fontsource-variable/source-code-pro/index.css";
+import "@fontsource-variable/source-sans-3/index.css";
+import "sit-onyx/global.css";
+import "sit-onyx/style.css";
+import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");

--- a/packages/figma-plugin-data-grid/ui/types/index.ts
+++ b/packages/figma-plugin-data-grid/ui/types/index.ts
@@ -1,0 +1,8 @@
+export type GenerateDataGridPayload = {
+  mode: "basic" | "advanced";
+  columns: ColumnDefinition[];
+};
+
+export type ColumnDefinition = {
+  headline: string;
+};

--- a/packages/figma-plugin-data-grid/ui/types/index.ts
+++ b/packages/figma-plugin-data-grid/ui/types/index.ts
@@ -1,8 +1,22 @@
+import type { HeadlineType } from "sit-onyx";
+
 export type GenerateDataGridPayload = {
   mode: "basic" | "advanced";
   columns: ColumnDefinition[];
+  rows: RowDefinition;
+  headline?: Exclude<HeadlineType, "h5" | "h6">;
+  pagination?: "select" | "button";
 };
 
 export type ColumnDefinition = {
   headline: string;
+  type: ColumnType;
+};
+
+export type ColumnType = "text" | "checkbox" | "icon" | "systemButton" | "tag";
+
+export type RowDefinition = {
+  count: number;
+  style: "flat" | "striped";
+  stroke: "horizontal" | "grid";
 };

--- a/packages/figma-plugin-data-grid/ui/utils/data-grid/useRowActions/useRowActions.scss
+++ b/packages/figma-plugin-data-grid/ui/utils/data-grid/useRowActions/useRowActions.scss
@@ -1,0 +1,8 @@
+.onyx-data-grid {
+  .onyx-data-grid-row-actions-cell {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--onyx-density-2xs);
+  }
+}

--- a/packages/figma-plugin-data-grid/ui/utils/data-grid/useRowActions/useRowActions.ts
+++ b/packages/figma-plugin-data-grid/ui/utils/data-grid/useRowActions/useRowActions.ts
@@ -1,0 +1,55 @@
+import {
+  createFeature,
+  DataGridFeatures,
+  type DataGridEntry,
+  type DataGridFeature,
+  type DataGridFeatureContext,
+} from "sit-onyx";
+import { h, type VNode } from "vue";
+import "./useRowActions.scss";
+
+export type UseRowActionsOptions<TEntry extends DataGridEntry> = {
+  actions: (row: TEntry, ctx: DataGridFeatureContext) => VNode[];
+};
+
+const ACTION_COLUMN_KEY = Symbol();
+const ACTION_COLUMN_TYPE = Symbol();
+
+/**
+ * Re-usable onyx data grid feature for adding an action column to each row.
+ */
+export const useRowActions = <TEntry extends DataGridEntry>(
+  options: UseRowActionsOptions<TEntry>,
+) => {
+  return createFeature((ctx) => ({
+    name: Symbol("rowActions"),
+    modifyColumns: {
+      order: Number.MAX_SAFE_INTEGER, // ensure actions are added as last column
+      func: (columns) => {
+        return [
+          ...columns,
+          {
+            key: ACTION_COLUMN_KEY,
+            label: "Actions",
+            type: { name: ACTION_COLUMN_TYPE },
+            width: "max-content",
+          },
+        ];
+      },
+    },
+    typeRenderer: {
+      [ACTION_COLUMN_TYPE]: DataGridFeatures.createTypeRenderer<object, TEntry>({
+        cell: {
+          component: ({ row }) => {
+            const actions = options.actions(row, ctx);
+            return h(
+              "div",
+              { class: ["onyx-data-grid-row-actions-cell", "onyx-density-compact"] },
+              actions,
+            );
+          },
+        },
+      }),
+    },
+  })) as DataGridFeature<TEntry>;
+};

--- a/packages/figma-plugin-data-grid/ui/utils/data-grid/useRowActions/useRowActions.ts
+++ b/packages/figma-plugin-data-grid/ui/utils/data-grid/useRowActions/useRowActions.ts
@@ -12,8 +12,8 @@ export type UseRowActionsOptions<TEntry extends DataGridEntry> = {
   actions: (row: TEntry, ctx: DataGridFeatureContext) => VNode[];
 };
 
-const ACTION_COLUMN_KEY = Symbol();
-const ACTION_COLUMN_TYPE = Symbol();
+const ACTION_COLUMN_KEY = Symbol("ActionColumn");
+const ACTION_COLUMN_TYPE = Symbol("ActionColumnType");
 
 /**
  * Re-usable onyx data grid feature for adding an action column to each row.

--- a/packages/figma-plugin-data-grid/vite.config.ts
+++ b/packages/figma-plugin-data-grid/vite.config.ts
@@ -1,0 +1,17 @@
+import vue from "@vitejs/plugin-vue";
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+
+// https://vite.dev/config/
+export default defineConfig({
+  root: "ui",
+  plugins: [
+    vue(),
+    // Figma Plugins expect the whole UI to be in a single file so we use a Vite plugin to achieve this
+    viteSingleFile(),
+  ],
+  build: {
+    outDir: "../dist/ui",
+    emptyOutDir: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,6 +474,40 @@ importers:
         specifier: ^10.4.1
         version: 10.4.1(eslint@10.9.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
 
+  packages/figma-plugin-data-grid:
+    dependencies:
+      '@sit-onyx/icons':
+        specifier: workspace:^
+        version: link:../icons
+      sit-onyx:
+        specifier: workspace:^
+        version: link:../sit-onyx
+      vue:
+        specifier: 3.5.41
+        version: 3.5.41(typescript@6.0.3)
+    devDependencies:
+      '@figma/plugin-typings':
+        specifier: ^1.134.0
+        version: 1.134.0
+      '@fontsource-variable/source-code-pro':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource-variable/source-sans-3':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@sit-onyx/shared':
+        specifier: workspace:^
+        version: link:../shared
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vite:
+        specifier: 8.2.2
+        version: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      vite-plugin-singlefile:
+        specifier: ^2.3.3
+        version: 2.3.3(rollup@4.62.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+
   packages/figma-plugin-sync-icons:
     dependencies:
       '@sit-onyx/icons':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,7 +488,7 @@ importers:
     devDependencies:
       '@figma/plugin-typings':
         specifier: ^1.134.0
-        version: 1.134.0
+        version: 1.135.0
       '@fontsource-variable/source-code-pro':
         specifier: ^5.3.0
         version: 5.3.0


### PR DESCRIPTION
Relates to #6034

Implement the basic UI for the Figma data grid plugin (without generation logic yet). Column re-ordering and settings for column width will be implemented in a separate PR.
<img width="736" height="615" alt="Bildschirmfoto 2026-08-26 um 13 21 30" src="https://github.com/user-attachments/assets/fbe1ef3c-9a91-470a-bc5f-5c978b1b91d4" />

## Checklist

- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
