### PR TITLE
fix(AccordionItem): fixed scrolling locked for onyx data grid & onyx accordion

### DIFF
--- a/.changeset/afraid-facts-lick.md
+++ b/.changeset/afraid-facts-lick.md
@@ -1,0 +1,5 @@
+---
+"sit-onyx": patch
+---
+
+fix(OnyxAccordionItem): fix page scroll locking issue when containing scrollable or interactive content by using clip-path for toggle animations.

--- a/packages/sit-onyx/src/components/OnyxAccordionItem/OnyxAccordionItem.vue
+++ b/packages/sit-onyx/src/components/OnyxAccordionItem/OnyxAccordionItem.vue
@@ -184,7 +184,7 @@ const showSkeleton = computed(() => skeleton.value || accordionContext?.skeleton
 
       &::details-content {
         height: 0;
-        overflow: clip;
+        clip-path: inset(0);
         transition:
           content-visibility var(--onyx-accordion-toggle-duration) ease,
           height var(--onyx-accordion-toggle-duration) ease;


### PR DESCRIPTION
Relates to #5684

- fixed page scroll locking issue when containing scrollable or interactive content by using clip-path instead of overflow: clip
