### PR TITLE
feat(OnyxDataGrid): support headless mode for row and column rearrange feature

### DIFF
--- a/.changeset/sunny-eyes-fold.md
+++ b/.changeset/sunny-eyes-fold.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat(OnyxDataGrid): support headless mode for row and column rearrange feature

--- a/apps/showcase/content/en/components/05.data/data-grid/index.md
+++ b/apps/showcase/content/en/components/05.data/data-grid/index.md
@@ -330,13 +330,13 @@ When the user has a selection inside the row (e.g. marked text to copy), the cli
 
 ### Rearrange rows
 
-Allows the user to rearrange the order of rows using drag-and-drop. Technically, the rearrange state contains a map of changed row IDs and their corresponding new order (starting from 1 for the first row).
+Allows the user to rearrange the order of rows using drag-and-drop. Technically, the rearrange state contains a map of changed row IDs and their corresponding new order (starting from 1 for the first row). The global action buttons can also be overridden when custom triggers are used to active the rearrange mode.
 
 :component-example{name="RearrangeRows" layout="fullWidth"}
 
 ### Rearrange columns
 
-Allows the user to rearrange the order of columns using drag-and-drop. Technically, the rearrange state contains a map of changed column keys and their corresponding new order (starting from 1 for the first column).
+Allows the user to rearrange the order of columns using drag-and-drop. Technically, the rearrange state contains a map of changed column keys and their corresponding new order (starting from 1 for the first column). The global action buttons can also be overridden when custom triggers are used to active the rearrange mode.
 
 :component-example{name="RearrangeColumns" layout="fullWidth"}
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/TestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/TestCase.ct.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import OnyxDataGrid from "../../OnyxDataGrid.vue";
 import type { ColumnRearrangeState } from "../all.js";
 import type { ColumnConfig } from "../index.js";
@@ -12,6 +12,10 @@ type TEntry = {
   birthday: Date;
   isActive?: boolean;
 };
