### PR TITLE
fix(nuxt-docs): implement custom scroll behavior

### DIFF
--- a/.changeset/fresh-needles-follow.md
+++ b/.changeset/fresh-needles-follow.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt": minor
+---
+
+feat: implement `useOnyxScrollBehavior` that can be used to correctly scroll to anchors on initial page load and scroll to the top of the page when navigating to a new page

--- a/.changeset/tricky-books-enter.md
+++ b/.changeset/tricky-books-enter.md
@@ -1,0 +1,5 @@
+---
+"@sit-onyx/nuxt-docs": minor
+---
+
+feat: use scroll behavior to correctly scroll to anchors on initial page load and scroll to the top of the page when navigating to a new page

--- a/packages/nuxt-docs/app/app.vue
+++ b/packages/nuxt-docs/app/app.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import { useScrollBehavior } from "./composables/useScrollBehavior.js";
-
 defineSlots<{
   /**
    * Page content. Can e.g. be used to display a custom error page inside `error.vue`.

--- a/packages/nuxt-docs/app/app.vue
+++ b/packages/nuxt-docs/app/app.vue
@@ -1,5 +1,19 @@
+<script lang="ts" setup>
+import { useScrollBehavior } from "./composables/useScrollBehavior.js";
+
+defineSlots<{
+  /**
+   * Page content. Can e.g. be used to display a custom error page inside `error.vue`.
+   */
+  default?(): unknown;
+}>();
+
+const app = useTemplateRef("app");
+useScrollBehavior({ root: app });
+</script>
+
 <template>
-  <OnyxAppLayout class="onyx-grid-max-lg onyx-grid-center">
+  <OnyxAppLayout ref="app" class="onyx-grid-max-lg onyx-grid-center">
     <template #navBar>
       <NavBar />
     </template>
@@ -11,7 +25,5 @@
         <NuxtPage />
       </slot>
     </NuxtLayout>
-
-    <OnyxToast />
   </OnyxAppLayout>
 </template>

--- a/packages/nuxt-docs/app/app.vue
+++ b/packages/nuxt-docs/app/app.vue
@@ -7,7 +7,7 @@ defineSlots<{
 }>();
 
 const app = useTemplateRef("app");
-useScrollBehavior({ root: app });
+useOnyxScrollBehavior({ root: app });
 </script>
 
 <template>

--- a/packages/nuxt-docs/app/composables/useScrollBehavior.ts
+++ b/packages/nuxt-docs/app/composables/useScrollBehavior.ts
@@ -1,0 +1,40 @@
+import type { ShallowRef } from "vue";
+import { computed, toValue, useRoute, useRuntimeHook } from "#imports";
+
+export type UseScrollBehaviorOptions = {
+  /**
+   * Template ref to the application's root element (typically the `<OnyxAppLayout>` component).
+   */
+  root: ShallowRef<Element | { $el?: Element | null } | null>;
+};
+
+/**
+ * Composable for applying router scroll behavior.
+ * Note: The default Vue Router scroll behavior does not work for because onyx uses
+ * a different scroll container (.onyx-page__main) instead of the html/body element.
+ */
+export const useScrollBehavior = (options: UseScrollBehaviorOptions) => {
+  const route = useRoute();
+  const element = computed<Element | null>(() => {
+    const root = toValue(options.root);
+    if (!root) return null;
+    return root instanceof Element ? root : (root.$el ?? null);
+  });
+
+  useRuntimeHook("page:finish", () => {
+    const scrollContainer = element.value?.querySelector(".onyx-page__main");
+    if (!scrollContainer) return;
+
+    // to avoid too much visual motion when switching pages or on initial page load when scrolling to an anchor
+    // we use "instant" scroll behavior here
+    const behavior: ScrollBehavior = "instant";
+
+    // support scroll to anchors (e.g. headlines)
+    const hashElement = route.hash ? scrollContainer.querySelector(route.hash) : undefined;
+    if (hashElement) {
+      return hashElement.scrollIntoView({ block: "start", behavior });
+    }
+
+    scrollContainer.scrollTo({ left: 0, top: 0, behavior });
+  });
+};

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,5 +1,12 @@
 import { stat } from "node:fs/promises";
-import { addComponent, addPlugin, createResolver, defineNuxtModule, useLogger } from "@nuxt/kit";
+import {
+  addComponent,
+  addImportsDir,
+  addPlugin,
+  createResolver,
+  defineNuxtModule,
+  useLogger,
+} from "@nuxt/kit";
 import type { NuxtOptions } from "@nuxt/schema";
 import type { ModuleHooks as NuxtI18nModuleHooks } from "@nuxtjs/i18n";
 import * as onyx from "sit-onyx";
@@ -96,6 +103,8 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     addPlugin({ src: resolve("./runtime/plugins/onyx") });
+
+    addImportsDir([resolve("./runtime/composables")]);
   },
 });
 

--- a/packages/nuxt/src/runtime/composables/scrollBehavior.ts
+++ b/packages/nuxt/src/runtime/composables/scrollBehavior.ts
@@ -1,7 +1,7 @@
 import type { ShallowRef } from "vue";
 import { computed, toValue, useRoute, useRuntimeHook } from "#imports";
 
-export type UseScrollBehaviorOptions = {
+export type UseOnyxScrollBehaviorOptions = {
   /**
    * Template ref to the application's root element (typically the `<OnyxAppLayout>` component).
    */
@@ -9,11 +9,11 @@ export type UseScrollBehaviorOptions = {
 };
 
 /**
- * Composable for applying router scroll behavior.
+ * Composable for applying router scroll behavior when using the onyx design system.
  * Note: The default Vue Router scroll behavior does not work for because onyx uses
  * a different scroll container (.onyx-page__main) instead of the html/body element.
  */
-export const useScrollBehavior = (options: UseScrollBehaviorOptions) => {
+export const useOnyxScrollBehavior = (options: UseOnyxScrollBehaviorOptions) => {
   const route = useRoute();
   const element = computed<Element | null>(() => {
     const root = toValue(options.root);


### PR DESCRIPTION
Our showcase / the Nuxt documentation template does not handle scroll behavior correctly. Since onyx uses a custom scroll container inside OnyxAppLayout, the default Vue Router scroll behavior does not work. Therefore, opening a page with a hash (e.g. https://onyx-showcase-dev.apps.01.cf.eu01.stackit.cloud/introduction/foundation/colors#usage) does not scroll to the correct position and when navigating to another page, the page scroll position is kept and not scrolled correctly to the top of the new page.

This PR fixes this by implementing a custom scroll behavior tailored to the OnyxAppLayout.

Note: The scrolling does currently NOT work for our component example pages since the OnyxTags component is not SSR compatible (the content does only render after mounted). A follow up is created for this: #6106
 
## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
