### PR TITLE
fix(figma-plugin-data-grid): correctly apply edit state

### DIFF
--- a/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
+++ b/packages/figma-plugin-data-grid/ui/components/ColumnsDataGrid.vue
@@ -105,10 +105,10 @@ watch(
 
     const rows = props.modelValue.slice();
 
-    Object.entries(editState.value).forEach(([id, editValue], index) => {
+    Object.entries(editState.value).forEach(([id, editValue]) => {
       const row = rows.find((row) => row.id === id);
       if (!row || !editValue) return;
-      rows[index] = { ...rows[index], ...editValue };
+      rows[rows.indexOf(row)] = { ...row, ...editValue };
     });
 
     emit("update:modelValue", rows);


### PR DESCRIPTION
Relates to #6034

Fix Figma data gird plugin to correctly apply edit state. Previously, an invalid item was added to the array in the following scenarion:
1. Edit headline
2. Delete edited row
3. Create a new row
4. Edit the headline of the new row
5. => instead of editing, a second empty row was added which does not have an ID an throws console errors