### PR TITLE
feat(figma-plugin-data-grid): implement rearrange and column width

### DIFF
--- a/.changeset/eight-seas-think.md
+++ b/.changeset/eight-seas-think.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": minor
+---
+
+feat: expose `applyArrayOrder` utility that can e.g. be useful to apply data grid rearrange rows/columns state

--- a/packages/figma-plugin-data-grid/package.json
+++ b/packages/figma-plugin-data-grid/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@sit-onyx/icons": "workspace:^",
+    "nanoid": "^6.0.1",
     "sit-onyx": "workspace:^",
     "vue": "catalog:"
   },

--- a/packages/figma-plugin-data-grid/plugin/index.ts
+++ b/packages/figma-plugin-data-grid/plugin/index.ts
@@ -6,7 +6,8 @@ const MESSAGE_HANDLERS: Record<string, (data?: any) => Promise<void>> = {
 runPlugin();
 
 async function runPlugin() {
-  figma.showUI(__html__, { width: 720, height: 560 });
+  // width = "sm" breakpoint - 1
+  figma.showUI(__html__, { width: 768, height: 560 });
 
   figma.ui.onmessage = async (msg) => {
     const handler = MESSAGE_HANDLERS[msg.type];

--- a/packages/figma-plugin-data-grid/ui/App.vue
+++ b/packages/figma-plugin-data-grid/ui/App.vue
@@ -48,7 +48,7 @@ const modeOptions: OnyxSegmentedControlOption<GenerateDataGridPayload["mode"]>[]
       <div class="content onyx-density-compact">
         <OnyxSegmentedControl v-model="data.mode" :options="modeOptions" />
 
-        <ColumnsDataGrid v-model="data.columns" />
+        <ColumnsDataGrid v-model="data.columns" :mode="data.mode" />
 
         <RowSection v-model="data" />
 

--- a/packages/figma-plugin-data-grid/ui/App.vue
+++ b/packages/figma-plugin-data-grid/ui/App.vue
@@ -14,6 +14,7 @@ import ExtraSection from "./components/sections/ExtraSection.vue";
 import RowSection from "./components/sections/RowSection.vue";
 import { postPluginMessage } from "./composables/usePluginMessage.js";
 import type { GenerateDataGridPayload } from "./types/index.js";
+import { getDefaultColumnDefinition } from "./utils/misc.js";
 
 const isLoading = ref(false);
 
@@ -27,7 +28,7 @@ const handleGenerate = () => {
 
 const data = ref<GenerateDataGridPayload>({
   mode: "basic",
-  columns: [{ headline: "Headline", type: "text" }],
+  columns: [getDefaultColumnDefinition()],
   rows: {
     count: 5,
     stroke: "grid",

--- a/packages/figma-plugin-data-grid/ui/components/ColumnWidthFormElement.vue
+++ b/packages/figma-plugin-data-grid/ui/components/ColumnWidthFormElement.vue
@@ -1,0 +1,91 @@
+<script lang="ts" setup>
+import {
+  OnyxSegmentedControl,
+  OnyxStepper,
+  OnyxUnstableDataGridFormElementWrapper,
+  type OnyxSegmentedControlOption,
+  type OnyxStepperProps,
+} from "sit-onyx";
+import { computed } from "vue";
+import type { ColumnDefinition } from "../types/index.js";
+
+const props = defineProps<{
+  modelValue: ColumnDefinition["width"];
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: ColumnDefinition["width"]];
+}>();
+
+const options: OnyxSegmentedControlOption[] = [
+  { label: "hug", value: "hug" },
+  { label: "auto", value: "auto" },
+  { label: "fixed", value: "fixed" },
+];
+
+const segmentedControlValue = computed({
+  get: () => {
+    if (typeof props.modelValue === "number") return "fixed";
+    return props.modelValue;
+  },
+  set: (newValue) => {
+    const value = newValue === "fixed" ? 180 : newValue;
+    emit("update:modelValue", value);
+  },
+});
+
+const stepperValue = computed({
+  get: () => {
+    if (typeof props.modelValue === "number" && !isNaN(props.modelValue)) return props.modelValue;
+    return undefined;
+  },
+  set: (newValue) => {
+    emit("update:modelValue", newValue || "auto");
+  },
+});
+
+const stepperProps = {
+  hideButtons: true,
+  precision: 0,
+  min: 1,
+  formatNumber: (value) => `${value}px`,
+} satisfies Partial<OnyxStepperProps>;
+</script>
+
+<template>
+  <div class="wrapper">
+    <OnyxSegmentedControl v-model="segmentedControlValue" class="segmented-control" :options />
+
+    <OnyxUnstableDataGridFormElementWrapper
+      :is="OnyxStepper"
+      v-bind="stepperProps"
+      v-model="stepperValue"
+      :class="['stepper', { 'stepper--hidden': segmentedControlValue !== 'fixed' }]"
+      label="Width"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.wrapper {
+  padding-block: var(--onyx-table-padding-block);
+  display: flex;
+  align-items: center;
+  gap: var(--onyx-density-md);
+}
+
+.segmented-control {
+  flex-grow: 1;
+  flex-shrink: 0;
+}
+
+.stepper {
+  // fit 4-digit number + "px" suffix
+  --onyx-form-element-v2-input-width: 6ch;
+
+  // we only visually hide the stepper but preserve its width so the layout does not jump
+  &--hidden {
+    visibility: hidden;
+  }
+}
+</style>

--- a/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
+++ b/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
@@ -1,19 +1,21 @@
 <script setup lang="ts">
 import { iconPlus, iconTrash } from "@sit-onyx/icons";
 import {
+  applyArrayOrder,
   createFeature,
   DataGridFeatures,
   OnyxDataGrid,
   OnyxIconButton,
   type ColumnConfig,
+  type ColumnGroupConfig,
+  type ColumnTypesFromFeatures,
 } from "sit-onyx";
-import { computed, h, ref } from "vue";
+import { computed, h, ref, watch } from "vue";
 import type { ColumnDefinition } from "../types/index.js";
 import { useRowActions } from "../utils/data-grid/useRowActions/useRowActions.js";
+import { getDefaultColumnDefinition } from "../utils/misc.js";
 
-type Entry = ColumnDefinition & {
-  id: number;
-};
+type CustomColumnTypes = ColumnTypesFromFeatures<[typeof withCustomTypes]>;
 
 const props = defineProps<{
   modelValue: ColumnDefinition[];
@@ -24,34 +26,30 @@ const emit = defineEmits<{
   "update:modelValue": [columns: ColumnDefinition[]];
 }>();
 
-const data = computed(() => {
-  return props.modelValue.map<Entry>((column, index) => {
-    return { ...column, id: index + 1 };
-  });
-});
-
-const columns = computed<ColumnConfig<Entry>[]>(() => {
-  return [
-    { key: "id", label: "Order", width: "max-content" },
-    { key: "headline", label: "Headline" },
-    {
-      key: "type",
-      label: "Typ",
-      type: {
-        name: "select",
-        options: {
-          options: [
-            { label: "Text", value: "text" },
-            { label: "Checkbox", value: "checkbox" },
-            { label: "Icon", value: "icon" },
-            { label: "System button", value: "systemButton" },
-            { label: "Tag", value: "tag" },
-          ],
+const columns = computed<ColumnConfig<ColumnDefinition, ColumnGroupConfig, CustomColumnTypes>[]>(
+  () => {
+    return [
+      { key: "id", label: "Order", width: "max-content", type: "order" },
+      { key: "headline", label: "Headline" },
+      {
+        key: "type",
+        label: "Typ",
+        type: {
+          name: "select",
+          options: {
+            options: [
+              { label: "Text", value: "text" },
+              { label: "Checkbox", value: "checkbox" },
+              { label: "Icon", value: "icon" },
+              { label: "System button", value: "systemButton" },
+              { label: "Tag", value: "tag" },
+            ],
+          },
         },
       },
-    },
-  ];
-});
+    ];
+  },
+);
 
 const withCustomTypes = createFeature(() => ({
   name: Symbol("customTypes"),
@@ -66,11 +64,40 @@ const withCustomTypes = createFeature(() => ({
       },
     ];
   },
+  typeRenderer: {
+    order: DataGridFeatures.createTypeRenderer<object, ColumnDefinition>({
+      cell: {
+        component: ({ row }) => {
+          const index = props.modelValue.findIndex((i) => i.id === row.id);
+          return index === -1 ? "-" : index + 1;
+        },
+      },
+    }),
+  },
 }));
 
-const editState = ref<DataGridFeatures.EditState<Entry>>({});
+const editState = ref<DataGridFeatures.EditState<ColumnDefinition>>({});
 
-const withEditing = DataGridFeatures.useEditing<Entry>({
+// apply edit changes
+watch(
+  editState,
+  () => {
+    if (!Object.keys(editState.value)) return;
+
+    const rows = props.modelValue.slice();
+
+    Object.entries(editState.value).forEach(([id, editValue], index) => {
+      const row = rows.find((row) => row.id === id);
+      if (!row || !editValue) return;
+      rows[index] = { ...rows[index], ...editValue };
+    });
+
+    emit("update:modelValue", rows);
+  },
+  { deep: true },
+);
+
+const withEditing = DataGridFeatures.useEditing<ColumnDefinition>({
   mode: "manual",
   editState,
   columns: {
@@ -78,7 +105,7 @@ const withEditing = DataGridFeatures.useEditing<Entry>({
   },
 });
 
-const withRowActions = useRowActions<Entry>({
+const withRowActions = useRowActions<ColumnDefinition>({
   actions: (row) => {
     return [
       h(OnyxIconButton, {
@@ -91,24 +118,48 @@ const withRowActions = useRowActions<Entry>({
   },
 });
 
+const rowRearrangeState = ref<DataGridFeatures.RowRearrangeState<ColumnDefinition>>({
+  active: true,
+  order: new Map(),
+});
+
+// apply rearrange
+watch(
+  () => rowRearrangeState.value.order,
+  (newOrder) => {
+    if (!newOrder.size) return;
+    const orderedData = applyArrayOrder(props.modelValue, newOrder, (item) => item.id);
+    emit("update:modelValue", orderedData);
+    rowRearrangeState.value.order.clear();
+  },
+  { deep: true },
+);
+
+const withRowRearrange = DataGridFeatures.useRowRearrange<ColumnDefinition>({
+  state: rowRearrangeState,
+  headless: true,
+});
+
 function handleAddColumn() {
-  const newColumns: ColumnDefinition[] = [
-    ...props.modelValue,
-    { headline: "Headline", type: "text" },
-  ];
+  const newColumns: ColumnDefinition[] = [...props.modelValue, getDefaultColumnDefinition()];
   emit("update:modelValue", newColumns);
 }
 
-function handleDelete(row: Entry) {
-  const newColumns = data.value.filter((column) => column.id !== row.id);
+function handleDelete(row: ColumnDefinition) {
+  const newColumns = props.modelValue.filter((column) => column.id !== row.id);
   emit("update:modelValue", newColumns);
 }
 
-const features = [withCustomTypes, withEditing, withRowActions];
+const features = [withCustomTypes, withEditing, withRowActions, withRowRearrange];
 </script>
 
 <template>
-  <OnyxDataGrid :headline="{ text: 'Columns', rowCount: true }" :columns :data :features />
+  <OnyxDataGrid
+    :headline="{ text: 'Columns', rowCount: true }"
+    :columns
+    :data="props.modelValue"
+    :features
+  />
 </template>
 
 <style lang="scss" scoped>

--- a/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
+++ b/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
@@ -11,14 +11,16 @@ import {
   type ColumnTypesFromFeatures,
 } from "sit-onyx";
 import { computed, h, ref, watch } from "vue";
-import type { ColumnDefinition } from "../types/index.js";
+import type { ColumnDefinition, GenerateDataGridPayload } from "../types/index.js";
 import { useRowActions } from "../utils/data-grid/useRowActions/useRowActions.js";
 import { getDefaultColumnDefinition } from "../utils/misc.js";
+import ColumnWidthFormElement from "./ColumnWidthFormElement.vue";
 
 type CustomColumnTypes = ColumnTypesFromFeatures<[typeof withCustomTypes]>;
 
 const props = defineProps<{
   modelValue: ColumnDefinition[];
+  mode: GenerateDataGridPayload["mode"];
   skeleton?: boolean;
 }>();
 
@@ -26,30 +28,39 @@ const emit = defineEmits<{
   "update:modelValue": [columns: ColumnDefinition[]];
 }>();
 
-const columns = computed<ColumnConfig<ColumnDefinition, ColumnGroupConfig, CustomColumnTypes>[]>(
-  () => {
-    return [
-      { key: "id", label: "Order", width: "max-content", type: "order" },
-      { key: "headline", label: "Headline" },
-      {
-        key: "type",
-        label: "Typ",
-        type: {
-          name: "select",
-          options: {
-            options: [
-              { label: "Text", value: "text" },
-              { label: "Checkbox", value: "checkbox" },
-              { label: "Icon", value: "icon" },
-              { label: "System button", value: "systemButton" },
-              { label: "Tag", value: "tag" },
-            ],
-          },
+const columns = computed(() => {
+  const _columns: ColumnConfig<ColumnDefinition, ColumnGroupConfig, CustomColumnTypes>[] = [
+    { key: "id", label: "Order", width: "max-content", type: "order" },
+    { key: "headline", label: "Headline" },
+    {
+      key: "type",
+      label: "Typ",
+      width: "12rem",
+      type: {
+        name: "select",
+        options: {
+          options: [
+            { label: "Text", value: "text" },
+            { label: "Checkbox", value: "checkbox" },
+            { label: "Icon", value: "icon" },
+            { label: "System button", value: "systemButton" },
+            { label: "Tag", value: "tag" },
+          ],
         },
       },
-    ];
-  },
-);
+    },
+  ];
+
+  if (props.mode === "advanced") {
+    _columns.push({
+      key: "width",
+      label: "Width",
+      type: "columnWidth",
+    });
+  }
+
+  return _columns;
+});
 
 const withCustomTypes = createFeature(() => ({
   name: Symbol("customTypes"),
@@ -70,6 +81,14 @@ const withCustomTypes = createFeature(() => ({
         component: ({ row }) => {
           const index = props.modelValue.findIndex((i) => i.id === row.id);
           return index === -1 ? "-" : index + 1;
+        },
+      },
+    }),
+    columnWidth: DataGridFeatures.createTypeRenderer<object, ColumnDefinition>({
+      cell: {
+        component: ({ row, metadata, ...rest }) => {
+          if (!metadata?.editable) return row.width;
+          return h(ColumnWidthFormElement, { ...rest, modelValue: row.width });
         },
       },
     }),

--- a/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
+++ b/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
@@ -184,5 +184,8 @@ const features = [withCustomTypes, withEditing, withRowActions, withRowRearrange
 <style lang="scss" scoped>
 :deep(td) {
   align-content: center;
+
+  // define min-height so the layout does not jump when switched between basic/advanced mode
+  min-height: calc(2.125rem + 2 * var(--onyx-table-padding-block));
 }
 </style>

--- a/packages/figma-plugin-data-grid/ui/components/sections/RowSection.vue
+++ b/packages/figma-plugin-data-grid/ui/components/sections/RowSection.vue
@@ -34,7 +34,13 @@ const strokeOptions = [
         </div>
       </div>
 
-      <div v-if="data.mode === 'advanced'" class="onyx-grid-span-4 container">
+      <div
+        :class="[
+          'onyx-grid-span-4',
+          'container',
+          { 'container--hidden': data.mode !== 'advanced' },
+        ]"
+      >
         <OnyxHeadline is="h3">Appearance</OnyxHeadline>
         <SegmentedControl v-model="data.rows.style" label="Style" :options="styleOptions" />
         <SegmentedControl v-model="data.rows.stroke" label="Stroke" :options="strokeOptions" />
@@ -49,5 +55,10 @@ const strokeOptions = [
   display: flex;
   flex-direction: column;
   gap: var(--onyx-density-sm);
+
+  // we use visibility instead of v-if so the layout does not jump when switching between basic/advanced mode
+  &--hidden {
+    visibility: hidden;
+  }
 }
 </style>

--- a/packages/figma-plugin-data-grid/ui/types/index.ts
+++ b/packages/figma-plugin-data-grid/ui/types/index.ts
@@ -12,6 +12,7 @@ export type ColumnDefinition = {
   id: string;
   headline: string;
   type: ColumnType;
+  width: "hug" | "auto" | number;
 };
 
 export type ColumnType = "text" | "checkbox" | "icon" | "systemButton" | "tag";

--- a/packages/figma-plugin-data-grid/ui/types/index.ts
+++ b/packages/figma-plugin-data-grid/ui/types/index.ts
@@ -9,6 +9,7 @@ export type GenerateDataGridPayload = {
 };
 
 export type ColumnDefinition = {
+  id: string;
   headline: string;
   type: ColumnType;
 };

--- a/packages/figma-plugin-data-grid/ui/utils/data-grid/useRowActions/useRowActions.scss
+++ b/packages/figma-plugin-data-grid/ui/utils/data-grid/useRowActions/useRowActions.scss
@@ -2,6 +2,7 @@
   .onyx-data-grid-row-actions-cell {
     display: flex;
     align-items: center;
+    justify-content: center;
     flex-wrap: wrap;
     gap: var(--onyx-density-2xs);
   }

--- a/packages/figma-plugin-data-grid/ui/utils/misc.ts
+++ b/packages/figma-plugin-data-grid/ui/utils/misc.ts
@@ -9,5 +9,6 @@ export function getDefaultColumnDefinition(): ColumnDefinition {
     id: nanoid(),
     headline: "Headline",
     type: "text",
+    width: "auto",
   };
 }

--- a/packages/figma-plugin-data-grid/ui/utils/misc.ts
+++ b/packages/figma-plugin-data-grid/ui/utils/misc.ts
@@ -1,0 +1,13 @@
+import { nanoid } from "nanoid";
+import type { ColumnDefinition } from "../types/index.js";
+
+/**
+ * Gets a new column definition with default values.
+ */
+export function getDefaultColumnDefinition(): ColumnDefinition {
+  return {
+    id: nanoid(),
+    headline: "Headline",
+    type: "text",
+  };
+}

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/columnRearrange/types.ts
@@ -9,6 +9,8 @@ export type ColumnRearrangeState = {
   /**
    * Map of rearranged columns. Key = columns ID, value = new order (starting from 1). Only
    * contains changed/rearranged columns and not necessarily all available columns.
+   *
+   * You might want to use the `applyArrayOrder()` utility.
    */
   order: Map<PropertyKey, number>;
 };

--- a/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/types.ts
+++ b/packages/sit-onyx/src/components/OnyxDataGrid/features/rowRearrange/types.ts
@@ -28,6 +28,8 @@ export type RowRearrangeState<TEntry extends DataGridEntry> = {
   /**
    * Map of rearranged rows. Key = row ID, value = new order (starting from 1). Only contains
    * changed/rearranged rows and not necessarily all available rows.
+   *
+   * You might want to use the `applyArrayOrder()` utility.
    */
   order: Map<TEntry["id"], number>;
 };

--- a/packages/sit-onyx/src/index.ts
+++ b/packages/sit-onyx/src/index.ts
@@ -348,3 +348,4 @@ export * from "./utils/props.js";
 export * from "./utils/router.js";
 export { type DateValue } from "./utils/date.js";
 export { normalizedIncludes } from "./utils/strings.js";
+export { applyArrayOrder } from "./utils/applyArrayOrder.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -479,6 +479,9 @@ importers:
       '@sit-onyx/icons':
         specifier: workspace:^
         version: link:../icons
+      nanoid:
+        specifier: ^6.0.1
+        version: 6.0.1
       sit-onyx:
         specifier: workspace:^
         version: link:../sit-onyx
@@ -7218,6 +7221,11 @@ packages:
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
     hasBin: true
 
   nanotar@0.3.0:
@@ -17360,6 +17368,8 @@ snapshots:
       minimatch: 3.1.5
 
   nanoid@3.3.18: {}
+
+  nanoid@6.0.1: {}
 
   nanotar@0.3.0: {}
 


### PR DESCRIPTION
Relates to #6034

Update Figma data grid plugin:
- support rearrange for columns
- support to adjust column width (in advanced mode)

<img width="778" height="612" alt="image" src="https://github.com/user-attachments/assets/1443ce4a-a9cc-4318-8c00-51dd11d38b85" />


## Checklist

- [x] A changeset is added with `pnpm exec changeset add` if your changes should be released as npm package (because they affect the library usage)
- [x] I have performed a self review of my code ("Files changed" tab in the pull request)