+
+const props = defineProps<{
+  headless?: boolean;
+}>();
 
 const emit = defineEmits<{
   "update:state": [order: Record<string, number>];
@@ -42,7 +46,10 @@ watch(
   { deep: true },
 );
 
-const withColumnRearrange = useColumnRearrange<TEntry>({ state });
+const withColumnRearrange = useColumnRearrange<TEntry>({
+  state,
+  headless: computed(() => props.headless),
+});
 const features = [withColumnRearrange];
 </script>
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/columnRearrange.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/columnRearrange.ct.tsx
@@ -215,3 +215,18 @@ test("should support save button", async ({ mount, page }) => {
   expect(state).toStrictEqual({ isActive: 2 });
   await expect(rearrangeButton).toBeVisible();
 });
+
+test("should support headless mode", async ({ mount }) => {
+  // ARRANGE
+  const component = await mount(TestCase);
+  const rearrangeButton = component.getByRole("button", { name: "Rearrange columns" });
+
+  // ASSERT
+  await expect(rearrangeButton).toBeVisible();
+
+  // ACT
+  await component.update({ props: { headless: true } });
+
+  // ASSERT
+  await expect(rearrangeButton).toBeHidden();
+});

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/columnRearrange.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/columnRearrange.ts
@@ -185,7 +185,7 @@ export const useColumnRearrange = <TEntry extends DataGridEntry = DataGridEntry>
           },
       },
       actions: () => {
-        if (!isEnabled.value) return [];
+        if (!isEnabled.value || options?.headless) return [];
 
         if (state.value.active) {
           const group: DataGridActionGroup = {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/columnRearrange.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/columnRearrange.ts
@@ -30,6 +30,8 @@ export const useColumnRearrange = <TEntry extends DataGridEntry = DataGridEntry>
       options?.state ?? { active: false, order: new Map() },
     ) as Ref<ColumnRearrangeState>;
 
+    const isHeadless = computed(() => toValue(options?.headless) ?? false);
+
     const draggedColumn = shallowRef<{ key: PropertyKey; th: HTMLElement | null }>();
     const targetOrder = ref<number>();
     const isHandleClicked = ref(false);
@@ -117,7 +119,7 @@ export const useColumnRearrange = <TEntry extends DataGridEntry = DataGridEntry>
 
     return {
       name: COLUMN_REARRANGE_FEATURE,
-      watch: [isEnabled, state, targetOrder, draggedColumn],
+      watch: [isEnabled, state, targetOrder, draggedColumn, isHeadless],
       modifyColumns: {
         func: (columns) => {
           if (!isEnabled.value) return columns;
@@ -185,7 +187,7 @@ export const useColumnRearrange = <TEntry extends DataGridEntry = DataGridEntry>
           },
       },
       actions: () => {
-        if (!isEnabled.value || options?.headless) return [];
+        if (!isEnabled.value || isHeadless.value) return [];
 
         if (state.value.active) {
           const group: DataGridActionGroup = {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/types.ts
@@ -24,4 +24,9 @@ export type ColumnRearrangeOptions = {
    * The current column rearrange state.
    */
   state?: Ref<ColumnRearrangeState>;
+  /**
+   * Whether to hide all default UI actions to activate the rearrange mode.
+   * Useful when custom triggers are used. You must set the `state` manually then.
+   */
+  headless?: boolean;
 };

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/types.ts
@@ -1,4 +1,4 @@
-import type { MaybeRefOrGetter, Ref } from "vue";
+import type { MaybeRef, MaybeRefOrGetter, Ref } from "vue";
 
 export type ColumnRearrangeState = {
   /**
@@ -28,5 +28,5 @@ export type ColumnRearrangeOptions = {
    * Whether to hide all default UI actions to activate the rearrange mode.
    * Useful when custom triggers are used. You must set the `state` manually then.
    */
-  headless?: boolean;
+  headless?: MaybeRef<boolean>;
 };

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/TestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/TestCase.ct.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import OnyxDataGrid from "../../OnyxDataGrid.vue";
 import type { ColumnConfig } from "../index.js";
 import { useRowRearrange } from "./rowRearrange.js";
@@ -10,6 +10,10 @@ type TEntry = {
   name: string;
   age: number;
 };
+
+const props = defineProps<{
+  headless?: boolean;
+}>();
 
 const emit = defineEmits<{
   "update:state": [order: Record<number, number>];
@@ -37,7 +41,10 @@ watch(
   { deep: true },
 );
 
-const withRowRearrange = useRowRearrange<TEntry>({ state });
+const withRowRearrange = useRowRearrange<TEntry>({
+  state,
+  headless: computed(() => props.headless),
+});
 const features = [withRowRearrange];
 </script>
 

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/rowRearrange.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/rowRearrange.ct.tsx
@@ -239,3 +239,18 @@ test("should support save button", async ({ mount, page }) => {
   expect(state).toStrictEqual({ 4: 2 });
   await expect(rearrangeButton).toBeVisible();
 });
+
+test("should support headless mode", async ({ mount }) => {
+  // ARRANGE
+  const component = await mount(TestCase);
+  const rearrangeButton = component.getByRole("button", { name: "Rearrange rows" });
+
+  // ASSERT
+  await expect(rearrangeButton).toBeVisible();
+
+  // ACT
+  await component.update({ props: { headless: true } });
+
+  // ASSERT
+  await expect(rearrangeButton).toBeHidden();
+});

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/rowRearrange.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/rowRearrange.ts
@@ -42,6 +42,7 @@ export const useRowRearrange = <TEntry extends DataGridEntry>(
     const state = toRef(options?.state ?? { active: false, order: new Map() }) as Ref<
       RowRearrangeState<TEntry>
     >;
+    const isHeadless = computed(() => toValue(options?.headless) ?? false);
 
     /**
      * ID of the row currently being dragged.
@@ -136,7 +137,7 @@ export const useRowRearrange = <TEntry extends DataGridEntry>(
 
     return {
       name: ROW_REARRANGE_FEATURE,
-      watch: [isEnabled, state, targetOrder],
+      watch: [isEnabled, state, targetOrder, isHeadless],
       mutation: {
         order: Number.MIN_SAFE_INTEGER,
         func: (entries) => {
@@ -145,7 +146,7 @@ export const useRowRearrange = <TEntry extends DataGridEntry>(
         },
       },
       actions: () => {
-        if (!isEnabled.value || options?.headless) return [];
+        if (!isEnabled.value || isHeadless.value) return [];
 
         if (state.value.active) {
           const group: DataGridActionGroup = {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/rowRearrange.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/rowRearrange.ts
@@ -145,7 +145,7 @@ export const useRowRearrange = <TEntry extends DataGridEntry>(
         },
       },
       actions: () => {
-        if (!isEnabled.value) return [];
+        if (!isEnabled.value || options?.headless) return [];
 
         if (state.value.active) {
           const group: DataGridActionGroup = {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/types.ts
@@ -12,6 +12,11 @@ export type RowRearrangeOptions<TEntry extends DataGridEntry> = {
    * The current row rearrange state.
    */
   state?: Ref<RowRearrangeState<TEntry>>;
+  /**
+   * Whether to hide all default UI actions to activate the rearrange mode.
+   * Useful when custom triggers are used. You must set the `state` manually then.
+   */
+  headless?: boolean;
 };
 
 export type RowRearrangeState<TEntry extends DataGridEntry> = {

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/types.ts
@@ -16,7 +16,7 @@ export type RowRearrangeOptions<TEntry extends DataGridEntry> = {
    * Whether to hide all default UI actions to activate the rearrange mode.
    * Useful when custom triggers are used. You must set the `state` manually then.
    */
-  headless?: boolean;
+  headless?: MaybeRef<boolean>;
 };
 
 export type RowRearrangeState<TEntry extends DataGridEntry> = {


### PR DESCRIPTION
Relates to #6034

Support a new headless mode for the row and column rearrange mode of the data grid. When headless, there are no buttons displayed to activate, cancel, undo or save the rearrange mode so custom triggers can be used. This is e.g. needed for our Figma data grid plugin (see #6034) where the row rearrange is always active

## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
- [x] All relevant changes are documented in the documentation app (folder `apps/docs`) if needed
