### PR TITLE
fix(OnyxFileUpload): prevent upload being invalid even when files are selected

### DIFF
--- a/.changeset/strict-ads-visit.md
+++ b/.changeset/strict-ads-visit.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxFileUpload): prevent upload being invalid even when files are selected

--- a/packages/sit-onyx/src/components/OnyxFileUpload/FormTestCase.ct.vue
+++ b/packages/sit-onyx/src/components/OnyxFileUpload/FormTestCase.ct.vue
@@ -1,0 +1,16 @@
+<script lang="ts" setup>
+import OnyxButton from "../OnyxButton/OnyxButton.vue";
+import OnyxForm from "../OnyxForm/OnyxForm.vue";
+import OnyxFileUpload from "./OnyxFileUpload.vue";
+
+const emit = defineEmits<{
+  formSubmit: [];
+}>();
+</script>
+
+<template>
+  <OnyxForm @submit.prevent="emit('formSubmit')">
+    <OnyxFileUpload required show-error />,
+    <OnyxButton label="Submit" type="submit" />
+  </OnyxForm>
+</template>

--- a/packages/sit-onyx/src/components/OnyxFileUpload/OnyxFileUpload.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxFileUpload/OnyxFileUpload.ct.tsx
@@ -4,6 +4,7 @@ import { DENSITIES } from "../../composables/density.js";
 import { expect, test } from "../../playwright/a11y.js";
 import { executeMatrixScreenshotTest } from "../../playwright/screenshots.js";
 import type { Nullable } from "../../types/utils.js";
+import FormTestCase from "./FormTestCase.ct.vue";
 import OnyxFileUpload from "./OnyxFileUpload.vue";
 import type { FileUploadSize } from "./types.js";
 const hooks: MatrixScreenshotTestOptions["hooks"] = {
@@ -300,9 +301,10 @@ test("should have hide button", async ({ mount, page }) => {
 
 test("should show required error message", async ({ mount, page }) => {
   // ARRANGE
-  const component = await mount(
-    <OnyxFileUpload required showError style={{ padding: "1rem", width: "32rem" }} />,
-  );
+  let submitted = false;
+  const onSubmit = () => (submitted = true);
+
+  const component = await mount(<FormTestCase onFormSubmit={onSubmit} />);
 
   const button = component.getByRole("button", { name: "Click to select" });
   const errorMessage = component.getByText("You need to upload at least one file").first();
@@ -315,4 +317,10 @@ test("should show required error message", async ({ mount, page }) => {
 
   // ASSERT
   await expect(errorMessage).toBeHidden();
+
+  // ACT
+  await component.getByRole("button", { name: "Submit" }).click();
+
+  // ASSERT
+  await expect(() => expect(submitted).toBe(true)).toPass();
 });

--- a/packages/sit-onyx/src/components/OnyxFileUpload/OnyxFileUpload.ct.tsx
+++ b/packages/sit-onyx/src/components/OnyxFileUpload/OnyxFileUpload.ct.tsx
@@ -1,5 +1,9 @@
 import type { Locator, Page } from "@playwright/test";
-import type { MatrixScreenshotTestOptions } from "@sit-onyx/playwright-utils";
+import {
+  createEmitSpy,
+  expectEmit,
+  type MatrixScreenshotTestOptions,
+} from "@sit-onyx/playwright-utils";
 import { DENSITIES } from "../../composables/density.js";
 import { expect, test } from "../../playwright/a11y.js";
 import { executeMatrixScreenshotTest } from "../../playwright/screenshots.js";
@@ -301,9 +305,7 @@ test("should have hide button", async ({ mount, page }) => {
 
 test("should show required error message", async ({ mount, page }) => {
   // ARRANGE
-  let submitted = false;
-  const onSubmit = () => (submitted = true);
-
+  const onSubmit = createEmitSpy<typeof FormTestCase, "onFormSubmit">();
   const component = await mount(<FormTestCase onFormSubmit={onSubmit} />);
 
   const button = component.getByRole("button", { name: "Click to select" });
@@ -322,5 +324,5 @@ test("should show required error message", async ({ mount, page }) => {
   await component.getByRole("button", { name: "Submit" }).click();
 
   // ASSERT
-  await expect(() => expect(submitted).toBe(true)).toPass();
+  await expectEmit(onSubmit, 1, []);
 });

--- a/packages/sit-onyx/src/components/OnyxFileUpload/OnyxFileUpload.vue
+++ b/packages/sit-onyx/src/components/OnyxFileUpload/OnyxFileUpload.vue
@@ -320,7 +320,14 @@ const shouldShowFileList = computed(() => {
           <input
             ref="input"
             v-custom-validity
-            v-bind="mergeVueProps(restAttrs, inputProps)"
+            v-bind="
+              mergeVueProps(restAttrs, {
+                ...inputProps,
+                // we must NOT define required on the input here since this does not work
+                // with our validation and will make the input invalid even if files are selected
+                required: undefined,
+              })
+            "
             aria-hidden="true"
             tabindex="-1"
             class="onyx-file-upload__input"


### PR DESCRIPTION
Relates to #6108

In #5884, we introduced a bug to the file upload that still considers a required upload invalid, even if files are selected. Unfortunately, our test cases didn't cover this issue. This PR fixes the issue and updates the test to ensure the correct behavior

## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
